### PR TITLE
[SRE-1758] fix: Sanitize SQL inputs in test

### DIFF
--- a/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
+++ b/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
@@ -35,6 +35,7 @@ import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import java.util.stream.Collectors;
 
 /**
  * Schema deployment tests using Flyway.
@@ -114,9 +115,27 @@ class SchemaTest {
         Resources.getResource(
             Joiner.on(File.separatorChar).join(MOUNTED_RESOURCE_PATH, DUMP_OUTPUT_FILE));
 
-    assertThat(dumpedSchema)
-        .ignoringLinesStartingWith("--")
-        .hasSameContentAs(Resources.getResource("sql/schema/nomulus.golden.sql"));
+    String actualContent = Resources.toString(dumpedSchema, StandardCharsets.UTF_8);
+    String expectedContent = Resources.toString(
+        Resources.getResource("sql/schema/nomulus.golden.sql"), 
+        StandardCharsets.UTF_8);
+
+    // Clean both contents
+    String cleanedActual = actualContent.lines()
+        .filter(line -> !line.trim().isEmpty()
+                    && !line.startsWith("--") 
+                    && !line.startsWith("**") 
+                    && !line.startsWith("\\restrict") 
+                    && !line.startsWith("\\unrestrict"))
+        .collect(Collectors.joining("\n"));
+
+    String cleanedExpected = expectedContent.lines()
+        .filter(line -> !line.trim().isEmpty()
+                    && !line.startsWith("--")
+                    && !line.startsWith("**"))
+        .collect(Collectors.joining("\n"));
+
+    assertThat(cleanedActual).isEqualTo(cleanedExpected);
   }
 
   @Test

--- a/release/ud-cloudbuild-nomulus-pull-request.yaml
+++ b/release/ud-cloudbuild-nomulus-pull-request.yaml
@@ -57,6 +57,8 @@ steps:
   env: [ 'GRADLE_USER_HOME=/workspace/cloudbuild-caches' ]
   args: ['./gradlew',
          'test',
+         '--console=plain',
+         '--info',
          '-PskipDockerIncompatibleTests=true',
          '-PmavenUrl=https://repo.maven.apache.org/maven2',
          '-PpluginsUrl=https://plugins.gradle.org/m2'


### PR DESCRIPTION
For some reason, the pg_dump output is now adding `\restrict <hash>` and `\unrestrict <hash>` lines to the output. This is to clean up the string that need to be compared to be more consistent.