### PR TITLE
Optimize runtime config validation to enable large zone scaling

### DIFF
--- a/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
+++ b/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
@@ -285,12 +285,15 @@ public class PowerDnsWriter extends DnsUpdateWriter {
   }
 
   /**
-   * Get a zone specific rectification lock.
+   * Get a zone specific rectification lock. This method is synchronized to ensure that the
+   * rectification state is initialized before it is used and always returns the same instance for
+   * the same zone ID. Performance due to lock contention is not a concern here since this is not a
+   * long-running operation.
    *
    * @param zoneId the ID of the zone to rectify
    * @return the rectification state
    */
-  private ZoneRectificationState getRectifyZoneState(String zoneId) {
+  private synchronized ZoneRectificationState getRectifyZoneState(String zoneId) {
     return rectifyZoneStateMap.computeIfAbsent(
         zoneId,
         k -> {
@@ -496,7 +499,10 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    * @param zone the TLD zone to validate
    */
   private void validateZoneConfig(Zone zone) throws IOException {
-    // validate the SOA and root NS records if RRSets are present
+    // validate the SOA and root NS records if RRSets are present, which only happens when
+    // the zone is automatically created. Once created at runtime, only the basic zone data
+    // is retrieved for better scaling. Retrieving all zone records for a large zone is time
+    // consuming and causes locking issues when committing changes.
     if (zone.getRrsets() != null && !zone.getRrsets().isEmpty()) {
       validateSoaConfig(zone);
       validateNsConfig(zone);
@@ -683,12 +689,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
           "Creating TSIG key '%s' for PowerDNS TLD zone %s", zoneTsigKeyName, zone.getName());
       powerDnsClient.createTSIGKey(TSIGKey.createTSIGKey(zoneTsigKeyName, TSIG_KEY_ALGORITHM));
     }
-    logger.atInfo().log(
-        "Validated TSIG key '%s' (%s) is available for AXFR replication to secondary servers for"
-            + " TLD zone %s. Retrieve the key using 'pdnsutil list-tsig-keys' in a secure"
-            + " environment and apply the key to the secondary server configuration.",
-        zoneTsigKeyName, TSIG_KEY_ALGORITHM, zone.getName());
-
+    
     // ensure the TSIG-ALLOW-AXFR metadata is set to the current TSIG key name
     try {
       Metadata metadata = powerDnsClient.getMetadata(zone.getId(), "TSIG-ALLOW-AXFR");
@@ -697,8 +698,10 @@ public class PowerDnsWriter extends DnsUpdateWriter {
         throw new IOException("missing expected TSIG-ALLOW-AXFR value");
       }
       logger.atInfo().log(
-          "Validated PowerDNS TLD zone %s is ready for AXFR replication using TSIG key '%s'",
-          zone.getName(), zoneTsigKeyName);
+          "Validated TSIG key '%s' (%s) is available for AXFR replication to secondary servers for"
+              + " TLD zone %s. Retrieve the key using 'pdnsutil list-tsig-keys' in a secure"
+              + " environment and apply the key to the secondary server configuration.",
+          zoneTsigKeyName, TSIG_KEY_ALGORITHM, zone.getName());
     } catch (IOException e) {
       // log the missing metadata with instructions on how to configure it
       logger.atSevere().log(

--- a/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
+++ b/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
@@ -74,7 +74,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
 
   // Zone ID cache configuration
   private static final ConcurrentHashMap<String, String> zoneIdCache = new ConcurrentHashMap<>();
-  private static long zoneIdCacheExpiration = 0;
+  private static volatile long zoneIdCacheExpiration = 0;
   private static int defaultZoneTtl = 3600; // 1 hour in seconds
 
   // Zone rectification state
@@ -956,7 +956,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    */
   private Zone getTldZoneForUpdate(List<RRSet> records) throws IOException {
     Zone tldZone = new Zone();
-    tldZone.setId(getTldZoneId());
+    tldZone.setId(getTldZoneId(tldZoneName, this));
     tldZone.setName(getHostNameWithoutTrailingDot(tldZoneName));
     tldZone.setRrsets(records);
     return tldZone;
@@ -1006,12 +1006,16 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    *
    * @return the ID of the TLD zone
    */
-  private synchronized String getTldZoneId() throws IOException {
+  private static synchronized String getTldZoneId(String tldZoneName, PowerDnsWriter writer)
+      throws IOException {
     // clear the cache if it has expired
     if (zoneIdCacheExpiration < System.currentTimeMillis()) {
       logger.atInfo().log("Clearing PowerDNS TLD zone ID cache");
       zoneIdCache.clear();
       zoneIdCacheExpiration = System.currentTimeMillis() + 1000 * 60 * 60; // 1 hour
+    } else if (zoneIdCache.containsKey(tldZoneName)) {
+      // show that we are using the cached entry
+      logger.atInfo().log("Using cached PowerDNS TLD zone ID for %s", tldZoneName);
     }
 
     // retrieve the TLD zone ID from the cache or retrieve it from the PowerDNS API
@@ -1023,7 +1027,8 @@ public class PowerDnsWriter extends DnsUpdateWriter {
               try {
                 // retrieve the TLD zone by name, which may result from an existing zone or
                 // be dynamically created if the zone does not exist
-                Zone tldZone = getAndValidateTldZoneByName();
+                logger.atInfo().log("Retrieving PowerDNS TLD zone ID for %s", tldZoneName);
+                Zone tldZone = writer.getAndValidateTldZoneByName();
 
                 // return the TLD zone ID, which will be cached for the next hour
                 return tldZone.getId();

--- a/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
+++ b/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
@@ -72,9 +72,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
   private static final ArrayList<String> supportedRecordTypes =
       new ArrayList<>(Arrays.asList("A", "AAAA", "DS", "NS"));
 
-  // Zone ID cache configuration
-  private static final ConcurrentHashMap<String, String> zoneIdCache = new ConcurrentHashMap<>();
-  private static volatile long zoneIdCacheExpiration = 0;
+  // Zone TTL configuration
   private static int defaultZoneTtl = 3600; // 1 hour in seconds
 
   // Zone rectification state
@@ -393,7 +391,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
     // prepare a PowerDNS zone object containing the TLD record updates using the RRSet objects
     // that have a valid change type
     Zone preparedTldZone =
-        getTldZoneForUpdate(
+        getTldZoneFromRecords(
             allRRSets.stream().filter(v -> v.getChangeType() != null).collect(Collectors.toList()));
 
     // return the prepared TLD zone
@@ -951,31 +949,19 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    * @param records the set of RRSet records that will be sent to the PowerDNS API
    * @return the prepared TLD zone
    */
-  private Zone getTldZoneForUpdate(List<RRSet> records) throws IOException {
-    Zone tldZone = new Zone();
-    tldZone.setId(getTldZoneId());
-    tldZone.setName(getHostNameWithoutTrailingDot(tldZoneName));
-    tldZone.setRrsets(records);
-    return tldZone;
-  }
+  private Zone getTldZoneFromRecords(List<RRSet> records) throws IOException {
+    // retrieve the TLD zone by name, which may result from an existing zone or
+    // be dynamically created if the zone does not exist
+    logger.atInfo().log("Retrieving PowerDNS TLD zone ID for %s", tldZoneName);
+    Zone tldZone = getAndValidateTldZoneByName();
 
-  /*
-   *
-   * {
-    "account": "DNSSEC-ZSK-EXPIRE-DATE:1759407683890",
-    "catalog": "",
-    "dnssec": true,
-    "edited_serial": 2025115665,
-    "id": "udrsptest1.",
-    "kind": "Master",
-    "last_check": 0,
-    "masters": [],
-    "name": "udrsptest1.",
-    "notified_serial": 2025112759,
-    "serial": 2025112759,
-    "url": "/api/v1/servers/localhost/zones/udrsptest1."
+    // prepare a zone for update
+    Zone tldZoneFromRecords = new Zone();
+    tldZoneFromRecords.setId(tldZone.getId());
+    tldZoneFromRecords.setName(getHostNameWithoutTrailingDot(tldZoneName));
+    tldZoneFromRecords.setRrsets(records);
+    return tldZoneFromRecords;
   }
-   */
 
   /**
    * Get the TLD zone by name and validate the zone's configuration before returning.
@@ -1012,53 +998,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
     throw new IOException("TLD zone not found: " + tldZoneName);
   }
 
-  /**
-   * Get the TLD zone ID for the given TLD zone name from the cache, or compute it if it is not
-   * present in the cache.
-   *
-   * @return the ID of the TLD zone
-   */
-  private String getTldZoneId() throws IOException {
-    // clear the cache if it has expired
-    if (zoneIdCacheExpiration < System.currentTimeMillis()) {
-      logger.atInfo().log("Clearing PowerDNS TLD zone ID cache");
-      zoneIdCache.clear();
-      zoneIdCacheExpiration = System.currentTimeMillis() + 1000 * 60 * 60; // 1 hour
-    } else if (zoneIdCache.containsKey(tldZoneName)) {
-      // show that we are using the cached entry
-      logger.atInfo().log("Using cached PowerDNS TLD zone ID for %s", tldZoneName);
-    }
-
-    // retrieve the TLD zone ID from the cache or retrieve it from the PowerDNS API
-    // if not available in the cache
-    String zoneId =
-        zoneIdCache.computeIfAbsent(
-            tldZoneName,
-            key -> {
-              try {
-                // retrieve the TLD zone by name, which may result from an existing zone or
-                // be dynamically created if the zone does not exist
-                logger.atInfo().log("Retrieving PowerDNS TLD zone ID for %s", tldZoneName);
-                Zone tldZone = getAndValidateTldZoneByName();
-
-                // return the TLD zone ID, which will be cached for the next hour
-                return tldZone.getId();
-              } catch (IOException e) {
-                // log the error and return a null value to indicate failure
-                logger.atWarning().log(
-                    "Failed to get PowerDNS TLD zone ID for %s: %s", tldZoneName, e);
-                return null;
-              }
-            });
-
-    // if the TLD zone ID is not found, throw an exception
-    if (zoneId == null) {
-      throw new IOException("TLD zone not found: " + tldZoneName);
-    }
-
-    // return the TLD zone ID
-    return zoneId;
-  }
+  
 
   /**
    * Determine if a record is a delete record.

--- a/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
+++ b/core/src/main/java/google/registry/dns/writer/powerdns/PowerDnsWriter.java
@@ -287,15 +287,12 @@ public class PowerDnsWriter extends DnsUpdateWriter {
   }
 
   /**
-   * Get a zone specific rectification lock. This method is synchronized to ensure that the
-   * rectification state is initialized before it is used and always returns the same instance for
-   * the same zone ID. Performance due to lock contention is not a concern here since this is not a
-   * long-running operation.
+   * Get a zone specific rectification lock.
    *
    * @param zoneId the ID of the zone to rectify
    * @return the rectification state
    */
-  private synchronized ZoneRectificationState getRectifyZoneState(String zoneId) {
+  private ZoneRectificationState getRectifyZoneState(String zoneId) {
     return rectifyZoneStateMap.computeIfAbsent(
         zoneId,
         k -> {
@@ -501,11 +498,11 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    * @param zone the TLD zone to validate
    */
   private void validateZoneConfig(Zone zone) throws IOException {
-    // validate the SOA and root NS records
-    validateSoaConfig(zone);
-
-    // validate the NS records
-    validateNsConfig(zone);
+    // validate the SOA and root NS records if RRSets are present
+    if (zone.getRrsets() != null && !zone.getRrsets().isEmpty()) {
+      validateSoaConfig(zone);
+      validateNsConfig(zone);
+    }
 
     // validate the TSIG key configuration
     validateTsigConfig(zone);
@@ -956,11 +953,29 @@ public class PowerDnsWriter extends DnsUpdateWriter {
    */
   private Zone getTldZoneForUpdate(List<RRSet> records) throws IOException {
     Zone tldZone = new Zone();
-    tldZone.setId(getTldZoneId(tldZoneName, this));
+    tldZone.setId(getTldZoneId());
     tldZone.setName(getHostNameWithoutTrailingDot(tldZoneName));
     tldZone.setRrsets(records);
     return tldZone;
   }
+
+  /*
+   *
+   * {
+    "account": "DNSSEC-ZSK-EXPIRE-DATE:1759407683890",
+    "catalog": "",
+    "dnssec": true,
+    "edited_serial": 2025115665,
+    "id": "udrsptest1.",
+    "kind": "Master",
+    "last_check": 0,
+    "masters": [],
+    "name": "udrsptest1.",
+    "notified_serial": 2025112759,
+    "serial": 2025112759,
+    "url": "/api/v1/servers/localhost/zones/udrsptest1."
+  }
+   */
 
   /**
    * Get the TLD zone by name and validate the zone's configuration before returning.
@@ -973,12 +988,10 @@ public class PowerDnsWriter extends DnsUpdateWriter {
     for (Zone zone : powerDnsClient.listZones()) {
       if (getHostNameWithoutTrailingDot(zone.getName())
           .equals(getHostNameWithoutTrailingDot(tldZoneName))) {
-        // retrieve full zone details
-        Zone fullZone = powerDnsClient.getZone(zone.getId());
 
         // validate the zone's configuration
-        validateZoneConfig(fullZone);
-        return fullZone;
+        validateZoneConfig(zone);
+        return zone;
       }
     }
 
@@ -1001,13 +1014,11 @@ public class PowerDnsWriter extends DnsUpdateWriter {
 
   /**
    * Get the TLD zone ID for the given TLD zone name from the cache, or compute it if it is not
-   * present in the cache. This method is synchronized since it may result in a new TLD zone being
-   * created and DNSSEC being configured, and this should only happen once.
+   * present in the cache.
    *
    * @return the ID of the TLD zone
    */
-  private static synchronized String getTldZoneId(String tldZoneName, PowerDnsWriter writer)
-      throws IOException {
+  private String getTldZoneId() throws IOException {
     // clear the cache if it has expired
     if (zoneIdCacheExpiration < System.currentTimeMillis()) {
       logger.atInfo().log("Clearing PowerDNS TLD zone ID cache");
@@ -1028,7 +1039,7 @@ public class PowerDnsWriter extends DnsUpdateWriter {
                 // retrieve the TLD zone by name, which may result from an existing zone or
                 // be dynamically created if the zone does not exist
                 logger.atInfo().log("Retrieving PowerDNS TLD zone ID for %s", tldZoneName);
-                Zone tldZone = writer.getAndValidateTldZoneByName();
+                Zone tldZone = getAndValidateTldZoneByName();
 
                 // return the TLD zone ID, which will be cached for the next hour
                 return tldZone.getId();

--- a/core/src/main/java/google/registry/dns/writer/powerdns/client/PowerDNSClient.java
+++ b/core/src/main/java/google/registry/dns/writer/powerdns/client/PowerDNSClient.java
@@ -102,7 +102,7 @@ public class PowerDNSClient {
   private Response logAndExecuteRequest(Request request) throws IOException {
     // log the request and create timestamp for the start time
     logger.atInfo().log(
-        "Executing PowerDNS request: %s, url: %s, body: %s",
+        "Executing PowerDNS request, method: %s, url: %s, body: %s",
         request.method(),
         request.url(),
         request.body() != null ? bodyToString(request.body()) : null);
@@ -115,13 +115,16 @@ public class PowerDNSClient {
 
     // execute the request and log the response
     Response response = httpClient.newCall(request).execute();
-    logger.atInfo().log("PowerDNS response: %s", response);
 
     // log the response time and response code
     long endTime = System.currentTimeMillis();
     logger.atInfo().log(
-        "Completed PowerDNS request in %d ms, success: %s, response code: %d",
-        endTime - startTime, response.isSuccessful(), response.code());
+        "Completed PowerDNS request in %d ms, method: %s, url: %s, success: %s, response code: %d",
+        endTime - startTime,
+        request.method(),
+        request.url(),
+        response.isSuccessful(),
+        response.code());
 
     // return the response
     return response;


### PR DESCRIPTION
Identified a scaling issue when zone size is greater than 1.5M domains. The current code validates the zone NS and SOA records periodically to check for some expected configuration. However, all zone records are required to be retrieved for this validation and the fetch takes a very long time as the zone gets large. The fetch time got long enough to start causing timeouts and subsequent locking issues in Nomulus due to the elevated processing time. As a result, the queuing starts to get very deep faster than it can be processed.

The solution for this scaling is to remove the two runtime checks that required these records to be fetched. If changes are required for NS or SOA configuration, they must be performed manually with `pdnsutil` by the operations team. Removing these checks additionally simplifies the code path beyond the large fetch, so it's quite beneficial.

Validated that our load test continues to scale once this change is applied.