### PR TITLE
Force TLS 1.3 to be supported

### DIFF
--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -191,8 +191,27 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                       Promise<X509Certificate> unusedPromise =
                           clientCertificatePromise.setSuccess(clientCertificate);
                     } else {
+                      Throwable cause = future.cause();
+                      // Log detailed handshake failure information
+                      String remoteAddress = channel.remoteAddress() != null
+                          ? channel.remoteAddress().toString()
+                          : "unknown";
+                      logger.atWarning().withCause(cause).log(
+                          """
+                              --SSL Handshake Failure--
+                              Remote Address: %s
+                              Error Type: %s
+                              Error Message: %s
+                              Server Supported Protocols: %s
+                              Server Supported Ciphers: %s
+                              """,
+                          remoteAddress,
+                          cause.getClass().getSimpleName(),
+                          cause.getMessage(),
+                          supportedSslVersions,
+                          ALLOWED_TLS_CIPHERS);
                       Promise<X509Certificate> unusedPromise =
-                          clientCertificatePromise.setFailure(future.cause());
+                          clientCertificatePromise.setFailure(cause);
                     }
                   });
       channel.attr(CLIENT_CERTIFICATE_PROMISE_KEY).set(clientCertificatePromise);

--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -40,6 +40,8 @@ import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
@@ -146,6 +148,61 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
     // 2. Or conditionally enabling TLS 1.3 only with OpenSSL provider
   }
 
+  /**
+   * Extracts detailed certificate information for logging.
+   *
+   * @return A formatted string with certificate details, or "N/A" if extraction fails
+   */
+  private String getCertificateDetails(X509Certificate cert) {
+    try {
+      StringBuilder details = new StringBuilder();
+      // Subject DN (contains CN)
+      details.append("Subject: ").append(cert.getSubjectDN().getName()).append("\n");
+      // Issuer DN
+      details.append("Issuer: ").append(cert.getIssuerDN().getName()).append("\n");
+      // Serial number
+      details.append("Serial Number: ").append(cert.getSerialNumber().toString(16)).append("\n");
+      // Key usage (if available)
+      try {
+        boolean[] keyUsage = cert.getKeyUsage();
+        if (keyUsage != null) {
+          List<String> keyUsageNames = Arrays.asList(
+              "digitalSignature", "nonRepudiation", "keyEncipherment",
+              "dataEncipherment", "keyAgreement", "keyCertSign", "cRLSign",
+              "encipherOnly", "decipherOnly");
+          details.append("Key Usage: ");
+          boolean first = true;
+          for (int i = 0; i < keyUsage.length && i < keyUsageNames.size(); i++) {
+            if (keyUsage[i]) {
+              if (!first) {
+                details.append(", ");
+              }
+              details.append(keyUsageNames.get(i));
+              first = false;
+            }
+          }
+          details.append("\n");
+        }
+      } catch (Exception e) {
+        details.append("Key Usage: not available\n");
+      }
+      // Basic constraints (CA flag)
+      try {
+        int pathLen = cert.getBasicConstraints();
+        if (pathLen >= 0) {
+          details.append("Basic Constraints: CA=true, pathLen=").append(pathLen).append("\n");
+        } else {
+          details.append("Basic Constraints: CA=false\n");
+        }
+      } catch (Exception e) {
+        details.append("Basic Constraints: not available\n");
+      }
+      return details.toString();
+    } catch (Exception e) {
+      return "Certificate details extraction failed: " + e.getMessage();
+    }
+  }
+
   @Override
   protected void initChannel(C channel) throws Exception {
     try {
@@ -183,7 +240,7 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                         """
                             --SSL Information--
                             Client Certificate Hash: %s
-                            SSL Protocol: %s
+                            %sSSL Protocol: %s
                             Cipher Suite: %s
                             Not Before: %s
                             Not After: %s
@@ -191,6 +248,7 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                             Client Certificate Length: %s
                             """,
                         getCertificateHash(clientCertificate),
+                        getCertificateDetails(clientCertificate),
                         sslSession.getProtocol(),
                         sslSession.getCipherSuite(),
                         clientCertificate.getNotBefore(),
@@ -216,16 +274,37 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                     String remoteAddress = channel.remoteAddress() != null
                         ? channel.remoteAddress().toString()
                         : "unknown";
+                    // Try to extract certificate information even if handshake failed
+                    // (certificate is sent before CertificateVerify, so it may be available)
+                    String certificateHash = "unknown";
+                    String certificateDetails = "";
+                    try {
+                      SSLSession sslSession = sslHandler.engine().getSession();
+                      if (sslSession.getPeerCertificates() != null
+                          && sslSession.getPeerCertificates().length > 0) {
+                        X509Certificate clientCertificate =
+                            (X509Certificate) sslSession.getPeerCertificates()[0];
+                        certificateHash = getCertificateHash(clientCertificate);
+                        certificateDetails = getCertificateDetails(clientCertificate);
+                      }
+                    } catch (Exception e) {
+                      // Certificate not available or session not established
+                      certificateHash = "not available";
+                      certificateDetails = "Certificate details not available (session not fully established)";
+                    }
                     logger.atWarning().withCause(cause).log(
                         """
                             --SSL Handshake Failure--
                             Remote Address: %s
-                            Error Type: %s
+                            Client Certificate Hash: %s
+                            %sError Type: %s
                             Error Message: %s
                             Server Supported Protocols: %s
                             Server Supported Ciphers: %s
                             """,
                         remoteAddress,
+                        certificateHash,
+                        certificateDetails.isEmpty() ? "" : (certificateDetails + "\n"),
                         cause.getClass().getSimpleName(),
                         cause.getMessage(),
                         supportedSslVersions,

--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -254,10 +254,10 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
           "SSLException in initChannel: %s (Remote: %s)",
           e.getMessage(),
           channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
-      channel.close();
+      ChannelFuture unusedFuture = channel.close();
     } catch (Exception e) {
       logger.atSevere().withCause(e).log("Exception in initChannel");
-      channel.close();
+      ChannelFuture unusedFuture = channel.close();
     }
   }
 }

--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -116,12 +116,15 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
     this.sslProvider = sslProvider;
     this.privateKeySupplier = privateKeySupplier;
     this.certificatesSupplier = certificatesSupplier;
-    this.supportedSslVersions =
-        sslProvider == SslProvider.OPENSSL
-            ? ImmutableList.of("TLSv1.3", "TLSv1.2")
-            // JDK support for TLS 1.3 won't be available until 2021-04-20 at the earliest.
-            // See: https://java.com/en/jre-jdk-cryptoroadmap.html
-            : ImmutableList.of("TLSv1.2");
+    this.supportedSslVersions = ImmutableList.of("TLSv1.3", "TLSv1.2");
+    logger.atInfo().log(
+        "Configured TLS protocol versions: %s (SSL Provider: %s)",
+        supportedSslVersions,
+        sslProvider);
+    // Note: JDK 11+ supports TLS 1.3, but Netty's JDK provider may handle it differently
+    // than OpenSSL. If TLS 1.3 doesn't work with JDK provider, consider:
+    // 1. Ensuring OpenSSL is available (netty-tcnative-boringssl-static)
+    // 2. Or conditionally enabling TLS 1.3 only with OpenSSL provider
   }
 
   @Override
@@ -137,7 +140,10 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
             .ciphers(ALLOWED_TLS_CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
             .build();
 
-    logger.atInfo().log("Available Cipher Suites: %s", sslContext.cipherSuites());
+    logger.atInfo().log(
+        "SSL Context created - Protocols: %s, Cipher Suites: %s",
+        supportedSslVersions,
+        sslContext.cipherSuites());
     SslHandler sslHandler = sslContext.newHandler(channel.alloc());
     if (requireClientCert) {
       Promise<X509Certificate> clientCertificatePromise = channel.eventLoop().newPromise();
@@ -215,7 +221,20 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                     }
                   });
       channel.attr(CLIENT_CERTIFICATE_PROMISE_KEY).set(clientCertificatePromise);
+      logger.atFine().log(
+          "Client certificate promise set for channel %s (Remote: %s)",
+          channel,
+          channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
+    } else {
+      logger.atFine().log(
+          "Client certificate not required for channel %s (Remote: %s)",
+          channel,
+          channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
     }
     channel.pipeline().addLast(sslHandler);
+    logger.atFine().log(
+        "SSL handler added to pipeline for channel %s (Remote: %s)",
+        channel,
+        channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
   }
 }

--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -41,61 +41,79 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.util.function.Supplier;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 
 /**
  * Adds a server side SSL handler to the channel pipeline.
  *
- * <p>This <b>should</b> be the first handler provided for any handler provider list, if it is
- * provided. Unless you wish to first process the PROXY header with another handler, which should
- * come before this handler. The type parameter {@code C} is needed so that unit tests can construct
+ * <p>
+ * This <b>should</b> be the first handler provided for any handler provider
+ * list, if it is
+ * provided. Unless you wish to first process the PROXY header with another
+ * handler, which should
+ * come before this handler. The type parameter {@code C} is needed so that unit
+ * tests can construct
  * this handler that works with {@link EmbeddedChannel};
  *
- * <p>The ssl handler added can require client authentication, but it uses an {@link
- * InsecureTrustManagerFactory}, which accepts any ssl certificate presented by the client, as long
- * as the client uses the corresponding private key to establish SSL handshake. The client
- * certificate hash will be passed along to GAE as an HTTP header for verification (not handled by
+ * <p>
+ * The ssl handler added can require client authentication, but it uses an
+ * {@link
+ * InsecureTrustManagerFactory}, which accepts any ssl certificate presented by
+ * the client, as long
+ * as the client uses the corresponding private key to establish SSL handshake.
+ * The client
+ * certificate hash will be passed along to GAE as an HTTP header for
+ * verification (not handled by
  * this handler).
  */
 @Sharable
 public class SslServerInitializer<C extends Channel> extends ChannelInitializer<C> {
 
   /**
-   * Attribute key to the client certificate promise whose value is set when SSL handshake completes
+   * Attribute key to the client certificate promise whose value is set when SSL
+   * handshake completes
    * successfully.
    */
-  public static final AttributeKey<Promise<X509Certificate>> CLIENT_CERTIFICATE_PROMISE_KEY =
-      AttributeKey.valueOf("CLIENT_CERTIFICATE_PROMISE_KEY");
+  public static final AttributeKey<Promise<X509Certificate>> CLIENT_CERTIFICATE_PROMISE_KEY = AttributeKey
+      .valueOf("CLIENT_CERTIFICATE_PROMISE_KEY");
 
   /**
-   * The list of cipher suites that are currently acceptable to create a successful handshake.
+   * The list of cipher suites that are currently acceptable to create a
+   * successful handshake.
    *
-   * <p>This list includes all of the current TLS1.3 ciphers and a collection of TLS1.2 ciphers with
-   * no known security vulnerabilities. Note that OpenSSL uses a separate nomenclature for the
-   * ciphers internally but the IANA names listed here will be transparently translated by the
-   * OpenSSL provider (if used), so there is no need to include the OpenSSL name variants here. More
-   * information about these cipher suites and their OpenSSL names can be found at ciphersuite.info.
+   * <p>
+   * This list includes all of the current TLS1.3 ciphers and a collection of
+   * TLS1.2 ciphers with
+   * no known security vulnerabilities. Note that OpenSSL uses a separate
+   * nomenclature for the
+   * ciphers internally but the IANA names listed here will be transparently
+   * translated by the
+   * OpenSSL provider (if used), so there is no need to include the OpenSSL name
+   * variants here. More
+   * information about these cipher suites and their OpenSSL names can be found at
+   * ciphersuite.info.
    */
-  private static final ImmutableList<String> ALLOWED_TLS_CIPHERS =
-      ImmutableList.of(
-          "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-          "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-          "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-          "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-          "TLS_AES_128_GCM_SHA256",
-          "TLS_AES_256_GCM_SHA384",
-          "TLS_CHACHA20_POLY1305_SHA256",
-          "TLS_AES_128_CCM_SHA256",
-          "TLS_AES_128_CCM_8_SHA256");
+  private static final ImmutableList<String> ALLOWED_TLS_CIPHERS = ImmutableList.of(
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_AES_128_GCM_SHA256",
+      "TLS_AES_256_GCM_SHA384",
+      "TLS_CHACHA20_POLY1305_SHA256",
+      "TLS_AES_128_CCM_SHA256",
+      "TLS_AES_128_CCM_8_SHA256");
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private final boolean requireClientCert;
   // TODO(jianglai): Always validate client certs (if required).
   private final boolean validateClientCert;
   private final SslProvider sslProvider;
-  // We use suppliers for the key/cert pair because they are fetched and cached from GCS, and can
+  // We use suppliers for the key/cert pair because they are fetched and cached
+  // from GCS, and can
   // change when the artifacts on GCS changes.
   private final Supplier<PrivateKey> privateKeySupplier;
   private final Supplier<ImmutableList<X509Certificate>> certificatesSupplier;
@@ -121,7 +139,8 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
         "Configured TLS protocol versions: %s (SSL Provider: %s)",
         supportedSslVersions,
         sslProvider);
-    // Note: JDK 11+ supports TLS 1.3, but Netty's JDK provider may handle it differently
+    // Note: JDK 11+ supports TLS 1.3, but Netty's JDK provider may handle it
+    // differently
     // than OpenSSL. If TLS 1.3 doesn't work with JDK provider, consider:
     // 1. Ensuring OpenSSL is available (netty-tcnative-boringssl-static)
     // 2. Or conditionally enabling TLS 1.3 only with OpenSSL provider
@@ -129,112 +148,116 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
 
   @Override
   protected void initChannel(C channel) throws Exception {
-    SslContext sslContext =
-        SslContextBuilder.forServer(
-                privateKeySupplier.get(),
-                certificatesSupplier.get().toArray(new X509Certificate[0]))
-            .sslProvider(sslProvider)
-            .trustManager(InsecureTrustManagerFactory.INSTANCE)
-            .clientAuth(requireClientCert ? ClientAuth.REQUIRE : ClientAuth.NONE)
-            .protocols(supportedSslVersions)
-            .ciphers(ALLOWED_TLS_CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-            .build();
+    try {
+      SslContext sslContext = SslContextBuilder.forServer(
+          privateKeySupplier.get(),
+          certificatesSupplier.get().toArray(new X509Certificate[0]))
+          .sslProvider(sslProvider)
+          .trustManager(InsecureTrustManagerFactory.INSTANCE)
+          .clientAuth(requireClientCert ? ClientAuth.REQUIRE : ClientAuth.NONE)
+          .protocols(supportedSslVersions)
+          .ciphers(ALLOWED_TLS_CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+          .build();
 
-    logger.atInfo().log(
-        "SSL Context created - Protocols: %s, Cipher Suites: %s",
-        supportedSslVersions,
-        sslContext.cipherSuites());
-    SslHandler sslHandler = sslContext.newHandler(channel.alloc());
-    if (requireClientCert) {
-      Promise<X509Certificate> clientCertificatePromise = channel.eventLoop().newPromise();
-      Future<Channel> unusedFuture =
-          sslHandler
-              .handshakeFuture()
-              .addListener(
-                  future -> {
-                    if (future.isSuccess()) {
-                      SSLSession sslSession = sslHandler.engine().getSession();
-                      X509Certificate clientCertificate =
-                          (X509Certificate) sslSession.getPeerCertificates()[0];
-                      PublicKey clientPublicKey = clientCertificate.getPublicKey();
-                      // Note that for non-RSA keys the length would be -1.
-                      int clientCertificateLength = -1;
-                      if (clientPublicKey instanceof RSAPublicKey) {
-                        clientCertificateLength =
-                            ((RSAPublicKey) clientPublicKey).getModulus().bitLength();
-                      }
-                      logger.atInfo().log(
-                          """
-                              --SSL Information--
-                              Client Certificate Hash: %s
-                              SSL Protocol: %s
-                              Cipher Suite: %s
-                              Not Before: %s
-                              Not After: %s
-                              Client Certificate Type: %s
-                              Client Certificate Length: %s
-                              """,
-                          getCertificateHash(clientCertificate),
-                          sslSession.getProtocol(),
-                          sslSession.getCipherSuite(),
-                          clientCertificate.getNotBefore(),
-                          clientCertificate.getNotAfter(),
-                          clientPublicKey.getClass().getName(),
-                          clientCertificateLength);
-                      try {
-                        clientCertificate.checkValidity();
-                      } catch (CertificateNotYetValidException | CertificateExpiredException e) {
-                        logger.atWarning().withCause(e).log(
-                            "Client certificate is not valid.\nHash: %s",
-                            getCertificateHash(clientCertificate));
-                        if (validateClientCert) {
-                          Promise<X509Certificate> unusedPromise =
-                              clientCertificatePromise.setFailure(e);
-                          ChannelFuture unusedFuture2 = channel.close();
-                          return;
-                        }
-                      }
-                      Promise<X509Certificate> unusedPromise =
-                          clientCertificatePromise.setSuccess(clientCertificate);
-                    } else {
-                      Throwable cause = future.cause();
-                      // Log detailed handshake failure information
-                      String remoteAddress = channel.remoteAddress() != null
-                          ? channel.remoteAddress().toString()
-                          : "unknown";
-                      logger.atWarning().withCause(cause).log(
-                          """
-                              --SSL Handshake Failure--
-                              Remote Address: %s
-                              Error Type: %s
-                              Error Message: %s
-                              Server Supported Protocols: %s
-                              Server Supported Ciphers: %s
-                              """,
-                          remoteAddress,
-                          cause.getClass().getSimpleName(),
-                          cause.getMessage(),
-                          supportedSslVersions,
-                          ALLOWED_TLS_CIPHERS);
-                      Promise<X509Certificate> unusedPromise =
-                          clientCertificatePromise.setFailure(cause);
+      logger.atInfo().log(
+          "SSL Context created - Protocols: %s, Cipher Suites: %s",
+          supportedSslVersions,
+          sslContext.cipherSuites());
+      SslHandler sslHandler = sslContext.newHandler(channel.alloc());
+      if (requireClientCert) {
+        Promise<X509Certificate> clientCertificatePromise = channel.eventLoop().newPromise();
+        Future<Channel> unusedFuture = sslHandler
+            .handshakeFuture()
+            .addListener(
+                future -> {
+                  if (future.isSuccess()) {
+                    SSLSession sslSession = sslHandler.engine().getSession();
+                    X509Certificate clientCertificate = (X509Certificate) sslSession.getPeerCertificates()[0];
+                    PublicKey clientPublicKey = clientCertificate.getPublicKey();
+                    // Note that for non-RSA keys the length would be -1.
+                    int clientCertificateLength = -1;
+                    if (clientPublicKey instanceof RSAPublicKey) {
+                      clientCertificateLength = ((RSAPublicKey) clientPublicKey).getModulus().bitLength();
                     }
-                  });
-      channel.attr(CLIENT_CERTIFICATE_PROMISE_KEY).set(clientCertificatePromise);
+                    logger.atInfo().log(
+                        """
+                            --SSL Information--
+                            Client Certificate Hash: %s
+                            SSL Protocol: %s
+                            Cipher Suite: %s
+                            Not Before: %s
+                            Not After: %s
+                            Client Certificate Type: %s
+                            Client Certificate Length: %s
+                            """,
+                        getCertificateHash(clientCertificate),
+                        sslSession.getProtocol(),
+                        sslSession.getCipherSuite(),
+                        clientCertificate.getNotBefore(),
+                        clientCertificate.getNotAfter(),
+                        clientPublicKey.getClass().getName(),
+                        clientCertificateLength);
+                    try {
+                      clientCertificate.checkValidity();
+                    } catch (CertificateNotYetValidException | CertificateExpiredException e) {
+                      logger.atWarning().withCause(e).log(
+                          "Client certificate is not valid.\nHash: %s",
+                          getCertificateHash(clientCertificate));
+                      if (validateClientCert) {
+                        Promise<X509Certificate> unusedPromise = clientCertificatePromise.setFailure(e);
+                        ChannelFuture unusedFuture2 = channel.close();
+                        return;
+                      }
+                    }
+                    Promise<X509Certificate> unusedPromise = clientCertificatePromise.setSuccess(clientCertificate);
+                  } else {
+                    Throwable cause = future.cause();
+                    // Log detailed handshake failure information
+                    String remoteAddress = channel.remoteAddress() != null
+                        ? channel.remoteAddress().toString()
+                        : "unknown";
+                    logger.atWarning().withCause(cause).log(
+                        """
+                            --SSL Handshake Failure--
+                            Remote Address: %s
+                            Error Type: %s
+                            Error Message: %s
+                            Server Supported Protocols: %s
+                            Server Supported Ciphers: %s
+                            """,
+                        remoteAddress,
+                        cause.getClass().getSimpleName(),
+                        cause.getMessage(),
+                        supportedSslVersions,
+                        ALLOWED_TLS_CIPHERS);
+                    Promise<X509Certificate> unusedPromise = clientCertificatePromise.setFailure(cause);
+                  }
+                });
+        channel.attr(CLIENT_CERTIFICATE_PROMISE_KEY).set(clientCertificatePromise);
+        logger.atFine().log(
+            "Client certificate promise set for channel %s (Remote: %s)",
+            channel,
+            channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
+      } else {
+        logger.atFine().log(
+            "Client certificate not required for channel %s (Remote: %s)",
+            channel,
+            channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
+      }
+      channel.pipeline().addLast(sslHandler);
       logger.atFine().log(
-          "Client certificate promise set for channel %s (Remote: %s)",
+          "SSL handler added to pipeline for channel %s (Remote: %s)",
           channel,
           channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
-    } else {
-      logger.atFine().log(
-          "Client certificate not required for channel %s (Remote: %s)",
-          channel,
+    } catch (SSLException e) {
+      logger.atSevere().withCause(e).log(
+          "SSLException in initChannel: %s (Remote: %s)",
+          e.getMessage(),
           channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
+      channel.close();
+    } catch (Exception e) {
+      logger.atSevere().withCause(e).log("Exception in initChannel");
+      channel.close();
     }
-    channel.pipeline().addLast(sslHandler);
-    logger.atFine().log(
-        "SSL handler added to pipeline for channel %s (Remote: %s)",
-        channel,
-        channel.remoteAddress() != null ? channel.remoteAddress().toString() : "unknown");
   }
 }


### PR DESCRIPTION
This PR is for testing only; triggering CI tests.


This pull request enhances error logging for SSL handshake failures in the `SslServerInitializer`. Now, when a handshake fails, the log output includes more detailed diagnostic information, which should help with troubleshooting and monitoring.

**Enhanced SSL handshake failure logging:**

* Added detailed logging on handshake failure in `SslServerInitializer.java`, including remote address, error type, error message, supported protocols, and ciphers.