### PR TITLE
fix: add missing alpha canary proxy config

### DIFF
--- a/proxy/src/main/java/google/registry/proxy/config/proxy-config-alpha-canary.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/proxy-config-alpha-canary.yaml
@@ -1,0 +1,1 @@
+# Add environment-specific proxy configuration here.


### PR DESCRIPTION
## Summary

- Adds `proxy-config-alpha-canary.yaml` to fix EPP proxy crash in the `frontend-canary` deployment on `ud-registry-alpha-gke`
- The canary deployment sets `PROXY_ENV=alpha_canary`, causing the proxy to look for `config/proxy-config-alpha-canary.yaml` as a Java resource — which didn't exist
- Content matches `proxy-config-alpha.yaml` (a placeholder comment), consistent with how sandbox and other environments handle base/canary config pairs

## Test plan

- [ ] Verify `frontend-canary` pods in `ud-registry-alpha-gke` start without `IllegalArgumentException`
- [ ] Confirm EPP proxy accepts connections on the canary deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)