### PR TITLE
fix: replace java.sql.Timestamp cast in dashboard actions

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
@@ -135,8 +135,9 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
     }
 
     int lookbackMonths = months.orElse(12);
-    Instant startDate =
-        ZonedDateTime.now(ZoneOffset.UTC).minusMonths(lookbackMonths).toInstant();
+    java.sql.Timestamp startDate =
+        java.sql.Timestamp.from(
+            ZonedDateTime.now(ZoneOffset.UTC).minusMonths(lookbackMonths).toInstant());
 
     tm().transact(
         () -> {
@@ -156,7 +157,8 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
 
           List<Map<String, Object>> activity = new ArrayList<>();
           for (Object[] row : activityResults) {
-            Instant period = (Instant) row[0];
+            java.sql.Timestamp periodTs = (java.sql.Timestamp) row[0];
+            Instant period = periodTs.toInstant();
             String tld = (String) row[1];
             String type = (String) row[2];
             Number count = (Number) row[3];

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashForecastingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashForecastingAction.java
@@ -165,8 +165,9 @@ public class RegistryDashForecastingAction extends ConsoleApiAction {
           }
 
           // Renewal rates — native SQL (history_type is a string column)
-          Instant startDate =
-              ZonedDateTime.now(ZoneOffset.UTC).minusMonths(12).toInstant();
+          java.sql.Timestamp startDate =
+              java.sql.Timestamp.from(
+                  ZonedDateTime.now(ZoneOffset.UTC).minusMonths(12).toInstant());
           @SuppressWarnings("unchecked")
           List<Object[]> renewalResults =
               isAdmin

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
@@ -110,8 +110,9 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
     }
 
     int lookbackMonths = months.orElse(12);
-    Instant startDate =
-        ZonedDateTime.now(ZoneOffset.UTC).minusMonths(lookbackMonths).toInstant();
+    java.sql.Timestamp startDate =
+        java.sql.Timestamp.from(
+            ZonedDateTime.now(ZoneOffset.UTC).minusMonths(lookbackMonths).toInstant());
 
     tm().transact(
         () -> {
@@ -134,7 +135,8 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
           String currency = "USD";
 
           for (Object[] row : results) {
-            Instant month = (Instant) row[0];
+            java.sql.Timestamp monthTs = (java.sql.Timestamp) row[0];
+            Instant month = monthTs.toInstant();
             String tld = (String) row[1];
             String operation = (String) row[2];
             BigDecimal amount = (BigDecimal) row[3];


### PR DESCRIPTION
## Summary
- Fix `ClassCastException: java.time.Instant cannot be cast to java.sql.Timestamp` in Revenue & Billing, Domain Activity, and Forecasting dashboard endpoints
- Native SQL `date_trunc` returns `java.sql.Timestamp`, not `java.time.Instant` — cast to Timestamp first, then convert
- Also fix `startDate` parameters passed to native queries (must be `Timestamp`, not `Instant`)

## Test plan
- [ ] Verify Revenue & Billing tab loads without errors
- [ ] Verify Domain Activity tab loads without errors
- [ ] Verify Forecasting tab loads without errors
- [ ] Verify existing Overview/Portfolio tabs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)