### PR TITLE
[no-ticket] feat: pass commit SHA as image tag to GKE deploy scripts

### DIFF
--- a/release/ud-cloudbuild-deploy-gke.yaml
+++ b/release/ud-cloudbuild-deploy-gke.yaml
@@ -70,7 +70,7 @@ steps:
     else
       base_domain="${_BASE_DOMAIN}"
     fi
-    ./deploy-nomulus-for-env.sh ${_ENV} ${base_domain} ${_GCR_HOSTNAME}
+    ./deploy-nomulus-for-env.sh ${_ENV} ${base_domain} ${_GCR_HOSTNAME} ${COMMIT_SHA}
   dir: 'jetty'
 # Deploy Proxy to GKE.
 - id: Deploy-Proxy
@@ -80,7 +80,7 @@ steps:
   - -c
   - |
     set -e
-    ./deploy-proxy-for-env.sh ${_ENV} ${_GCR_HOSTNAME}
+    ./deploy-proxy-for-env.sh ${_ENV} ${_GCR_HOSTNAME} ${COMMIT_SHA}
   dir: 'proxy'
 timeout: 3600s
 options:

--- a/release/ud-cloudbuild-deploy-proxy.yaml
+++ b/release/ud-cloudbuild-deploy-proxy.yaml
@@ -38,7 +38,7 @@ steps:
   args:
   - -c
   - |
-    ./deploy-proxy-for-env.sh ${_ENV} ${_GCR_HOSTNAME}
+    ./deploy-proxy-for-env.sh ${_ENV} ${_GCR_HOSTNAME} ${COMMIT_SHA}
   dir: 'proxy'
 timeout: 3600s
 options:


### PR DESCRIPTION
## Summary
- Pass `${COMMIT_SHA}` as the image tag argument to `deploy-nomulus-for-env.sh` and `deploy-proxy-for-env.sh` in the GKE deploy Cloud Build configs
- This ensures deployments reference a specific image tag instead of defaulting to `:latest`, enabling `kubectl rollout undo` to actually roll back to a previous image

## Changes
- `release/ud-cloudbuild-deploy-gke.yaml` — added `${COMMIT_SHA}` as 4th arg to `deploy-nomulus-for-env.sh` and 3rd arg to `deploy-proxy-for-env.sh`
- `release/ud-cloudbuild-deploy-proxy.yaml` — added `${COMMIT_SHA}` as 3rd arg to `deploy-proxy-for-env.sh`

## Context
The deploy scripts in nomulus-secrets (`UDtorrey/gke-sha-image-tags` branch) now accept an optional image tag argument that defaults to `latest`. The Kubernetes manifests use `:IMAGE_TAG` as a placeholder that gets replaced via `sed`. Image build configs already push with both `${COMMIT_SHA}` and `:latest` tags, so no changes needed there.

## Test plan
- [ ] Verify deploy triggers fire successfully on alpha/sandbox
- [ ] Confirm deployed pods reference the commit SHA tag (not `:latest`)
- [ ] Validate `kubectl rollout undo` works with SHA-tagged images

🤖 Generated with [Claude Code](https://claude.com/claude-code)