### PR TITLE
fix: restrict REGISTRY_OPERATOR to Registry Dashboard only

### DIFF
--- a/console-webapp/src/app/navigation/navigation.component.html
+++ b/console-webapp/src/app/navigation/navigation.component.html
@@ -19,11 +19,13 @@
     }
     {{ node.title }}
   </mat-tree-node>
+  <!-- UD: Registry Dashboard — apply visibility directive to parent nodes -->
   <mat-nested-tree-node
     *matTreeNodeDef="let node; when: hasChild"
     (click)="onClick(node)"
     tabindex="0"
     (keyup.enter)="onClick(node)"
+    [elementId]="getElementId(node)"
   >
     <div class="mat-tree-node" [class.active]="router.url.includes(node.path)">
       <button

--- a/console-webapp/src/app/navigation/navigation.component.ts
+++ b/console-webapp/src/app/navigation/navigation.component.ts
@@ -20,6 +20,12 @@ import { Subscription } from 'rxjs';
 import { RouteWithIcon, routes, PATHS } from '../app-routing.module';
 import { RESTRICTED_ELEMENTS } from '../shared/directives/userLevelVisiblity.directive';
 import { RegistrarComponent } from '../registrar/registrarsTable.component';
+// UD: Registry Dashboard — imports for registrar-specific page path constants
+import { DomainListComponent } from '../domains/domainList.component';
+import { SettingsComponent } from '../settings/settings.component';
+import { BillingInfoComponent } from '../billingInfo/billingInfo.component';
+import { ResourcesComponent } from '../resources/resources.component';
+import { SupportComponent } from '../support/support.component';
 
 interface NavMenuNode extends RouteWithIcon {
   parentRoute?: RouteWithIcon;
@@ -67,6 +73,16 @@ export class NavigationComponent {
       return RESTRICTED_ELEMENTS.USERS;
     } else if (node.path === PATHS.RegistryDash) {
       return RESTRICTED_ELEMENTS.REGISTRY_DASH;
+    // UD: Registry Dashboard — hide registrar-specific pages for REGISTRY_OPERATOR role
+    } else if (
+      node.path === 'home' ||
+      node.path === DomainListComponent.PATH ||
+      node.path === SettingsComponent.PATH ||
+      node.path === BillingInfoComponent.PATH ||
+      node.path === ResourcesComponent.PATH ||
+      node.path === SupportComponent.PATH
+    ) {
+      return RESTRICTED_ELEMENTS.REGISTRAR_PAGES;
     }
     return null;
   }

--- a/console-webapp/src/app/shared/directives/userLevelVisiblity.directive.ts
+++ b/console-webapp/src/app/shared/directives/userLevelVisiblity.directive.ts
@@ -23,6 +23,7 @@ export enum RESTRICTED_ELEMENTS {
   BULK_DELETE,
   SUSPEND,
   REGISTRY_DASH,
+  REGISTRAR_PAGES, // UD: Registry Dashboard — hide registrar-specific pages for REGISTRY_OPERATOR
 }
 
 export const DISABLED_ELEMENTS_PER_ROLE: Record<string, RESTRICTED_ELEMENTS[]> = {
@@ -44,6 +45,7 @@ export const DISABLED_ELEMENTS_PER_ROLE: Record<string, RESTRICTED_ELEMENTS[]> =
     RESTRICTED_ELEMENTS.ACTIVITY_PER_USER,
     RESTRICTED_ELEMENTS.REGISTRAR_ELEMENT,
     RESTRICTED_ELEMENTS.USERS,
+    RESTRICTED_ELEMENTS.REGISTRAR_PAGES, // UD: Registry Dashboard — hide all registrar pages
   ],
 };
 

--- a/console-webapp/src/app/shared/services/backend.service.ts
+++ b/console-webapp/src/app/shared/services/backend.service.ts
@@ -144,10 +144,12 @@ export class BackendService {
       .pipe(catchError((err) => this.errorCatcher<HistoryRecord[]>(err)));
   }
 
+  // UD: Registry Dashboard — return empty array for users without registrar access
+  // (e.g. REGISTRY_OPERATOR) so the app doesn't hang on startup
   getRegistrars(): Observable<Registrar[]> {
     return this.http
       .get<Registrar[]>('/console-api/registrars')
-      .pipe(catchError((err) => this.errorCatcher<Registrar[]>(err)));
+      .pipe(catchError((err) => this.errorCatcher<Registrar[]>(err, [])));
   }
 
   createRegistrar(registrar: Registrar): Observable<Registrar> {

--- a/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
+++ b/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
@@ -64,15 +64,13 @@ public class ConsoleRoleDefinitions {
               ConsolePermission.MANAGE_DOCUMENTATION)
           .build();
 
+  // UD: Removed registrar-facing permissions (VIEW_REGISTRARS, VIEW_REGISTRAR_DETAILS,
+  // DOWNLOAD_DOMAINS, ACCESS_BILLING_DETAILS, VIEW_OPERATIONAL_DATA) —
+  // REGISTRY_OPERATOR should only access Registry Dashboard, not registrar-scoped data.
   /** Permissions for a registry operator (dashboard user). */
   static final ImmutableSet<ConsolePermission> REGISTRY_OPERATOR_PERMISSIONS =
       ImmutableSet.of(
-          ConsolePermission.VIEW_REGISTRARS,
-          ConsolePermission.VIEW_REGISTRAR_DETAILS,
-          ConsolePermission.DOWNLOAD_DOMAINS,
           ConsolePermission.VIEW_TLD_PORTFOLIO,
-          ConsolePermission.ACCESS_BILLING_DETAILS,
-          ConsolePermission.VIEW_OPERATIONAL_DATA,
           ConsolePermission.VIEW_DASHBOARD_OVERVIEW,
           ConsolePermission.VIEW_REGISTRAR_PORTFOLIO,
           ConsolePermission.VIEW_PRICING,

--- a/core/src/test/java/google/registry/model/console/RegistryOperatorRoleTest.java
+++ b/core/src/test/java/google/registry/model/console/RegistryOperatorRoleTest.java
@@ -32,14 +32,26 @@ class RegistryOperatorRoleTest {
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.MANAGE_COST_BASIS)).isTrue();
   }
 
+  // UD: Registry Dashboard — REGISTRY_OPERATOR should NOT have registrar-facing permissions
   @Test
-  void testRegistryOperator_hasReadOnlyRegistrarPermissions() {
+  void testRegistryOperator_doesNotHaveRegistrarPermissions() {
     UserRoles userRoles =
         new UserRoles.Builder().setGlobalRole(GlobalRole.REGISTRY_OPERATOR).build();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_REGISTRARS)).isFalse();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_REGISTRAR_DETAILS)).isFalse();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.DOWNLOAD_DOMAINS)).isFalse();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_TLD_PORTFOLIO)).isTrue();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.ACCESS_BILLING_DETAILS)).isFalse();
+    assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_OPERATIONAL_DATA)).isFalse();
+  }
+
+  // UD: Verify FTE still has perms after REGISTRY_OPERATOR tightening
+  @Test
+  void testFte_stillHasRegistrarPermissions() {
+    UserRoles userRoles = new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build();
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_REGISTRARS)).isTrue();
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_REGISTRAR_DETAILS)).isTrue();
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.DOWNLOAD_DOMAINS)).isTrue();
-    assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_TLD_PORTFOLIO)).isTrue();
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.ACCESS_BILLING_DETAILS)).isTrue();
     assertThat(userRoles.hasGlobalPermission(ConsolePermission.VIEW_OPERATIONAL_DATA)).isTrue();
   }

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleDomainGetActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleDomainGetActionTest.java
@@ -21,6 +21,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import google.registry.model.console.GlobalRole;
 import google.registry.model.console.RegistrarRole;
 import google.registry.model.console.User;
 import google.registry.model.console.UserRoles;
@@ -76,6 +77,21 @@ public class ConsoleDomainGetActionTest extends ConsoleActionBaseTestCase {
         createAction(AuthResult.createApp("service@registry.example"), "exists.tld");
     action.run();
     assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+  }
+
+  // UD: Registry Dashboard — verify REGISTRY_OPERATOR cannot get domain details
+  @Test
+  void testFailure_registryOperatorCannotGetDomain() {
+    ConsoleDomainGetAction action =
+        createAction(
+            AuthResult.createUser(
+                createUser(
+                    new UserRoles.Builder()
+                        .setGlobalRole(GlobalRole.REGISTRY_OPERATOR)
+                        .build())),
+            "exists.tld");
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_NOT_FOUND);
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleDomainListActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleDomainListActionTest.java
@@ -18,11 +18,16 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
 import google.registry.model.ForeignKeyUtils;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
 import google.registry.model.domain.Domain;
 import google.registry.request.Action;
 import google.registry.request.auth.AuthResult;
@@ -46,6 +51,35 @@ public class ConsoleDomainListActionTest extends ConsoleActionBaseTestCase {
       clock.advanceOneMilli();
     }
     DatabaseHelper.persistDeletedDomain("deleted.tld", clock.nowUtc().minusDays(1));
+  }
+
+  // UD: Registry Dashboard — verify REGISTRY_OPERATOR cannot list domains
+  @Test
+  void testForbidden_registryOperatorCannotListDomains() {
+    User roUser =
+        persistResource(
+            new User.Builder()
+                .setEmailAddress("ro@email.tld")
+                .setUserRoles(
+                    new UserRoles.Builder()
+                        .setGlobalRole(GlobalRole.REGISTRY_OPERATOR)
+                        .build())
+                .build());
+    AuthResult authResult = AuthResult.createUser(roUser);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    when(consoleApiParams.request().getMethod()).thenReturn(Action.Method.GET.toString());
+    response = (FakeResponse) consoleApiParams.response();
+    ConsoleDomainListAction action =
+        new ConsoleDomainListAction(
+            consoleApiParams,
+            "TheRegistrar",
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_FORBIDDEN);
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/server/console/RegistrarsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/RegistrarsActionTest.java
@@ -22,6 +22,7 @@ import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -87,6 +88,21 @@ class RegistrarsActionTest extends ConsoleActionBaseTestCase {
           "localizedAddress",
           "{ \"street\": [\"test street\"], \"city\": \"test city\", \"state\": \"test state\","
               + " \"zip\": \"00700\", \"countryCode\": \"US\" }");
+
+  // UD: Registry Dashboard — verify REGISTRY_OPERATOR cannot list registrars
+  @Test
+  void testForbidden_registryOperatorCannotListRegistrars() {
+    RegistrarsAction action =
+        createAction(
+            Action.Method.GET,
+            AuthResult.createUser(
+                createUser(
+                    new UserRoles.Builder()
+                        .setGlobalRole(GlobalRole.REGISTRY_OPERATOR)
+                        .build())));
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_FORBIDDEN);
+  }
 
   @Test
   void testSuccess_onlyRealAndOteRegistrars() {


### PR DESCRIPTION
## Summary

- **Security fix**: REGISTRY_OPERATOR users with no registrar associations could see and access registrar-specific pages (Domains, Settings, Billing Info, etc.) in both the frontend navigation and backend API
- **Backend**: Remove 5 registrar-facing permissions from REGISTRY_OPERATOR_PERMISSIONS (VIEW_REGISTRARS, VIEW_REGISTRAR_DETAILS, DOWNLOAD_DOMAINS, ACCESS_BILLING_DETAILS, VIEW_OPERATIONAL_DATA). FTE role unaffected — these permissions come via SUPPORT_LEAD
- **Frontend**: Add REGISTRAR_PAGES restricted element to hide registrar nav items for REGISTRY_OPERATOR. Apply visibility directive to parent nodes (Settings). Gracefully handle 403 from registrars endpoint
- **Tests**: REGISTRY_OPERATOR 403 tests for RegistrarsAction, ConsoleDomainListAction, ConsoleDomainGetAction. FTE regression test. Updated permission assertions

## Test plan

- [ ] CI passes (all -gke checks green)
- [ ] Backend: `RegistryOperatorRoleTest` — verifies permissions removed and FTE unaffected
- [ ] Backend: `RegistrarsActionTest` — REGISTRY_OPERATOR gets 403 from registrar list
- [ ] Backend: `ConsoleDomainListActionTest` — REGISTRY_OPERATOR gets 403 from domain list
- [ ] Backend: `ConsoleDomainGetActionTest` — REGISTRY_OPERATOR gets 404 from domain get
- [ ] Manual: Login as REGISTRY_OPERATOR on alpha-gke — only Registry Dashboard visible
- [ ] Manual: FTE user can still access all pages (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)