### PR TITLE
feat: add Source filter to Effective Fees tab

### DIFF
--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
@@ -31,6 +31,15 @@
         <mat-option *ngFor="let tld of uniqueTlds()" [value]="tld">.{{ tld }}</mat-option>
       </mat-select>
     </mat-form-field>
+
+    <mat-form-field appearance="outline">
+      <mat-label>Source</mat-label>
+      <mat-select [value]="filterSource()" (selectionChange)="onSourceFilterChange($event.value)">
+        <mat-option value="all">All Sources</mat-option>
+        <mat-option value="Default">Default</mat-option>
+        <mat-option value="Custom">Custom</mat-option>
+      </mat-select>
+    </mat-form-field>
   </div>
 
   <!-- Table -->

--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
@@ -35,6 +35,7 @@ export class EffectiveFeesComponent implements AfterViewInit {
 
   filterRegistrar = signal<string>('all');
   filterTld = signal<string>('all');
+  filterSource = signal<string>('all');
 
   uniqueRegistrars = computed(() => {
     const fees = this.dashService.effectiveFees();
@@ -50,8 +51,10 @@ export class EffectiveFeesComponent implements AfterViewInit {
     let fees = this.dashService.effectiveFees();
     const reg = this.filterRegistrar();
     const tld = this.filterTld();
+    const source = this.filterSource();
     if (reg !== 'all') fees = fees.filter(f => f.registrarId === reg);
     if (tld !== 'all') fees = fees.filter(f => f.tld === tld);
+    if (source !== 'all') fees = fees.filter(f => f.source === source);
     return fees;
   });
 
@@ -75,5 +78,9 @@ export class EffectiveFeesComponent implements AfterViewInit {
 
   onTldFilterChange(value: string) {
     this.filterTld.set(value);
+  }
+
+  onSourceFilterChange(value: string) {
+    this.filterSource.set(value);
   }
 }


### PR DESCRIPTION
## Summary
- Adds a **Source** dropdown filter (All Sources / Default / Custom) to the Effective Fees sub-tab
- Sits alongside the existing Registrar and TLD filters
- Lets users quickly isolate rows with custom pricing overrides vs default TLD prices

## Test plan
- [ ] Verify "All Sources" shows all rows (default behavior unchanged)
- [ ] Verify "Default" filter shows only rows with gray DEFAULT badge
- [ ] Verify "Custom" filter shows only rows with blue CUSTOM badge
- [ ] Verify filters combine correctly (e.g. Registrar + Source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)