### PR TITLE
feat: show fetch timestamp on Effective Fees tab

### DIFF
--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
@@ -2,7 +2,7 @@
   <div class="effective-fees-header">
     <h3>Effective Fees by Registrar</h3>
     <p class="effective-fees-description">
-      What each registrar is actually paying per TLD per operation. Default TLD prices are shown unless overridden by an active custom pricing rule.
+      What each registrar is actually paying per TLD per operation. Default TLD prices are shown unless overridden by an active custom pricing rule.<span *ngIf="fetchedAt()"> Data active as of {{ fetchedAt() }}.</span>
     </p>
   </div>
 

--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
@@ -33,6 +33,7 @@ export class EffectiveFeesComponent implements AfterViewInit {
     'registrarId', 'registrarName', 'tld', 'operation', 'price', 'currency', 'source',
   ];
 
+  fetchedAt = signal<string>('');
   filterRegistrar = signal<string>('all');
   filterTld = signal<string>('all');
   filterSource = signal<string>('all');
@@ -61,7 +62,14 @@ export class EffectiveFeesComponent implements AfterViewInit {
   dataSource = new MatTableDataSource<EffectiveFeeEntry>([]);
 
   constructor(public dashService: RegistryDashService) {
-    this.dashService.getEffectiveFees().subscribe();
+    this.dashService.getEffectiveFees().subscribe(() => {
+      this.fetchedAt.set(
+        new Date().toLocaleDateString('en-US', {
+          month: 'short', day: 'numeric', year: 'numeric',
+          hour: 'numeric', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short',
+        })
+      );
+    });
 
     effect(() => {
       this.dataSource.data = this.filteredFees();


### PR DESCRIPTION
## Summary
- Shows a UTC timestamp in the Effective Fees description indicating when the data was fetched
- e.g. "Data active as of Apr 6, 2026, 1:21 PM UTC."
- Timestamp appears after data loads, hidden while loading

## Test plan
- [ ] Verify timestamp appears after data loads
- [ ] Verify timestamp is in UTC with readable format
- [ ] Verify no timestamp shown while loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)