### PR TITLE
feat: dashboard logo spacing, subtitle, and user email display

### DIFF
--- a/console-webapp/src/app/header/header.component.html
+++ b/console-webapp/src/app/header/header.component.html
@@ -17,11 +17,15 @@
       class="console-app__logo"
     >
       <span class="console-app__logo-text">DNEX <span class="logo-registry">Registry</span></span>
+      <span class="console-app__logo-subtitle">and Service Provider</span>
     </a>
     <span class="spacer"></span>
     <!-- UD: Registry Dashboard — hide registrar selector for REGISTRY_OPERATOR -->
     @if (!breakpointObserver.isMobileView()) {
     <app-registrar-selector [elementId]="registrarPagesRestriction" />
+    }
+    @if (userEmail()) {
+    <span class="console-app__header-user-email">{{ userEmail() }}</span>
     }
     <button
       class="console-app__header-user-icon"

--- a/console-webapp/src/app/header/header.component.scss
+++ b/console-webapp/src/app/header/header.component.scss
@@ -16,9 +16,18 @@
   &__logo {
     color: inherit;
     text-decoration: none;
-    margin-left: -15px;
+    margin-left: 8px;
     display: flex;
-    align-items: center;
+    flex-direction: column;
+  }
+  &__logo-subtitle {
+    font-size: 11px;
+    font-weight: 400;
+    font-style: italic;
+    color: #9AA0A6;
+    letter-spacing: 0.1px;
+    margin-top: 1px;
+    line-height: 1.2;
   }
   &__logo-text {
     font-size: 22px;
@@ -46,8 +55,15 @@
       margin-bottom: 10px;
     }
 
+    &-user-email {
+      font-size: 11px;
+      font-weight: 400;
+      color: #9AA0A6;
+      letter-spacing: 0.1px;
+      margin-right: 2px;
+    }
     &-user-icon {
-      margin-left: 20px;
+      margin-left: 8px;
     }
   }
 }

--- a/console-webapp/src/app/header/header.component.ts
+++ b/console-webapp/src/app/header/header.component.ts
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Output, computed } from '@angular/core';
 import { BreakPointObserverService } from '../shared/services/breakPoint.service';
 // UD: Registry Dashboard — hide registrar selector for REGISTRY_OPERATOR
 import { RESTRICTED_ELEMENTS } from '../shared/directives/userLevelVisiblity.directive';
+import { UserDataService } from '../shared/services/userData.service';
 
 @Component({
   selector: 'app-header',
@@ -28,7 +29,13 @@ export class HeaderComponent {
   registrarPagesRestriction = RESTRICTED_ELEMENTS.REGISTRAR_PAGES;
   private isNavOpen = false;
 
-  constructor(protected breakpointObserver: BreakPointObserverService) {}
+  // UD: display logged-in user email in header
+  userEmail = computed(() => this.userDataService.userData()?.userEmail || '');
+
+  constructor(
+    protected breakpointObserver: BreakPointObserverService,
+    private userDataService: UserDataService,
+  ) {}
 
   @Output() toggleNavOpen = new EventEmitter<boolean>();
 

--- a/console-webapp/src/app/shared/services/userData.service.ts
+++ b/console-webapp/src/app/shared/services/userData.service.ts
@@ -27,6 +27,7 @@ export interface UserData {
   supportEmail: string;
   supportPhoneNumber: string;
   technicalDocsUrl: string;
+  userEmail?: string;
   userRoles?: Map<string, string>;
 }
 

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
@@ -69,7 +69,7 @@ public class ConsoleUserDataAction extends ConsoleApiAction {
 
     JSONObject json =
         new JSONObject(
-            ImmutableMap.of(
+            ImmutableMap.builder()
                 // Both isAdmin and globalRole flags are used by UI as an indicator to hide / show
                 // specific set of widgets and screens.
                 // For example:
@@ -78,16 +78,19 @@ public class ConsoleUserDataAction extends ConsoleApiAction {
                 // screens and widgets.
                 // This however is merely for visual representation, as any back-end action contains
                 // auth checks.
-                "isAdmin", user.getUserRoles().isAdmin(),
-                "globalRole", user.getUserRoles().getGlobalRole(),
+                .put("isAdmin", user.getUserRoles().isAdmin())
+                .put("globalRole", user.getUserRoles().getGlobalRole())
                 // registrar-specific roles
-                "userRoles", user.getUserRoles().getRegistrarRoles(),
+                .put("userRoles", user.getUserRoles().getRegistrarRoles())
                 // Include static contact resources in this call to minimize round trips
-                "productName", productName,
-                "supportEmail", supportEmail,
-                "supportPhoneNumber", supportPhoneNumber,
+                .put("productName", productName)
+                .put("supportEmail", supportEmail)
+                .put("supportPhoneNumber", supportPhoneNumber)
                 // Is used by UI to construct a link to registry resources
-                "technicalDocsUrl", technicalDocsUrl));
+                .put("technicalDocsUrl", technicalDocsUrl)
+                // UD: logged-in user's email for header display
+                .put("userEmail", user.getEmailAddress())
+                .buildOrThrow());
 
     consoleApiParams.response().setPayload(json.toString());
     consoleApiParams.response().setStatus(SC_OK);

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleUserDataActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleUserDataActionTest.java
@@ -64,7 +64,9 @@ class ConsoleUserDataActionTest extends ConsoleActionBaseTestCase {
             "supportPhoneNumber",
             "+1 (212) 867 5309",
             "supportEmail",
-            "support@example.com");
+            "support@example.com",
+            "userEmail",
+            "fte@email.tld");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Fix logo left spacing — was `margin-left: -15px`, now `+8px`
- Add italic "and Service Provider" subtitle below "DNEX Registry" logo
- Expose `userEmail` from `/console-api/userdata` backend endpoint
- Display logged-in user's email (subtle, 11px light gray) next to the person icon in the header

## Changes
- **Backend**: `ConsoleUserDataAction.java` — added `userEmail` field to JSON response
- **Frontend**: `header.component.{html,ts,scss}` — logo layout, subtitle, user email display
- **Interface**: `userData.service.ts` — added `userEmail` to `UserData` interface
- **Test**: `ConsoleUserDataActionTest.java` — updated assertion for new field

## Test plan
- [ ] Verify logo has proper left spacing and subtitle renders
- [ ] Verify user email appears next to person icon
- [ ] CI passes (backend + frontend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)