### PR TITLE
fix: prevent registrar dropdown flash for registry_operator users

### DIFF
--- a/console-webapp/src/app/header/header.component.html
+++ b/console-webapp/src/app/header/header.component.html
@@ -21,7 +21,7 @@
     </a>
     <span class="spacer"></span>
     <!-- UD: Registry Dashboard — hide registrar selector for REGISTRY_OPERATOR -->
-    @if (!breakpointObserver.isMobileView()) {
+    @if (!breakpointObserver.isMobileView() && isUserLoaded()) {
     <app-registrar-selector [elementId]="registrarPagesRestriction" />
     }
     @if (userEmail()) {
@@ -41,7 +41,7 @@
     </mat-menu>
   </mat-toolbar>
   <!-- UD: Registry Dashboard — hide registrar selector for REGISTRY_OPERATOR -->
-  @if (breakpointObserver.isMobileView()) {
+  @if (breakpointObserver.isMobileView() && isUserLoaded()) {
   <app-registrar-selector [elementId]="registrarPagesRestriction" />
   }
 </p>

--- a/console-webapp/src/app/header/header.component.ts
+++ b/console-webapp/src/app/header/header.component.ts
@@ -27,6 +27,7 @@ import { UserDataService } from '../shared/services/userData.service';
 export class HeaderComponent {
   // UD: Registry Dashboard — used by [elementId] directive in template
   registrarPagesRestriction = RESTRICTED_ELEMENTS.REGISTRAR_PAGES;
+  isUserLoaded = computed(() => !!this.userDataService.userData());
   private isNavOpen = false;
 
   // UD: display logged-in user email in header


### PR DESCRIPTION
## Summary
- Gate registrar selector rendering on `userData` being loaded to prevent the "Registrar" dropdown from briefly flashing on screen for `registry_operator` users during initial page load

## Root Cause
The `UserLevelVisibility` directive defaults to `'NONE'` role while `userData` is loading asynchronously. The `'NONE'` role doesn't disable `REGISTRAR_PAGES`, so the selector is visible until the real role arrives and hides it.

## Changes
- Added `isUserLoaded` computed signal to `HeaderComponent`
- Gated both desktop and mobile registrar selector `@if` blocks on `isUserLoaded()`

## Test plan
- [ ] Build console webapp (`npm run build`) — verified locally
- [ ] Log in as registry_operator — no registrar dropdown flash
- [ ] Log in as registrar user — dropdown still appears after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)