### PR TITLE
fix: prevent nav sidebar flicker for registry_operator users

### DIFF
--- a/console-webapp/src/app/shared/directives/userLevelVisiblity.directive.ts
+++ b/console-webapp/src/app/shared/directives/userLevelVisiblity.directive.ts
@@ -68,7 +68,15 @@ export class UserLevelVisibility {
   }
 
   processElement() {
-    const globalRole = this.userDataService?.userData()?.globalRole || 'NONE';
+    const userData = this.userDataService?.userData();
+    // UD: Hide role-restricted elements until user data loads to prevent flash
+    if (!userData) {
+      if (this.elementId !== null) {
+        this.el.nativeElement.style.display = 'none';
+      }
+      return;
+    }
+    const globalRole = userData.globalRole || 'NONE';
     if (this.elementId === null) {
       return;
     }


### PR DESCRIPTION
## Summary
- Hide role-restricted nav elements until user data loads, preventing brief flash of wrong nav items for `registry_operator` users
- When `userData()` is undefined (still loading), elements with `elementId` are hidden instead of being evaluated against the `NONE` role

## Changes
- `console-webapp/src/app/shared/directives/userLevelVisiblity.directive.ts`: In `processElement()`, check if `userData` is undefined before evaluating role-based visibility. If undefined, hide the element and return early.

## Test plan
- [ ] Load console as registry_operator user — nav should not flash registrar pages
- [ ] Load console as admin/support user — nav should behave as before
- [ ] Verify CI `-gke` checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)