### PR TITLE
fix: use actual event dates in dashboard instead of ICANN reporting dates

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
@@ -54,97 +54,112 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
   private static final Set<String> VALID_GRANULARITIES = Set.of("15min", "hour", "day", "month");
 
   // --- Standard granularity SQL (hour, day, month) ---
+  // Uses DomainHistory.history_modification_time (actual event time) instead of
+  // DomainTransactionRecord.reporting_time (which includes grace period offsets
+  // that push dates into the future by days or weeks).
 
   private static final String ACTIVITY_ALL_TEMPLATE =
       """
-      SELECT date_trunc('%s', dtr.reporting_time) AS period,
-             dtr.tld,
+      SELECT date_trunc('%s', dh.history_modification_time) AS period,
+             d.tld,
              CASE
-               WHEN dtr.report_field LIKE 'NET_ADDS_%%%%' THEN 'CREATES'
-               WHEN dtr.report_field LIKE 'NET_RENEWS_%%%%' THEN 'RENEWS'
-               WHEN dtr.report_field = 'TRANSFER_SUCCESSFUL' THEN 'TRANSFERS'
-               WHEN dtr.report_field IN (
-                 'DELETED_DOMAINS_GRACE', 'DELETED_DOMAINS_NOGRACE'
-               ) THEN 'DELETES'
-               WHEN dtr.report_field = 'RESTORED_DOMAINS' THEN 'RESTORES'
+               WHEN dh.history_type = 'DOMAIN_CREATE' THEN 'CREATES'
+               WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 'RENEWS'
+               WHEN dh.history_type = 'DOMAIN_TRANSFER_APPROVE' THEN 'TRANSFERS'
+               WHEN dh.history_type = 'DOMAIN_DELETE' THEN 'DELETES'
+               WHEN dh.history_type = 'DOMAIN_RESTORE' THEN 'RESTORES'
                ELSE 'OTHER'
              END AS activity_type,
-             SUM(dtr.report_amount) AS total_count
-      FROM "DomainTransactionRecord" dtr
-      WHERE dtr.reporting_time >= :startDate
-      GROUP BY period, dtr.tld, activity_type
-      ORDER BY period, dtr.tld
+             COUNT(*) AS total_count
+      FROM "DomainHistory" dh
+      JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
+      WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_type IN (
+          'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
+          'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
+      GROUP BY period, d.tld, activity_type
+      ORDER BY period, d.tld
       """;
 
   private static final String ACTIVITY_SCOPED_TEMPLATE =
       """
-      SELECT date_trunc('%s', dtr.reporting_time) AS period,
-             dtr.tld,
+      SELECT date_trunc('%s', dh.history_modification_time) AS period,
+             d.tld,
              CASE
-               WHEN dtr.report_field LIKE 'NET_ADDS_%%%%' THEN 'CREATES'
-               WHEN dtr.report_field LIKE 'NET_RENEWS_%%%%' THEN 'RENEWS'
-               WHEN dtr.report_field = 'TRANSFER_SUCCESSFUL' THEN 'TRANSFERS'
-               WHEN dtr.report_field IN (
-                 'DELETED_DOMAINS_GRACE', 'DELETED_DOMAINS_NOGRACE'
-               ) THEN 'DELETES'
-               WHEN dtr.report_field = 'RESTORED_DOMAINS' THEN 'RESTORES'
+               WHEN dh.history_type = 'DOMAIN_CREATE' THEN 'CREATES'
+               WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 'RENEWS'
+               WHEN dh.history_type = 'DOMAIN_TRANSFER_APPROVE' THEN 'TRANSFERS'
+               WHEN dh.history_type = 'DOMAIN_DELETE' THEN 'DELETES'
+               WHEN dh.history_type = 'DOMAIN_RESTORE' THEN 'RESTORES'
                ELSE 'OTHER'
              END AS activity_type,
-             SUM(dtr.report_amount) AS total_count
-      FROM "DomainTransactionRecord" dtr
-      WHERE dtr.reporting_time >= :startDate
-        AND dtr.tld IN :tlds
-      GROUP BY period, dtr.tld, activity_type
-      ORDER BY period, dtr.tld
+             COUNT(*) AS total_count
+      FROM "DomainHistory" dh
+      JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
+      WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND d.tld IN :tlds
+        AND dh.history_type IN (
+          'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
+          'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
+      GROUP BY period, d.tld, activity_type
+      ORDER BY period, d.tld
       """;
 
   // --- 15-minute bucket SQL ---
 
   private static final String ACTIVITY_15MIN_ALL =
       """
-      SELECT date_trunc('hour', dtr.reporting_time)
-               + floor(extract(minute from dtr.reporting_time) / 15)
+      SELECT date_trunc('hour', dh.history_modification_time)
+               + floor(extract(minute from dh.history_modification_time) / 15)
                * interval '15 minutes' AS period,
-             dtr.tld,
+             d.tld,
              CASE
-               WHEN dtr.report_field LIKE 'NET_ADDS_%%%%' THEN 'CREATES'
-               WHEN dtr.report_field LIKE 'NET_RENEWS_%%%%' THEN 'RENEWS'
-               WHEN dtr.report_field = 'TRANSFER_SUCCESSFUL' THEN 'TRANSFERS'
-               WHEN dtr.report_field IN (
-                 'DELETED_DOMAINS_GRACE', 'DELETED_DOMAINS_NOGRACE'
-               ) THEN 'DELETES'
-               WHEN dtr.report_field = 'RESTORED_DOMAINS' THEN 'RESTORES'
+               WHEN dh.history_type = 'DOMAIN_CREATE' THEN 'CREATES'
+               WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 'RENEWS'
+               WHEN dh.history_type = 'DOMAIN_TRANSFER_APPROVE' THEN 'TRANSFERS'
+               WHEN dh.history_type = 'DOMAIN_DELETE' THEN 'DELETES'
+               WHEN dh.history_type = 'DOMAIN_RESTORE' THEN 'RESTORES'
                ELSE 'OTHER'
              END AS activity_type,
-             SUM(dtr.report_amount) AS total_count
-      FROM "DomainTransactionRecord" dtr
-      WHERE dtr.reporting_time >= :startDate
-      GROUP BY period, dtr.tld, activity_type
-      ORDER BY period, dtr.tld
+             COUNT(*) AS total_count
+      FROM "DomainHistory" dh
+      JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
+      WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_type IN (
+          'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
+          'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
+      GROUP BY period, d.tld, activity_type
+      ORDER BY period, d.tld
       """;
 
   private static final String ACTIVITY_15MIN_SCOPED =
       """
-      SELECT date_trunc('hour', dtr.reporting_time)
-               + floor(extract(minute from dtr.reporting_time) / 15)
+      SELECT date_trunc('hour', dh.history_modification_time)
+               + floor(extract(minute from dh.history_modification_time) / 15)
                * interval '15 minutes' AS period,
-             dtr.tld,
+             d.tld,
              CASE
-               WHEN dtr.report_field LIKE 'NET_ADDS_%%%%' THEN 'CREATES'
-               WHEN dtr.report_field LIKE 'NET_RENEWS_%%%%' THEN 'RENEWS'
-               WHEN dtr.report_field = 'TRANSFER_SUCCESSFUL' THEN 'TRANSFERS'
-               WHEN dtr.report_field IN (
-                 'DELETED_DOMAINS_GRACE', 'DELETED_DOMAINS_NOGRACE'
-               ) THEN 'DELETES'
-               WHEN dtr.report_field = 'RESTORED_DOMAINS' THEN 'RESTORES'
+               WHEN dh.history_type = 'DOMAIN_CREATE' THEN 'CREATES'
+               WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 'RENEWS'
+               WHEN dh.history_type = 'DOMAIN_TRANSFER_APPROVE' THEN 'TRANSFERS'
+               WHEN dh.history_type = 'DOMAIN_DELETE' THEN 'DELETES'
+               WHEN dh.history_type = 'DOMAIN_RESTORE' THEN 'RESTORES'
                ELSE 'OTHER'
              END AS activity_type,
-             SUM(dtr.report_amount) AS total_count
-      FROM "DomainTransactionRecord" dtr
-      WHERE dtr.reporting_time >= :startDate
-        AND dtr.tld IN :tlds
-      GROUP BY period, dtr.tld, activity_type
-      ORDER BY period, dtr.tld
+             COUNT(*) AS total_count
+      FROM "DomainHistory" dh
+      JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
+      WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND d.tld IN :tlds
+        AND dh.history_type IN (
+          'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
+          'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
+      GROUP BY period, d.tld, activity_type
+      ORDER BY period, d.tld
       """;
 
   private static final String CURRENT_COUNTS_ALL =
@@ -221,7 +236,7 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
         () -> {
           String sql = buildSql(resolvedGran, isAdmin);
 
-          // Activity data from DomainTransactionRecord
+          // Activity data from DomainHistory (uses actual event time)
           @SuppressWarnings("unchecked")
           List<Object[]> activityResults;
           if (isAdmin) {

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashDomainActivityAction.java
@@ -74,7 +74,7 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
       FROM "DomainHistory" dh
       JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
       WHERE dh.history_modification_time >= :startDate
-        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_modification_time <= :endDate
         AND dh.history_type IN (
           'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
           'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
@@ -98,7 +98,7 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
       FROM "DomainHistory" dh
       JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
       WHERE dh.history_modification_time >= :startDate
-        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_modification_time <= :endDate
         AND d.tld IN :tlds
         AND dh.history_type IN (
           'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
@@ -127,7 +127,7 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
       FROM "DomainHistory" dh
       JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
       WHERE dh.history_modification_time >= :startDate
-        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_modification_time <= :endDate
         AND dh.history_type IN (
           'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
           'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')
@@ -153,7 +153,7 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
       FROM "DomainHistory" dh
       JOIN "Domain" d ON d.repo_id = dh.domain_repo_id
       WHERE dh.history_modification_time >= :startDate
-        AND dh.history_modification_time <= CURRENT_TIMESTAMP
+        AND dh.history_modification_time <= :endDate
         AND d.tld IN :tlds
         AND dh.history_type IN (
           'DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',
@@ -228,8 +228,9 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
       gran = "month";
     }
 
-    Instant startDate = ZonedDateTime.now(ZoneOffset.UTC)
-        .minus(hoursBack, ChronoUnit.HOURS).toInstant();
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    Instant startDate = now.minus(hoursBack, ChronoUnit.HOURS).toInstant();
+    Instant endDate = now.toInstant();
 
     String resolvedGran = gran;
     tm().transact(
@@ -243,11 +244,13 @@ public class RegistryDashDomainActivityAction extends ConsoleApiAction {
             activityResults = tm().getEntityManager()
                 .createNativeQuery(sql)
                 .setParameter("startDate", startDate)
+                .setParameter("endDate", endDate)
                 .getResultList();
           } else {
             activityResults = tm().getEntityManager()
                 .createNativeQuery(sql)
                 .setParameter("startDate", startDate)
+                .setParameter("endDate", endDate)
                 .setParameter("tlds", tlds)
                 .getResultList();
           }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
@@ -60,10 +60,14 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
   private static final Set<String> VALID_GRANULARITIES = Set.of("15min", "hour", "day", "month");
 
   // --- Standard granularity SQL (hour, day, month) ---
+  // Uses DomainHistory.history_modification_time for the period timestamp instead of
+  // BillingEvent.event_time. For most operations these are identical, but for transfers
+  // the BillingEvent.event_time is set to the speculative auto-approval date (days/weeks
+  // in the future), while DomainHistory records when the action was actually taken.
 
   private static final String REVENUE_ALL_TEMPLATE =
       """
-      SELECT date_trunc('%s', b.event_time) AS period,
+      SELECT date_trunc('%s', dh.history_modification_time) AS period,
              d.tld, b.reason,
              SUM(b.cost_amount) AS total_amount,
              SUM(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0))
@@ -71,26 +75,27 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
              b.cost_currency
       FROM "BillingEvent" b
       JOIN "Domain" d ON d.repo_id = b.domain_repo_id
+      JOIN "DomainHistory" dh ON dh.history_revision_id = b.domain_history_revision_id
+        AND dh.domain_repo_id = b.domain_repo_id
       LEFT JOIN LATERAL (
         SELECT rsp_retained_fee_amount
         FROM "RegistryDashboardCostBasis"
         WHERE (tld = d.tld OR tld = '*')
           AND operation = b.reason
-          AND effective_date <= b.event_time
+          AND effective_date <= dh.history_modification_time
         ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END,
                  effective_date DESC
         LIMIT 1
       ) cb ON true
-      WHERE b.event_time >= :startDate
-        AND b.event_time <= CURRENT_TIMESTAMP
+      WHERE dh.history_modification_time >= :startDate
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
-      GROUP BY date_trunc('%s', b.event_time), d.tld, b.reason, b.cost_currency
+      GROUP BY date_trunc('%s', dh.history_modification_time), d.tld, b.reason, b.cost_currency
       ORDER BY period, d.tld
       """;
 
   private static final String REVENUE_SCOPED_TEMPLATE =
       """
-      SELECT date_trunc('%s', b.event_time) AS period,
+      SELECT date_trunc('%s', dh.history_modification_time) AS period,
              d.tld, b.reason,
              SUM(b.cost_amount) AS total_amount,
              SUM(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0))
@@ -98,21 +103,22 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
              b.cost_currency
       FROM "BillingEvent" b
       JOIN "Domain" d ON d.repo_id = b.domain_repo_id
+      JOIN "DomainHistory" dh ON dh.history_revision_id = b.domain_history_revision_id
+        AND dh.domain_repo_id = b.domain_repo_id
       LEFT JOIN LATERAL (
         SELECT rsp_retained_fee_amount
         FROM "RegistryDashboardCostBasis"
         WHERE (tld = d.tld OR tld = '*')
           AND operation = b.reason
-          AND effective_date <= b.event_time
+          AND effective_date <= dh.history_modification_time
         ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END,
                  effective_date DESC
         LIMIT 1
       ) cb ON true
-      WHERE b.event_time >= :startDate
-        AND b.event_time <= CURRENT_TIMESTAMP
+      WHERE dh.history_modification_time >= :startDate
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
-      GROUP BY date_trunc('%s', b.event_time), d.tld, b.reason, b.cost_currency
+      GROUP BY date_trunc('%s', dh.history_modification_time), d.tld, b.reason, b.cost_currency
       ORDER BY period, d.tld
       """;
 
@@ -120,8 +126,9 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
 
   private static final String REVENUE_15MIN_ALL =
       """
-      SELECT date_trunc('hour', b.event_time)
-               + floor(extract(minute from b.event_time) / 15) * interval '15 minutes' AS period,
+      SELECT date_trunc('hour', dh.history_modification_time)
+               + floor(extract(minute from dh.history_modification_time) / 15)
+                 * interval '15 minutes' AS period,
              d.tld, b.reason,
              SUM(b.cost_amount) AS total_amount,
              SUM(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0))
@@ -129,18 +136,19 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
              b.cost_currency
       FROM "BillingEvent" b
       JOIN "Domain" d ON d.repo_id = b.domain_repo_id
+      JOIN "DomainHistory" dh ON dh.history_revision_id = b.domain_history_revision_id
+        AND dh.domain_repo_id = b.domain_repo_id
       LEFT JOIN LATERAL (
         SELECT rsp_retained_fee_amount
         FROM "RegistryDashboardCostBasis"
         WHERE (tld = d.tld OR tld = '*')
           AND operation = b.reason
-          AND effective_date <= b.event_time
+          AND effective_date <= dh.history_modification_time
         ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END,
                  effective_date DESC
         LIMIT 1
       ) cb ON true
-      WHERE b.event_time >= :startDate
-        AND b.event_time <= CURRENT_TIMESTAMP
+      WHERE dh.history_modification_time >= :startDate
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY period, d.tld, b.reason, b.cost_currency
       ORDER BY period, d.tld
@@ -148,8 +156,9 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
 
   private static final String REVENUE_15MIN_SCOPED =
       """
-      SELECT date_trunc('hour', b.event_time)
-               + floor(extract(minute from b.event_time) / 15) * interval '15 minutes' AS period,
+      SELECT date_trunc('hour', dh.history_modification_time)
+               + floor(extract(minute from dh.history_modification_time) / 15)
+                 * interval '15 minutes' AS period,
              d.tld, b.reason,
              SUM(b.cost_amount) AS total_amount,
              SUM(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0))
@@ -157,18 +166,19 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
              b.cost_currency
       FROM "BillingEvent" b
       JOIN "Domain" d ON d.repo_id = b.domain_repo_id
+      JOIN "DomainHistory" dh ON dh.history_revision_id = b.domain_history_revision_id
+        AND dh.domain_repo_id = b.domain_repo_id
       LEFT JOIN LATERAL (
         SELECT rsp_retained_fee_amount
         FROM "RegistryDashboardCostBasis"
         WHERE (tld = d.tld OR tld = '*')
           AND operation = b.reason
-          AND effective_date <= b.event_time
+          AND effective_date <= dh.history_modification_time
         ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END,
                  effective_date DESC
         LIMIT 1
       ) cb ON true
-      WHERE b.event_time >= :startDate
-        AND b.event_time <= CURRENT_TIMESTAMP
+      WHERE dh.history_modification_time >= :startDate
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY period, d.tld, b.reason, b.cost_currency

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
@@ -82,6 +82,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE b.event_time >= :startDate
+        AND b.event_time <= CURRENT_TIMESTAMP
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY date_trunc('%s', b.event_time), d.tld, b.reason, b.cost_currency
       ORDER BY period, d.tld
@@ -108,6 +109,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE b.event_time >= :startDate
+        AND b.event_time <= CURRENT_TIMESTAMP
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY date_trunc('%s', b.event_time), d.tld, b.reason, b.cost_currency
@@ -138,6 +140,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE b.event_time >= :startDate
+        AND b.event_time <= CURRENT_TIMESTAMP
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY period, d.tld, b.reason, b.cost_currency
       ORDER BY period, d.tld
@@ -165,6 +168,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE b.event_time >= :startDate
+        AND b.event_time <= CURRENT_TIMESTAMP
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY period, d.tld, b.reason, b.cost_currency

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingActionTest.java
@@ -94,6 +94,9 @@ class RegistryDashRevenueBillingActionTest {
 
   private Domain createDomainWithBilling(
       String label, String tld, Reason reason, String cost, DateTime eventTime) {
+    // Set clock to eventTime so the DomainHistory gets the correct modification timestamp.
+    // The revenue SQL now groups by DomainHistory.history_modification_time, not event_time.
+    clock.setTo(eventTime);
     Domain domain =
         persistDomainWithDependentResources(
             label, tld, clock.nowUtc(), clock.nowUtc(), clock.nowUtc().plusYears(2));

--- a/local-demo-billing-data.sql
+++ b/local-demo-billing-data.sql
@@ -21,7 +21,8 @@
 --
 -- What this populates:
 --   - BillingEvent            → Registry Revenue tab (Overview + Revenue & Billing)
---   - DomainTransactionRecord → Domain Activity tab
+--   - DomainTransactionRecord → ICANN reporting (no longer used by Domain Activity tab)
+--   Note: Domain Activity tab now queries DomainHistory directly (actual event time)
 --   - DomainHistory (renew/delete) → Forecasting renewal rates
 --   - Domain expiration spread → Forecasting expiration curve
 


### PR DESCRIPTION
## Summary

- **Domain Activity tab**: Switched from `DomainTransactionRecord.reporting_time` to `DomainHistory.history_modification_time`. The reporting_time includes grace period offsets (5-45 days depending on operation type) that push dates into the future, causing charts to show data in wrong months.
- **Revenue Billing tab**: Joined with `DomainHistory` to use `history_modification_time` for period grouping instead of `BillingEvent.event_time`. For most operations these are identical, but for transfers the event_time is set to the speculative auto-approval date (days/weeks in the future). All billing data is still included — nothing is hidden or filtered out.

### Root cause

Both dashboard tabs were using timestamps that include future-looking offsets:
- `DomainTransactionRecord.reporting_time` = event time + grace period (5-45 days)
- `BillingEvent.event_time` for transfers = speculative auto-approval date

These caused charts to show data in future months. The fix uses `DomainHistory.history_modification_time` which records when events actually occurred.

### What changed

| File | Change |
|------|--------|
| `RegistryDashDomainActivityAction.java` | Query `DomainHistory` (actual event time) instead of `DomainTransactionRecord` (ICANN reporting time) |
| `RegistryDashRevenueBillingAction.java` | Join with `DomainHistory` to use `history_modification_time` for period grouping instead of `BillingEvent.event_time` |
| `local-demo-billing-data.sql` | Updated comment |

## Test plan

- [ ] CI passes
- [ ] Verify on alpha-gke that Domain Activity, Forecasting, and Revenue tabs show dates in the past
- [ ] Verify transfer revenue appears at the request date, not the auto-approval date

🤖 Generated with [Claude Code](https://claude.com/claude-code)