### PR TITLE
fix: filter TLD dropdown by registry ownership in Custom Pricing

### DIFF
--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
@@ -15,7 +15,7 @@
 import { Component, OnInit, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { switchMap } from 'rxjs';
+import { EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../ud-echarts';
@@ -162,7 +162,9 @@ export class DomainActivityComponent implements OnInit {
       .pipe(
         switchMap(range => {
           const config = RANGE_CONFIG[range];
-          return this.dashService.getDomainActivity(config.lookbackHours, config.granularity);
+          return this.dashService.getDomainActivity(config.lookbackHours, config.granularity).pipe(
+            catchError(() => EMPTY) // Prevent subscription death on HTTP errors
+          );
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
@@ -21,6 +21,7 @@ import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { SnackBarModule } from '../../snackbar.module';
 import { PricingRule, RegistryDashService, SystemRegistrar } from '../registry-dash.service';
+import { UserDataService } from '../../shared/services/userData.service';
 
 @Component({
   selector: 'app-registry-dash-pricing',
@@ -76,10 +77,41 @@ export class PricingComponent implements AfterViewInit {
   editingRule = signal<PricingRule | undefined>(undefined);
   selectedRegistrarId = signal<string>('');
 
-  registrars = computed<SystemRegistrar[]>(
-    () => this.dashService.systemInfo()?.registrars || []
-  );
+  /** TLDs owned by the current user's registry (empty for admins = no filtering). */
+  private registryTlds = computed<Set<string>>(() => {
+    const admin = this.dashService.adminData();
+    const user = this.userDataService.userData();
+    if (!admin || !user) return new Set();
+    // Admins see everything
+    if (user.isAdmin) return new Set();
+    const email = user.userEmail?.toLowerCase();
+    if (!email) return new Set();
+    for (const reg of admin.registries) {
+      const isMember = reg.users?.some(
+        (u) => u.userEmail?.toLowerCase() === email
+      );
+      if (isMember) {
+        return new Set(reg.tlds?.map((t) => t.tld) ?? []);
+      }
+    }
+    return new Set();
+  });
 
+  /** Registrars filtered to those with at least one TLD in the user's registry. */
+  registrars = computed<SystemRegistrar[]>(() => {
+    const all = this.dashService.systemInfo()?.registrars || [];
+    const scope = this.registryTlds();
+    // Empty scope set means admin — show all
+    if (scope.size === 0) return all;
+    return all
+      .filter((r) => r.allowedTlds.some((tld) => scope.has(tld)))
+      .map((r) => ({
+        ...r,
+        allowedTlds: r.allowedTlds.filter((tld) => scope.has(tld)),
+      }));
+  });
+
+  /** TLDs available for the selected registrar, scoped to the user's registry. */
   availableTlds = computed<string[]>(() => {
     const regId = this.selectedRegistrarId();
     if (!regId) return [];
@@ -103,6 +135,7 @@ export class PricingComponent implements AfterViewInit {
 
   constructor(
     protected dashService: RegistryDashService,
+    private userDataService: UserDataService,
     private snackBar: MatSnackBar
   ) {
     this.dashService.getPricing().subscribe();


### PR DESCRIPTION
## Summary
- **Custom Pricing TLD filtering**: The "Add Rule" form's registrar and TLD dropdowns now only show registrars/TLDs that belong to the current user's registry. Previously, all system registrars and their full TLD lists were shown regardless of registry ownership. Admins (FTE) still see everything unfiltered.
- **Domain Activity time range resilience**: Added `catchError(EMPTY)` inside the reactive `switchMap` subscription so that a failed HTTP request doesn't kill the subscription and make subsequent time range changes unresponsive.

## How it works (TLD filtering)
1. Looks up the current user's email in the `adminData.registries` to find which registry they belong to
2. Extracts that registry's TLD list
3. Filters the registrar dropdown to only show registrars with at least one TLD in the user's registry
4. Trims each registrar's `allowedTlds` to only registry-scoped TLDs
5. The TLD dropdown for a selected registrar already uses `allowedTlds`, so it's automatically scoped

## Test plan
- [ ] Log in as a registry_operator user who owns only specific TLDs (e.g., .dialup and .modem)
- [ ] Navigate to Custom Pricing → Add Rule
- [ ] Verify the Registrar dropdown only shows registrars authorized for TLDs in your registry
- [ ] Verify the TLD dropdown for each registrar only shows TLDs your registry owns
- [ ] Log in as an admin (FTE) user and verify all registrars/TLDs are still visible
- [ ] Navigate to Domain Activity, switch between time ranges, verify data refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)