### PR TITLE
fix: pin DOCKER_API_VERSION=1.41 for Cloud Build deploy steps

### DIFF
--- a/release/ud-cloudbuild-nomulus-gke.yaml
+++ b/release/ud-cloudbuild-nomulus-gke.yaml
@@ -107,7 +107,9 @@ steps:
   name: '$_GCR_HOSTNAME/${PROJECT_ID}/nomulus/builder:latest'
   # Set home for Gradle caches. Must be consistent with last step below
   # and ./build_nomulus_for_env.sh
-  env: [ 'GRADLE_USER_HOME=/workspace/cloudbuild-caches' ]
+  env:
+    - 'GRADLE_USER_HOME=/workspace/cloudbuild-caches'
+    - 'DOCKER_API_VERSION=1.41'
   entrypoint: /bin/bash
   args:
   - -c
@@ -144,7 +146,9 @@ steps:
   name: '$_GCR_HOSTNAME/${PROJECT_ID}/nomulus/builder:latest'
   # Set home for Gradle caches. Must be consistent with last step below
   # and ./build_nomulus_for_env.sh
-  env: [ 'GRADLE_USER_HOME=/workspace/cloudbuild-caches' ]
+  env:
+    - 'GRADLE_USER_HOME=/workspace/cloudbuild-caches'
+    - 'DOCKER_API_VERSION=1.41'
   entrypoint: /bin/bash
   args:
   - -c
@@ -212,6 +216,8 @@ steps:
 # nomulus.jar built earlier.
 - id: Build-And-Push-Prober-Cert-Updater-Image
   name: '$_GCR_HOSTNAME/${PROJECT_ID}/nomulus/builder:latest'
+  env:
+    - 'DOCKER_API_VERSION=1.41'
   entrypoint: /bin/bash
   args:
   - -c


### PR DESCRIPTION
## Summary

- Pins `DOCKER_API_VERSION=1.41` on all Docker-using Cloud Build deploy steps (`Build-Deployment-Files`, `Build-Nomulus-Tool-Image-And-Push`, `Build-And-Push-Prober-Cert-Updater-Image`)
- The builder image was rebuilt on 2026-04-12 with Ubuntu 24.04's latest `docker.io` package, which ships a Docker client newer than Cloud Build's daemon supports (max API v1.41)
- Without this fix, the next deploy will fail with: `Error response from daemon: client version X.XX is too new. Maximum supported API version is 1.41`

## Test plan

- [ ] CI passes (no Docker usage in test pipeline, so this is a no-op for CI)
- [ ] Trigger alpha-gke deploy and confirm `Build-Nomulus-Tool-Image-And-Push` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)