### PR TITLE
fix(explore): add @Expose annotations for Gson deserialization

### DIFF
--- a/console-webapp/src/app/app-routing.module.ts
+++ b/console-webapp/src/app/app-routing.module.ts
@@ -211,6 +211,14 @@ export const routes: RouteWithIcon[] = [
             (mod) => mod.AdminComponent
           ),
       },
+      {
+        path: 'explore',
+        title: 'Data Exploration',
+        loadComponent: () =>
+          import('./registry-dash/explore/explore.component').then(
+            (mod) => mod.ExploreComponent
+          ),
+      },
     ],
   },
 ];

--- a/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
+++ b/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
@@ -1,0 +1,78 @@
+import { DataSourceSchema, DataSourceType } from './explore.models';
+
+export const DATA_SOURCE_SCHEMAS: Record<DataSourceType, DataSourceSchema> = {
+  DOMAIN_ACTIVITY: {
+    label: 'Domain Activity',
+    description: 'Registration activity: creates, renews, transfers, deletes, restores',
+    metrics: [{ field: 'count', label: 'Count' }],
+    dimensions: [
+      { field: 'tld', label: 'TLD' },
+      { field: 'activity_type', label: 'Activity Type' },
+      { field: 'period', label: 'Time Period' },
+      { field: 'registrar', label: 'Registrar' },
+    ],
+    filters: ['tlds', 'activityTypes', 'dateRange'],
+    supportsGranularity: true,
+  },
+  REVENUE: {
+    label: 'Revenue',
+    description: 'Billing revenue by TLD, operation, and time period',
+    metrics: [
+      { field: 'amount', label: 'Gross Amount' },
+      { field: 'netAmountToRegistry', label: 'Net to Registry' },
+    ],
+    dimensions: [
+      { field: 'tld', label: 'TLD' },
+      { field: 'operation', label: 'Operation' },
+      { field: 'period', label: 'Time Period' },
+    ],
+    filters: ['tlds', 'operations', 'dateRange'],
+    supportsGranularity: true,
+  },
+  DOMAIN_COUNTS: {
+    label: 'Domain Counts',
+    description: 'Current active domain counts by TLD and registrar',
+    metrics: [{ field: 'count', label: 'Count' }],
+    dimensions: [
+      { field: 'tld', label: 'TLD' },
+      { field: 'registrar', label: 'Registrar' },
+    ],
+    filters: ['tlds', 'registrarIds'],
+    supportsGranularity: false,
+  },
+  RENEWAL_RATES: {
+    label: 'Renewal Rates',
+    description: 'Renewal and deletion counts by TLD',
+    metrics: [
+      { field: 'renewals', label: 'Renewals' },
+      { field: 'deletions', label: 'Deletions' },
+      { field: 'renewalRate', label: 'Renewal Rate' },
+    ],
+    dimensions: [{ field: 'tld', label: 'TLD' }],
+    filters: ['tlds', 'dateRange'],
+    supportsGranularity: false,
+  },
+  EXPIRATION_CURVE: {
+    label: 'Expiration Curve',
+    description: 'Domain expiration distribution over time',
+    metrics: [{ field: 'count', label: 'Count' }],
+    dimensions: [
+      { field: 'tld', label: 'TLD' },
+      { field: 'month', label: 'Month' },
+    ],
+    filters: ['tlds', 'dateRange'],
+    supportsGranularity: false,
+  },
+  PRICING_RULES: {
+    label: 'Pricing Rules',
+    description: 'Active pricing rules by registrar, TLD, and operation',
+    metrics: [{ field: 'priceAmount', label: 'Price Amount' }],
+    dimensions: [
+      { field: 'registrar', label: 'Registrar' },
+      { field: 'tld', label: 'TLD' },
+      { field: 'operation', label: 'Operation' },
+    ],
+    filters: ['tlds', 'registrarIds', 'operations'],
+    supportsGranularity: false,
+  },
+};

--- a/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
+++ b/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { DataSourceSchema, DataSourceType } from './explore.models';
 
 export const DATA_SOURCE_SCHEMAS: Record<DataSourceType, DataSourceSchema> = {

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.html
@@ -1,0 +1,132 @@
+<div class="builder-panel">
+  <!-- Data Source -->
+  <div class="builder-section">
+    <h4>Data Source</h4>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Source</mat-label>
+      <mat-select [value]="query().dataSource"
+                  (selectionChange)="onDataSourceChange($event.value)">
+        <mat-option *ngFor="let key of dataSourceKeys" [value]="key">
+          {{ schemas[key].label }}
+        </mat-option>
+      </mat-select>
+      <mat-hint>{{ currentSchema().description }}</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <!-- Metrics -->
+  <div class="builder-section">
+    <h4>Metrics</h4>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select metrics</mat-label>
+      <mat-select multiple
+                  [value]="selectedMetricFields()"
+                  (selectionChange)="onMetricsChange($event.value)">
+        <mat-option *ngFor="let m of currentSchema().metrics" [value]="m.field">
+          {{ m.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <!-- Dimensions (Group By) -->
+  <div class="builder-section">
+    <h4>Group By</h4>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Dimensions</mat-label>
+      <mat-select multiple
+                  [value]="query().dimensions"
+                  (selectionChange)="onDimensionsChange($event.value)">
+        <mat-option *ngFor="let d of currentSchema().dimensions" [value]="d.field">
+          {{ d.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <!-- Granularity -->
+  <div class="builder-section" *ngIf="showGranularity()">
+    <h4>Granularity</h4>
+    <mat-button-toggle-group [value]="query().granularity || 'month'"
+                             (change)="onGranularityChange($event.value)">
+      <mat-button-toggle *ngFor="let g of granularityOptions" [value]="g.value">
+        {{ g.label }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <!-- Filters -->
+  <div class="builder-section">
+    <h4>Filters</h4>
+    <div class="filter-row">
+      <!-- TLD Filter -->
+      <mat-form-field appearance="outline" *ngIf="showTldFilter()">
+        <mat-label>TLDs</mat-label>
+        <mat-select multiple
+                    [value]="query().filters.tlds || []"
+                    (selectionChange)="onTldFilterChange($event.value)">
+          <mat-option *ngFor="let tld of availableTlds()" [value]="tld">
+            .{{ tld }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <!-- Registrar Filter -->
+      <mat-form-field appearance="outline" *ngIf="showRegistrarFilter()">
+        <mat-label>Registrars</mat-label>
+        <mat-select multiple
+                    [value]="query().filters.registrarIds || []"
+                    (selectionChange)="onRegistrarFilterChange($event.value)">
+          <mat-option *ngFor="let r of availableRegistrars()" [value]="r.registrarId">
+            {{ r.registrarName }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <!-- Date Range -->
+      <ng-container *ngIf="showDateRange()">
+        <mat-form-field appearance="outline">
+          <mat-label>Start Date</mat-label>
+          <input matInput type="date"
+                 [value]="query().filters.dateRange?.start || ''"
+                 (change)="onDateStartChange($any($event.target).value)">
+        </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>End Date</mat-label>
+          <input matInput type="date"
+                 [value]="query().filters.dateRange?.end || ''"
+                 (change)="onDateEndChange($any($event.target).value)">
+        </mat-form-field>
+      </ng-container>
+    </div>
+  </div>
+
+  <!-- Chart Type -->
+  <div class="builder-section">
+    <h4>Chart Type</h4>
+    <mat-button-toggle-group [value]="chartType()"
+                             (change)="onChartTypeChange($event.value)">
+      <mat-button-toggle *ngFor="let ct of chartTypes" [value]="ct.value"
+                         [matTooltip]="ct.label">
+        <mat-icon>{{ ct.icon }}</mat-icon>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <!-- Save / Load -->
+  <div class="builder-actions">
+    <button mat-stroked-button (click)="saveView()">
+      <mat-icon>save</mat-icon> Save View
+    </button>
+    <button mat-stroked-button [matMenuTriggerFor]="recentMenu"
+            [disabled]="recentViews().length === 0">
+      <mat-icon>history</mat-icon> Recent Views
+    </button>
+    <mat-menu #recentMenu="matMenu">
+      <button mat-menu-item *ngFor="let v of recentViews()" (click)="loadView(v)">
+        <span>{{ v.name }}</span>
+        <mat-icon class="delete-icon" (click)="deleteView(v, $event)">close</mat-icon>
+      </button>
+    </mat-menu>
+  </div>
+</div>

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.scss
@@ -1,0 +1,56 @@
+@use '../../ud-mixins' as ud;
+
+.builder-panel {
+  background: var(--ud-surface-muted);
+  border-radius: var(--ud-radius-md);
+  padding: 20px 24px;
+  margin-bottom: 24px;
+}
+
+.builder-section {
+  margin-bottom: 16px;
+
+  h4 {
+    margin: 0 0 8px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ud-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+.filter-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  mat-form-field {
+    flex: 1;
+    min-width: 180px;
+  }
+}
+
+.builder-actions {
+  display: flex;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--ud-border-subtle);
+}
+
+.delete-icon {
+  font-size: 16px;
+  height: 16px;
+  width: 16px;
+  margin-left: 8px;
+  color: var(--ud-text-secondary);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--ud-error);
+  }
+}

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Component, computed, inject, model, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
@@ -1,0 +1,168 @@
+import { Component, computed, inject, model, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MaterialModule } from '../../../material.module';
+import { RegistryDashService } from '../../registry-dash.service';
+import { DATA_SOURCE_SCHEMAS } from '../data-source-schemas';
+import {
+  ChartType,
+  DataSourceType,
+  ExploreQuery,
+  MetricSpec,
+  SavedExploreView,
+} from '../explore.models';
+import { ExploreService } from '../explore.service';
+
+const CHART_TYPES: { value: ChartType; icon: string; label: string }[] = [
+  { value: 'bar', icon: 'bar_chart', label: 'Bar' },
+  { value: 'line', icon: 'show_chart', label: 'Line' },
+  { value: 'pie', icon: 'pie_chart', label: 'Pie' },
+  { value: 'stacked-bar', icon: 'stacked_bar_chart', label: 'Stacked' },
+  { value: 'area', icon: 'area_chart', label: 'Area' },
+];
+
+const GRANULARITY_OPTIONS = [
+  { value: 'day', label: 'Daily' },
+  { value: 'week', label: 'Weekly' },
+  { value: 'month', label: 'Monthly' },
+];
+
+@Component({
+  selector: 'app-explore-builder',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MaterialModule],
+  templateUrl: './explore-builder.component.html',
+  styleUrls: ['./explore-builder.component.scss'],
+})
+export class ExploreBuilderComponent {
+  private dashService = inject(RegistryDashService);
+  private exploreService = inject(ExploreService);
+
+  query = model.required<ExploreQuery>();
+  chartType = model.required<ChartType>();
+
+  /** Emitted when user wants to run the query explicitly. */
+  run = output<void>();
+
+  readonly schemas = DATA_SOURCE_SCHEMAS;
+  readonly dataSourceKeys = Object.keys(DATA_SOURCE_SCHEMAS) as DataSourceType[];
+  readonly chartTypes = CHART_TYPES;
+  readonly granularityOptions = GRANULARITY_OPTIONS;
+
+  availableTlds = computed(() => this.dashService.availableTlds());
+  availableRegistrars = computed(() => this.dashService.availableRegistrars());
+
+  currentSchema = computed(() => this.schemas[this.query().dataSource]);
+
+  showGranularity = computed(() => {
+    const schema = this.currentSchema();
+    const dims = this.query().dimensions;
+    return schema.supportsGranularity && dims.includes('period');
+  });
+
+  recentViews = computed(() => this.exploreService.getRecentViews());
+
+  // --- Handlers ---
+
+  onDataSourceChange(ds: DataSourceType): void {
+    const schema = this.schemas[ds];
+    const defaultMetric = schema.metrics[0];
+    this.query.update(q => ({
+      ...q,
+      dataSource: ds,
+      metrics: [{ field: defaultMetric.field, aggregation: 'sum' }],
+      dimensions: schema.dimensions.length > 0 ? [schema.dimensions[0].field] : [],
+      granularity: schema.supportsGranularity ? 'month' : undefined,
+    }));
+  }
+
+  onMetricsChange(fields: string[]): void {
+    this.query.update(q => ({
+      ...q,
+      metrics: fields.map(f => ({ field: f, aggregation: 'sum' as const })),
+    }));
+  }
+
+  onDimensionsChange(fields: string[]): void {
+    this.query.update(q => ({
+      ...q,
+      dimensions: fields,
+    }));
+  }
+
+  onGranularityChange(value: string): void {
+    this.query.update(q => ({ ...q, granularity: value }));
+  }
+
+  onChartTypeChange(value: ChartType): void {
+    this.chartType.set(value);
+  }
+
+  onTldFilterChange(tlds: string[]): void {
+    this.query.update(q => ({
+      ...q,
+      filters: { ...q.filters, tlds: tlds.length > 0 ? tlds : undefined },
+    }));
+  }
+
+  onRegistrarFilterChange(ids: string[]): void {
+    this.query.update(q => ({
+      ...q,
+      filters: { ...q.filters, registrarIds: ids.length > 0 ? ids : undefined },
+    }));
+  }
+
+  onDateStartChange(value: string): void {
+    this.query.update(q => ({
+      ...q,
+      filters: {
+        ...q.filters,
+        dateRange: {
+          start: value,
+          end: q.filters.dateRange?.end ?? '',
+        },
+      },
+    }));
+  }
+
+  onDateEndChange(value: string): void {
+    this.query.update(q => ({
+      ...q,
+      filters: {
+        ...q.filters,
+        dateRange: {
+          start: q.filters.dateRange?.start ?? '',
+          end: value,
+        },
+      },
+    }));
+  }
+
+  // --- Save / Load ---
+
+  saveView(): void {
+    const name = prompt('Enter a name for this view:');
+    if (name) {
+      this.exploreService.saveRecentView(name, this.query(), this.chartType());
+    }
+  }
+
+  loadView(view: SavedExploreView): void {
+    this.query.set({ ...view.query });
+    this.chartType.set(view.chartType);
+  }
+
+  deleteView(view: SavedExploreView, event: Event): void {
+    event.stopPropagation();
+    this.exploreService.deleteRecentView(view.name);
+  }
+
+  /** Helper to get the metric fields from the current query. */
+  selectedMetricFields = computed(() => this.query().metrics.map(m => m.field));
+
+  /** Whether tld filter is relevant for this data source. */
+  showTldFilter = computed(() => this.currentSchema().filters.includes('tlds'));
+  showRegistrarFilter = computed(() =>
+    this.currentSchema().filters.includes('registrarIds'));
+  showDateRange = computed(() => this.currentSchema().filters.includes('dateRange'));
+}

--- a/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { ChartType, ExploreResult } from './explore.models';
 
 export function buildChartOptions(

--- a/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
@@ -1,0 +1,125 @@
+import { ChartType, ExploreResult } from './explore.models';
+
+export function buildChartOptions(
+  result: ExploreResult,
+  chartType: ChartType,
+  dimensions: string[],
+  metricColumn: string,
+): any {
+  if (!result || result.rows.length === 0) return null;
+
+  const primaryDim = dimensions[0];
+  const secondaryDim = dimensions.length > 1 ? dimensions[1] : null;
+
+  switch (chartType) {
+    case 'pie':
+      return buildPieOptions(result, primaryDim, metricColumn);
+    case 'line':
+      return buildLineOptions(result, primaryDim, secondaryDim, metricColumn);
+    case 'area':
+      return buildAreaOptions(result, primaryDim, secondaryDim, metricColumn);
+    case 'stacked-bar':
+      return buildStackedBarOptions(result, primaryDim, secondaryDim, metricColumn);
+    case 'bar':
+    default:
+      return buildBarOptions(result, primaryDim, secondaryDim, metricColumn);
+  }
+}
+
+function buildPieOptions(result: ExploreResult, dim: string, metric: string): any {
+  const data = result.rows.map(r => ({
+    name: String(r[dim] ?? 'Unknown'),
+    value: Number(r[metric] ?? 0),
+  }));
+  return {
+    tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+    legend: { type: 'scroll', bottom: 0 },
+    series: [{
+      type: 'pie',
+      radius: ['35%', '65%'],
+      data,
+      emphasis: { itemStyle: { shadowBlur: 10 } },
+    }],
+  };
+}
+
+function buildBarOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string | null, metric: string,
+): any {
+  if (secondaryDim) {
+    return buildGroupedBarOptions(result, primaryDim, secondaryDim, metric);
+  }
+  const categories = [...new Set(result.rows.map(r => String(r[primaryDim] ?? '')))];
+  const values = categories.map(cat => {
+    const row = result.rows.find(r => String(r[primaryDim]) === cat);
+    return Number(row?.[metric] ?? 0);
+  });
+  return {
+    tooltip: { trigger: 'axis' },
+    xAxis: { type: 'category', data: categories, axisLabel: { rotate: categories.length > 10 ? 45 : 0 } },
+    yAxis: { type: 'value' },
+    series: [{ type: 'bar', data: values }],
+    grid: { bottom: categories.length > 10 ? 80 : 40 },
+  };
+}
+
+function buildGroupedBarOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string, metric: string,
+): any {
+  const categories = [...new Set(result.rows.map(r => String(r[primaryDim] ?? '')))];
+  const groups = [...new Set(result.rows.map(r => String(r[secondaryDim] ?? '')))];
+  const series = groups.map(group => ({
+    name: group,
+    type: 'bar' as const,
+    data: categories.map(cat => {
+      const row = result.rows.find(
+        r => String(r[primaryDim]) === cat && String(r[secondaryDim]) === group);
+      return Number(row?.[metric] ?? 0);
+    }),
+  }));
+  return {
+    tooltip: { trigger: 'axis' },
+    legend: { type: 'scroll', bottom: 0 },
+    xAxis: { type: 'category', data: categories, axisLabel: { rotate: categories.length > 10 ? 45 : 0 } },
+    yAxis: { type: 'value' },
+    series,
+    grid: { bottom: 60 },
+  };
+}
+
+function buildLineOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string | null, metric: string,
+): any {
+  const opts = buildBarOptions(result, primaryDim, secondaryDim, metric);
+  for (const s of (opts.series || [])) {
+    s.type = 'line';
+    s.smooth = true;
+  }
+  return opts;
+}
+
+function buildAreaOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string | null, metric: string,
+): any {
+  const opts = buildLineOptions(result, primaryDim, secondaryDim, metric);
+  for (const s of (opts.series || [])) {
+    s.areaStyle = { opacity: 0.3 };
+  }
+  return opts;
+}
+
+function buildStackedBarOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string | null, metric: string,
+): any {
+  const opts = buildGroupedBarOptions(
+    result, primaryDim, secondaryDim ?? primaryDim, metric);
+  for (const s of (opts.series || [])) {
+    s.stack = 'total';
+  }
+  return opts;
+}

--- a/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.html
@@ -1,0 +1,7 @@
+<div class="chart-wrapper" *ngIf="hasData()">
+  <div echarts [options]="chartOptions()!" [theme]="'ud-brand'" class="chart"></div>
+</div>
+<div *ngIf="!hasData()" class="empty-chart">
+  <mat-icon>insert_chart_outlined</mat-icon>
+  <p>Configure your query to see results</p>
+</div>

--- a/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.scss
@@ -1,0 +1,16 @@
+@use '../../ud-mixins' as ud;
+
+.chart-wrapper {
+  background: var(--ud-surface-muted);
+  border-radius: var(--ud-radius-md);
+  padding: 20px 24px;
+}
+
+.chart {
+  height: 400px;
+  width: 100%;
+}
+
+.empty-chart {
+  @include ud.empty-state;
+}

--- a/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.ts
@@ -1,0 +1,33 @@
+import { Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MaterialModule } from '../../../material.module';
+import { NgxEchartsDirective } from 'ngx-echarts';
+import { UD_ECHARTS_PROVIDER } from '../../ud-echarts';
+import { ChartType, ExploreResult } from '../explore.models';
+import { buildChartOptions } from '../explore-chart-builder';
+
+@Component({
+  selector: 'app-explore-chart',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, NgxEchartsDirective],
+  providers: [UD_ECHARTS_PROVIDER],
+  templateUrl: './explore-chart.component.html',
+  styleUrls: ['./explore-chart.component.scss'],
+})
+export class ExploreChartComponent {
+  result = input.required<ExploreResult | undefined>();
+  chartType = input.required<ChartType>();
+  dimensions = input.required<string[]>();
+  metricColumn = input.required<string>();
+
+  chartOptions = computed(() => {
+    const r = this.result();
+    if (!r || r.rows.length === 0) return null;
+    return buildChartOptions(r, this.chartType(), this.dimensions(), this.metricColumn());
+  });
+
+  hasData = computed(() => {
+    const r = this.result();
+    return r != null && r.rows.length > 0;
+  });
+}

--- a/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart/explore-chart.component.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Component, computed, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '../../../material.module';

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -1,0 +1,54 @@
+<div class="explore-container">
+  <h2>Data Exploration</h2>
+  <p class="subtitle">Build custom queries across registry data sources, visualize results, and discover insights.</p>
+
+  <!-- Loading -->
+  <div *ngIf="loading()" class="loading">
+    <mat-spinner diameter="40"></mat-spinner>
+  </div>
+
+  <!-- Error -->
+  <div *ngIf="error()" class="error-banner">
+    {{ error() }}
+  </div>
+
+  <!-- Query Builder -->
+  <app-explore-builder [(query)]="query" [(chartType)]="chartType"></app-explore-builder>
+
+  <!-- Result Info -->
+  <div class="result-info" *ngIf="result()">
+    <span class="row-count">{{ result()!.totalRows | number }} rows</span>
+    <span class="truncated-badge" *ngIf="result()!.truncated">
+      Showing first {{ result()!.rows.length | number }} of {{ result()!.totalRows | number }}
+    </span>
+  </div>
+
+  <!-- Chart -->
+  <app-explore-chart
+    [result]="result()"
+    [chartType]="chartType()"
+    [dimensions]="query().dimensions"
+    [metricColumn]="metricColumn()">
+  </app-explore-chart>
+
+  <!-- Raw Data Table -->
+  <div class="data-table-wrapper" *ngIf="result() && result()!.rows.length > 0">
+    <h3>Raw Data</h3>
+    <div class="table-scroll">
+      <table mat-table [dataSource]="result()!.rows">
+        <ng-container *ngFor="let col of tableColumns()" [matColumnDef]="col">
+          <th mat-header-cell *matHeaderCellDef>{{ col }}</th>
+          <td mat-cell *matCellDef="let row">{{ row[col] }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="tableColumns()"></tr>
+        <tr mat-row *matRowDef="let row; columns: tableColumns();"></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- Empty State -->
+  <div *ngIf="!result() && !loading() && !error()" class="empty-state">
+    <mat-icon>explore</mat-icon>
+    <p>Configure a data source and metrics above to start exploring.</p>
+  </div>
+</div>

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -15,12 +15,15 @@
   <!-- Query Builder -->
   <app-explore-builder [(query)]="query" [(chartType)]="chartType"></app-explore-builder>
 
-  <!-- Run Query -->
-  <div class="run-query">
-    <button mat-flat-button color="primary" (click)="runQuery()" [disabled]="loading()">
+  <!-- Run Controls -->
+  <div class="run-controls">
+    <button mat-flat-button color="primary" (click)="runQuery()" [disabled]="loading()" *ngIf="!autoUpdate()">
       <mat-icon>play_arrow</mat-icon>
       {{ loading() ? 'Running...' : 'Run Query' }}
     </button>
+    <mat-slide-toggle [checked]="autoUpdate()" (change)="autoUpdate.set($event.checked)">
+      Auto-update
+    </mat-slide-toggle>
   </div>
 
   <!-- Result Info -->

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -15,6 +15,14 @@
   <!-- Query Builder -->
   <app-explore-builder [(query)]="query" [(chartType)]="chartType"></app-explore-builder>
 
+  <!-- Run Query -->
+  <div class="run-query">
+    <button mat-flat-button color="primary" (click)="runQuery()" [disabled]="loading()">
+      <mat-icon>play_arrow</mat-icon>
+      {{ loading() ? 'Running...' : 'Run Query' }}
+    </button>
+  </div>
+
   <!-- Result Info -->
   <div class="result-info" *ngIf="result()">
     <span class="row-count">{{ result()!.totalRows | number }} rows</span>

--- a/console-webapp/src/app/registry-dash/explore/explore.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.scss
@@ -30,6 +30,17 @@
   @include ud.empty-state;
 }
 
+.run-query {
+  margin-bottom: 20px;
+
+  button {
+    font-weight: 500;
+    mat-icon {
+      margin-right: 4px;
+    }
+  }
+}
+
 .result-info {
   display: flex;
   align-items: center;

--- a/console-webapp/src/app/registry-dash/explore/explore.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.scss
@@ -1,0 +1,87 @@
+@use '../ud-mixins' as ud;
+
+.explore-container {
+  padding: 24px;
+
+  h2 {
+    margin: 0 0 4px;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  .subtitle {
+    margin: 0 0 20px;
+    font-size: 13px;
+    color: var(--ud-text-secondary);
+  }
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 32px 0;
+}
+
+.error-banner {
+  @include ud.error-banner;
+}
+
+.empty-state {
+  @include ud.empty-state;
+}
+
+.result-info {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  color: var(--ud-text-secondary);
+
+  .row-count {
+    font-weight: 500;
+  }
+
+  .truncated-badge {
+    background: var(--ud-accent);
+    color: #fff;
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 100px;
+    font-weight: 500;
+  }
+}
+
+.data-table-wrapper {
+  margin-top: 24px;
+
+  h3 {
+    margin: 0 0 12px;
+    font-size: 15px;
+    font-weight: 500;
+  }
+}
+
+.table-scroll {
+  overflow-x: auto;
+  background: var(--ud-surface-muted);
+  border-radius: var(--ud-radius-md);
+
+  table {
+    width: 100%;
+  }
+
+  th.mat-mdc-header-cell {
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--ud-text-secondary);
+    white-space: nowrap;
+  }
+
+  td.mat-mdc-cell {
+    font-size: 13px;
+    white-space: nowrap;
+  }
+}

--- a/console-webapp/src/app/registry-dash/explore/explore.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.scss
@@ -30,15 +30,11 @@
   @include ud.empty-state;
 }
 
-.run-query {
+.run-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
   margin-bottom: 20px;
-
-  button {
-    font-weight: 500;
-    mat-icon {
-      margin-right: 4px;
-    }
-  }
 }
 
 .result-info {

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -1,0 +1,71 @@
+import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { catchError, debounceTime, EMPTY, switchMap } from 'rxjs';
+import { MaterialModule } from '../../material.module';
+import { RegistryDashService } from '../registry-dash.service';
+import { ExploreService } from './explore.service';
+import { ExploreBuilderComponent } from './explore-builder/explore-builder.component';
+import { ExploreChartComponent } from './explore-chart/explore-chart.component';
+import { ChartType, DEFAULT_QUERY, ExploreQuery } from './explore.models';
+
+@Component({
+  selector: 'app-explore',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, ExploreBuilderComponent, ExploreChartComponent],
+  templateUrl: './explore.component.html',
+  styleUrls: ['./explore.component.scss'],
+})
+export class ExploreComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+  private dashService = inject(RegistryDashService);
+  exploreService = inject(ExploreService);
+
+  query = signal<ExploreQuery>({ ...DEFAULT_QUERY, filters: { ...DEFAULT_QUERY.filters } });
+  chartType = signal<ChartType>('bar');
+
+  result = computed(() => this.exploreService.result());
+  loading = computed(() => this.exploreService.loading());
+  error = computed(() => this.exploreService.error());
+
+  /** First metric field — used as the value column for chart rendering. */
+  metricColumn = computed(() => {
+    const metrics = this.query().metrics;
+    return metrics.length > 0 ? metrics[0].field : 'count';
+  });
+
+  /** Dynamic table columns — dimensions + metric fields. */
+  tableColumns = computed(() => {
+    const r = this.result();
+    return r ? r.columns : [];
+  });
+
+  constructor() {
+    // Reactive fetch: debounce query changes, then call explore API
+    toObservable(this.query)
+      .pipe(
+        debounceTime(500),
+        switchMap(q =>
+          this.exploreService.explore(q).pipe(catchError(() => EMPTY))
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  ngOnInit(): void {
+    // Seed query filters from global filter bar if active
+    if (this.dashService.hasActiveFilters()) {
+      const tlds = this.dashService.selectedTlds();
+      const regIds = this.dashService.selectedRegistrarIds();
+      this.query.update(q => ({
+        ...q,
+        filters: {
+          ...q.filters,
+          tlds: tlds.length > 0 ? [...tlds] : undefined,
+          registrarIds: regIds.length > 0 ? [...regIds] : undefined,
+        },
+      }));
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Component, computed, DestroyRef, effect, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -1,5 +1,7 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
+import { catchError, debounceTime, EMPTY, filter, switchMap } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { RegistryDashService } from '../registry-dash.service';
 import { ExploreService } from './explore.service';
@@ -15,11 +17,13 @@ import { ChartType, DEFAULT_QUERY, ExploreQuery } from './explore.models';
   styleUrls: ['./explore.component.scss'],
 })
 export class ExploreComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
   private dashService = inject(RegistryDashService);
   exploreService = inject(ExploreService);
 
   query = signal<ExploreQuery>({ ...DEFAULT_QUERY, filters: { ...DEFAULT_QUERY.filters } });
   chartType = signal<ChartType>('bar');
+  autoUpdate = signal(false);
 
   result = computed(() => this.exploreService.result());
   loading = computed(() => this.exploreService.loading());
@@ -34,6 +38,17 @@ export class ExploreComponent implements OnInit {
     const r = this.result();
     return r ? r.columns : [];
   });
+
+  constructor() {
+    toObservable(this.query).pipe(
+      debounceTime(500),
+      filter(() => this.autoUpdate()),
+      switchMap(q =>
+        this.exploreService.explore(q).pipe(catchError(() => EMPTY))
+      ),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe();
+  }
 
   ngOnInit(): void {
     if (this.dashService.hasActiveFilters()) {

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -1,7 +1,5 @@
-import { Component, computed, DestroyRef, inject, OnInit, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { catchError, debounceTime, EMPTY, switchMap } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { RegistryDashService } from '../registry-dash.service';
 import { ExploreService } from './explore.service';
@@ -17,7 +15,6 @@ import { ChartType, DEFAULT_QUERY, ExploreQuery } from './explore.models';
   styleUrls: ['./explore.component.scss'],
 })
 export class ExploreComponent implements OnInit {
-  private destroyRef = inject(DestroyRef);
   private dashService = inject(RegistryDashService);
   exploreService = inject(ExploreService);
 
@@ -28,33 +25,17 @@ export class ExploreComponent implements OnInit {
   loading = computed(() => this.exploreService.loading());
   error = computed(() => this.exploreService.error());
 
-  /** First metric field — used as the value column for chart rendering. */
   metricColumn = computed(() => {
     const metrics = this.query().metrics;
     return metrics.length > 0 ? metrics[0].field : 'count';
   });
 
-  /** Dynamic table columns — dimensions + metric fields. */
   tableColumns = computed(() => {
     const r = this.result();
     return r ? r.columns : [];
   });
 
-  constructor() {
-    // Reactive fetch: debounce query changes, then call explore API
-    toObservable(this.query)
-      .pipe(
-        debounceTime(500),
-        switchMap(q =>
-          this.exploreService.explore(q).pipe(catchError(() => EMPTY))
-        ),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
-  }
-
   ngOnInit(): void {
-    // Seed query filters from global filter bar if active
     if (this.dashService.hasActiveFilters()) {
       const tlds = this.dashService.selectedTlds();
       const regIds = this.dashService.selectedRegistrarIds();
@@ -67,5 +48,9 @@ export class ExploreComponent implements OnInit {
         },
       }));
     }
+  }
+
+  runQuery(): void {
+    this.exploreService.explore(this.query()).subscribe();
   }
 }

--- a/console-webapp/src/app/registry-dash/explore/explore.models.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.models.ts
@@ -1,0 +1,66 @@
+export type DataSourceType =
+  | 'DOMAIN_ACTIVITY'
+  | 'REVENUE'
+  | 'DOMAIN_COUNTS'
+  | 'RENEWAL_RATES'
+  | 'EXPIRATION_CURVE'
+  | 'PRICING_RULES';
+
+export type ChartType = 'bar' | 'line' | 'pie' | 'stacked-bar' | 'area';
+
+export interface MetricSpec {
+  field: string;
+  aggregation: 'sum' | 'count' | 'avg';
+}
+
+export interface DateRange {
+  start: string;
+  end: string;
+}
+
+export interface ExploreFilters {
+  tlds?: string[];
+  registrarIds?: string[];
+  activityTypes?: string[];
+  operations?: string[];
+  dateRange?: DateRange;
+}
+
+export interface ExploreQuery {
+  dataSource: DataSourceType;
+  metrics: MetricSpec[];
+  dimensions: string[];
+  filters: ExploreFilters;
+  granularity?: string;
+  limit?: number;
+}
+
+export interface ExploreResult {
+  columns: string[];
+  rows: Record<string, any>[];
+  truncated: boolean;
+  totalRows: number;
+}
+
+export interface SavedExploreView {
+  name: string;
+  query: ExploreQuery;
+  chartType: ChartType;
+  savedAt: string;
+}
+
+export interface DataSourceSchema {
+  label: string;
+  description: string;
+  metrics: { field: string; label: string }[];
+  dimensions: { field: string; label: string }[];
+  filters: string[];
+  supportsGranularity: boolean;
+}
+
+export const DEFAULT_QUERY: ExploreQuery = {
+  dataSource: 'DOMAIN_ACTIVITY',
+  metrics: [{ field: 'count', aggregation: 'sum' }],
+  dimensions: ['tld'],
+  filters: {},
+};

--- a/console-webapp/src/app/registry-dash/explore/explore.models.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.models.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 export type DataSourceType =
   | 'DOMAIN_ACTIVITY'
   | 'REVENUE'

--- a/console-webapp/src/app/registry-dash/explore/explore.service.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.service.ts
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { Injectable, signal } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';

--- a/console-webapp/src/app/registry-dash/explore/explore.service.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, signal } from '@angular/core';
+import { Observable, throwError } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { BackendService } from '../../shared/services/backend.service';
+import { ExploreQuery, ExploreResult, SavedExploreView } from './explore.models';
+
+const RECENT_VIEWS_KEY = 'registry-dash-explore-recent';
+const MAX_RECENT_VIEWS = 5;
+
+@Injectable({ providedIn: 'root' })
+export class ExploreService {
+  result = signal<ExploreResult | undefined>(undefined);
+  loading = signal(false);
+  error = signal<string | undefined>(undefined);
+
+  constructor(private backend: BackendService) {}
+
+  explore(query: ExploreQuery): Observable<ExploreResult> {
+    this.loading.set(true);
+    this.error.set(undefined);
+    return this.backend.postRegistryDashExplore(query).pipe(
+      tap((data: ExploreResult) => {
+        this.result.set(data);
+        this.loading.set(false);
+      }),
+      catchError((err: HttpErrorResponse) => {
+        const msg = typeof err.error === 'string' ? err.error
+          : err.error?.message ?? `Error ${err.status}`;
+        this.error.set(msg);
+        this.loading.set(false);
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  getRecentViews(): SavedExploreView[] {
+    try {
+      const raw = localStorage.getItem(RECENT_VIEWS_KEY);
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  saveRecentView(name: string, query: ExploreQuery, chartType: string): void {
+    const views = this.getRecentViews();
+    const newView: SavedExploreView = {
+      name,
+      query,
+      chartType: chartType as any,
+      savedAt: new Date().toISOString(),
+    };
+    const updated = [newView, ...views.filter(v => v.name !== name)].slice(0, MAX_RECENT_VIEWS);
+    localStorage.setItem(RECENT_VIEWS_KEY, JSON.stringify(updated));
+  }
+
+  deleteRecentView(name: string): void {
+    const views = this.getRecentViews().filter(v => v.name !== name);
+    localStorage.setItem(RECENT_VIEWS_KEY, JSON.stringify(views));
+  }
+}

--- a/console-webapp/src/app/shared/services/backend.service.ts
+++ b/console-webapp/src/app/shared/services/backend.service.ts
@@ -491,4 +491,10 @@ export class BackendService {
       .get<EffectiveFeeEntry[]>('/console-api/registry-dash/effective-fees')
       .pipe(catchError((err) => this.errorCatcher<EffectiveFeeEntry[]>(err)));
   }
+
+  postRegistryDashExplore(query: any): Observable<any> {
+    return this.http
+      .post<any>('/console-api/registry-dash/explore', query)
+      .pipe(catchError((err) => this.errorCatcher<any>(err)));
+  }
 }

--- a/core/src/main/java/google/registry/model/console/ConsolePermission.java
+++ b/core/src/main/java/google/registry/model/console/ConsolePermission.java
@@ -89,5 +89,7 @@ public enum ConsolePermission {
   /** View domain activity analytics in the registry dashboard. */
   VIEW_DOMAIN_ACTIVITY,
   /** View domain forecasting data in the registry dashboard. */
-  VIEW_FORECASTING
+  VIEW_FORECASTING,
+  /** Explore raw registry data via the data exploration endpoint. */
+  VIEW_DATA_EXPLORE
 }

--- a/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
+++ b/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
@@ -78,7 +78,8 @@ public class ConsoleRoleDefinitions {
           ConsolePermission.MANAGE_COST_BASIS,
           ConsolePermission.VIEW_REVENUE_BILLING,
           ConsolePermission.VIEW_DOMAIN_ACTIVITY,
-          ConsolePermission.VIEW_FORECASTING);
+          ConsolePermission.VIEW_FORECASTING,
+          ConsolePermission.VIEW_DATA_EXPLORE);
 
   /** Permissions for a registry full-time employee. */
   static final ImmutableSet<ConsolePermission> FTE_PERMISSIONS =

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -131,6 +131,7 @@ import google.registry.ui.server.console.PasswordResetVerifyAction;
 import google.registry.ui.server.console.RegistrarsAction;
 import google.registry.ui.server.console.domains.ConsoleBulkDomainAction;
 import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
+import google.registry.ui.server.console.registrydash.RegistryDashExploreAction;
 import google.registry.ui.server.console.registrydash.RegistryDashCostBasisAction;
 import google.registry.ui.server.console.registrydash.RegistryDashDomainActivityAction;
 import google.registry.ui.server.console.registrydash.RegistryDashFilterOptionsAction;
@@ -337,6 +338,8 @@ interface RequestComponent {
   RegistryDashRevenueBillingAction registryDashRevenueBillingAction();
 
   RegistryDashDomainActivityAction registryDashDomainActivityAction();
+
+  RegistryDashExploreAction registryDashExploreAction();
 
   RegistryDashFilterOptionsAction registryDashFilterOptionsAction();
 

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
@@ -40,6 +40,7 @@ import google.registry.ui.server.SendEmailUtils;
 import google.registry.ui.server.console.ConsoleEppPasswordAction.EppPasswordData;
 import google.registry.ui.server.console.ConsoleOteAction.OteCreateData;
 import google.registry.ui.server.console.ConsoleRegistryLockAction.ConsoleRegistryLockPostInput;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
 import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
 import google.registry.ui.server.console.ConsoleUsersAction.UserData;
 import google.registry.ui.server.console.PasswordResetRequestAction.PasswordResetRequestData;
@@ -426,6 +427,13 @@ public final class ConsoleModule {
               obj.has("id") ? obj.get("id").getAsLong() : null,
               obj.has("settings") ? obj.get("settings").getAsString() : null);
         });
+  }
+
+  @Provides
+  @Parameter("registryDashExplore")
+  public static Optional<ExploreQueryDescriptor> provideExploreQuery(
+      Gson gson, @OptionalJsonPayload Optional<JsonElement> payload) {
+    return payload.map(e -> gson.fromJson(e, ExploreQueryDescriptor.class));
   }
 
   @Provides

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
@@ -1,11 +1,25 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package google.registry.ui.server.console.registrydash;
 
 import com.google.common.collect.ImmutableSet;
 
 /**
- * Enum defining valid data sources for the explore endpoint. Each source declares its
- * allowed metrics, dimensions, and filters. The query builder uses these to validate
- * requests and reject unknown fields with 400 (not 500).
+ * Enum defining valid data sources for the explore endpoint. Each source declares its allowed
+ * metrics, dimensions, and filters. The query builder uses these to validate requests and reject
+ * unknown fields with 400 (not 500).
  */
 public enum ExploreDataSource {
 
@@ -52,40 +66,58 @@ public enum ExploreDataSource {
     this.allowedFilters = allowedFilters;
   }
 
-  public ImmutableSet<String> getAllowedMetrics() { return allowedMetrics; }
-  public ImmutableSet<String> getAllowedDimensions() { return allowedDimensions; }
+  public ImmutableSet<String> getAllowedMetrics() {
+    return allowedMetrics;
+  }
 
-  /** Validates the descriptor against this source's allowlist. Throws IllegalArgumentException on unknown fields. */
+  public ImmutableSet<String> getAllowedDimensions() {
+    return allowedDimensions;
+  }
+
+  /**
+   * Validates the descriptor against this source's allowlist. Throws IllegalArgumentException on
+   * unknown fields.
+   */
   public void validate(ExploreQueryDescriptor desc) {
     for (ExploreQueryDescriptor.MetricSpec m : desc.getMetrics()) {
       if (!allowedMetrics.contains(m.getField())) {
         throw new IllegalArgumentException(
-            String.format("Unknown metric '%s' for data source %s. Allowed: %s",
+            String.format(
+                "Unknown metric '%s' for data source %s. Allowed: %s",
                 m.getField(), name(), allowedMetrics));
       }
     }
     for (String dim : desc.getDimensions()) {
       if (!allowedDimensions.contains(dim)) {
         throw new IllegalArgumentException(
-            String.format("Unknown dimension '%s' for data source %s. Allowed: %s",
+            String.format(
+                "Unknown dimension '%s' for data source %s. Allowed: %s",
                 dim, name(), allowedDimensions));
       }
     }
     ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
     if (!f.getTlds().isEmpty() && !allowedFilters.contains("tlds")) {
-      throw new IllegalArgumentException("Filter 'tlds' not supported for " + name());
+      throw new IllegalArgumentException(
+          "Filter 'tlds' not supported for " + name());
     }
-    if (!f.getRegistrarIds().isEmpty() && !allowedFilters.contains("registrarIds")) {
-      throw new IllegalArgumentException("Filter 'registrarIds' not supported for " + name());
+    if (!f.getRegistrarIds().isEmpty()
+        && !allowedFilters.contains("registrarIds")) {
+      throw new IllegalArgumentException(
+          "Filter 'registrarIds' not supported for " + name());
     }
-    if (!f.getActivityTypes().isEmpty() && !allowedFilters.contains("activityTypes")) {
-      throw new IllegalArgumentException("Filter 'activityTypes' not supported for " + name());
+    if (!f.getActivityTypes().isEmpty()
+        && !allowedFilters.contains("activityTypes")) {
+      throw new IllegalArgumentException(
+          "Filter 'activityTypes' not supported for " + name());
     }
-    if (!f.getOperations().isEmpty() && !allowedFilters.contains("operations")) {
-      throw new IllegalArgumentException("Filter 'operations' not supported for " + name());
+    if (!f.getOperations().isEmpty()
+        && !allowedFilters.contains("operations")) {
+      throw new IllegalArgumentException(
+          "Filter 'operations' not supported for " + name());
     }
     if (f.getDateRange() != null && !allowedFilters.contains("dateRange")) {
-      throw new IllegalArgumentException("Filter 'dateRange' not supported for " + name());
+      throw new IllegalArgumentException(
+          "Filter 'dateRange' not supported for " + name());
     }
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
@@ -1,0 +1,91 @@
+package google.registry.ui.server.console.registrydash;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Enum defining valid data sources for the explore endpoint. Each source declares its
+ * allowed metrics, dimensions, and filters. The query builder uses these to validate
+ * requests and reject unknown fields with 400 (not 500).
+ */
+public enum ExploreDataSource {
+
+  DOMAIN_ACTIVITY(
+      ImmutableSet.of("count"),
+      ImmutableSet.of("tld", "activity_type", "period", "registrar"),
+      ImmutableSet.of("tlds", "activityTypes", "dateRange")),
+
+  REVENUE(
+      ImmutableSet.of("amount", "netAmountToRegistry"),
+      ImmutableSet.of("tld", "operation", "period"),
+      ImmutableSet.of("tlds", "operations", "dateRange")),
+
+  DOMAIN_COUNTS(
+      ImmutableSet.of("count"),
+      ImmutableSet.of("tld", "registrar"),
+      ImmutableSet.of("tlds", "registrarIds")),
+
+  RENEWAL_RATES(
+      ImmutableSet.of("renewals", "deletions", "renewalRate"),
+      ImmutableSet.of("tld"),
+      ImmutableSet.of("tlds", "dateRange")),
+
+  EXPIRATION_CURVE(
+      ImmutableSet.of("count"),
+      ImmutableSet.of("tld", "month"),
+      ImmutableSet.of("tlds", "dateRange")),
+
+  PRICING_RULES(
+      ImmutableSet.of("priceAmount"),
+      ImmutableSet.of("registrar", "tld", "operation"),
+      ImmutableSet.of("tlds", "registrarIds", "operations"));
+
+  private final ImmutableSet<String> allowedMetrics;
+  private final ImmutableSet<String> allowedDimensions;
+  private final ImmutableSet<String> allowedFilters;
+
+  ExploreDataSource(
+      ImmutableSet<String> allowedMetrics,
+      ImmutableSet<String> allowedDimensions,
+      ImmutableSet<String> allowedFilters) {
+    this.allowedMetrics = allowedMetrics;
+    this.allowedDimensions = allowedDimensions;
+    this.allowedFilters = allowedFilters;
+  }
+
+  public ImmutableSet<String> getAllowedMetrics() { return allowedMetrics; }
+  public ImmutableSet<String> getAllowedDimensions() { return allowedDimensions; }
+
+  /** Validates the descriptor against this source's allowlist. Throws IllegalArgumentException on unknown fields. */
+  public void validate(ExploreQueryDescriptor desc) {
+    for (ExploreQueryDescriptor.MetricSpec m : desc.getMetrics()) {
+      if (!allowedMetrics.contains(m.getField())) {
+        throw new IllegalArgumentException(
+            String.format("Unknown metric '%s' for data source %s. Allowed: %s",
+                m.getField(), name(), allowedMetrics));
+      }
+    }
+    for (String dim : desc.getDimensions()) {
+      if (!allowedDimensions.contains(dim)) {
+        throw new IllegalArgumentException(
+            String.format("Unknown dimension '%s' for data source %s. Allowed: %s",
+                dim, name(), allowedDimensions));
+      }
+    }
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+    if (!f.getTlds().isEmpty() && !allowedFilters.contains("tlds")) {
+      throw new IllegalArgumentException("Filter 'tlds' not supported for " + name());
+    }
+    if (!f.getRegistrarIds().isEmpty() && !allowedFilters.contains("registrarIds")) {
+      throw new IllegalArgumentException("Filter 'registrarIds' not supported for " + name());
+    }
+    if (!f.getActivityTypes().isEmpty() && !allowedFilters.contains("activityTypes")) {
+      throw new IllegalArgumentException("Filter 'activityTypes' not supported for " + name());
+    }
+    if (!f.getOperations().isEmpty() && !allowedFilters.contains("operations")) {
+      throw new IllegalArgumentException("Filter 'operations' not supported for " + name());
+    }
+    if (f.getDateRange() != null && !allowedFilters.contains("dateRange")) {
+      throw new IllegalArgumentException("Filter 'dateRange' not supported for " + name());
+    }
+  }
+}

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
@@ -1,0 +1,324 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class ExploreQueryBuilder {
+
+  private static final ImmutableSet<String> VALID_GRANULARITIES =
+      ImmutableSet.of("hour", "day", "month");
+
+  private ExploreQueryBuilder() {}
+
+  public static String build(
+      ExploreDataSource source,
+      ExploreQueryDescriptor desc,
+      ImmutableSet<String> effectiveTlds) {
+    return switch (source) {
+      case DOMAIN_ACTIVITY -> buildDomainActivity(desc, effectiveTlds);
+      case REVENUE -> buildRevenue(desc, effectiveTlds);
+      case DOMAIN_COUNTS -> buildDomainCounts(desc, effectiveTlds);
+      case RENEWAL_RATES -> buildRenewalRates(desc, effectiveTlds);
+      case EXPIRATION_CURVE -> buildExpirationCurve(desc, effectiveTlds);
+      case PRICING_RULES -> buildPricingRules(desc, effectiveTlds);
+    };
+  }
+
+  private static String buildDomainActivity(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    String gran = resolveGranularity(desc.getGranularity());
+    Set<String> dims = Set.copyOf(desc.getDimensions());
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    List<String> groupByCols = new ArrayList<>();
+
+    if (dims.contains("period")) {
+      selectCols.add(
+          String.format("date_trunc('%s', dh.history_modification_time) AS period", gran));
+      groupByCols.add("period");
+    }
+    if (dims.contains("tld")) {
+      selectCols.add("d.tld");
+      groupByCols.add("d.tld");
+    }
+    if (dims.contains("activity_type")) {
+      selectCols.add(
+          "CASE"
+              + " WHEN dh.history_type = 'DOMAIN_CREATE' THEN 'CREATES'"
+              + " WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 'RENEWS'"
+              + " WHEN dh.history_type = 'DOMAIN_TRANSFER_APPROVE' THEN 'TRANSFERS'"
+              + " WHEN dh.history_type = 'DOMAIN_DELETE' THEN 'DELETES'"
+              + " WHEN dh.history_type = 'DOMAIN_RESTORE' THEN 'RESTORES'"
+              + " ELSE 'OTHER'"
+              + " END AS activity_type");
+      groupByCols.add("activity_type");
+    }
+    if (dims.contains("registrar")) {
+      selectCols.add("d.current_sponsor_registrar_id AS registrar");
+      groupByCols.add("d.current_sponsor_registrar_id");
+    }
+    selectCols.add("COUNT(*) AS count_value");
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add(
+        "dh.history_type IN ('DOMAIN_CREATE', 'DOMAIN_RENEW', 'DOMAIN_AUTORENEW',"
+            + " 'DOMAIN_TRANSFER_APPROVE', 'DOMAIN_DELETE', 'DOMAIN_RESTORE')");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (f.getDateRange() != null) {
+      whereClauses.add("dh.history_modification_time >= :startDate");
+      whereClauses.add("dh.history_modification_time <= :endDate");
+    }
+    if (!f.getActivityTypes().isEmpty()) {
+      whereClauses.add("dh.history_type IN (:activityTypes)");
+    }
+    return assembleQuery(
+        selectCols,
+        "\"DomainHistory\" dh JOIN \"Domain\" d ON d.repo_id = dh.domain_repo_id",
+        whereClauses,
+        groupByCols,
+        dims.contains("period") ? "period" : null);
+  }
+
+  private static String buildRevenue(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    String gran = resolveGranularity(desc.getGranularity());
+    Set<String> dims = Set.copyOf(desc.getDimensions());
+    Set<String> metricFields = new HashSet<>();
+    for (ExploreQueryDescriptor.MetricSpec m : desc.getMetrics()) {
+      metricFields.add(m.getField());
+    }
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    List<String> groupByCols = new ArrayList<>();
+
+    if (dims.contains("period")) {
+      selectCols.add(
+          String.format(
+              "date_trunc('%s', dh.history_modification_time) AS period", gran));
+      groupByCols.add("period");
+    }
+    if (dims.contains("tld")) {
+      selectCols.add("d.tld");
+      groupByCols.add("d.tld");
+    }
+    if (dims.contains("operation")) {
+      selectCols.add("b.reason AS operation");
+      groupByCols.add("b.reason");
+    }
+    if (metricFields.contains("amount")) {
+      selectCols.add("SUM(b.cost_amount) AS amount");
+    }
+    if (metricFields.contains("netAmountToRegistry")) {
+      selectCols.add(
+          "SUM(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0))"
+              + " AS net_amount_to_registry");
+    }
+    selectCols.add("b.cost_currency");
+    groupByCols.add("b.cost_currency");
+
+    String fromClause =
+        "\"BillingEvent\" b"
+            + " JOIN \"Domain\" d ON d.repo_id = b.domain_repo_id"
+            + " JOIN \"DomainHistory\" dh ON dh.history_revision_id ="
+            + " b.domain_history_revision_id"
+            + " AND dh.domain_repo_id = b.domain_repo_id"
+            + " LEFT JOIN LATERAL ("
+            + " SELECT rsp_retained_fee_amount"
+            + " FROM \"RegistryDashboardCostBasis\""
+            + " WHERE (tld = d.tld OR tld = '*')"
+            + " AND operation = b.reason"
+            + " AND effective_date <= dh.history_modification_time"
+            + " ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END, effective_date DESC"
+            + " LIMIT 1"
+            + ") cb ON true";
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add("b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (f.getDateRange() != null) {
+      whereClauses.add("dh.history_modification_time >= :startDate");
+      whereClauses.add("dh.history_modification_time <= :endDate");
+    }
+    if (!f.getOperations().isEmpty()) {
+      whereClauses.add("b.reason IN (:operations)");
+    }
+    return assembleQuery(
+        selectCols,
+        fromClause,
+        whereClauses,
+        groupByCols,
+        dims.contains("period") ? "period" : null);
+  }
+
+  private static String buildDomainCounts(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    Set<String> dims = Set.copyOf(desc.getDimensions());
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    List<String> groupByCols = new ArrayList<>();
+
+    if (dims.contains("tld")) {
+      selectCols.add("d.tld");
+      groupByCols.add("d.tld");
+    }
+    if (dims.contains("registrar")) {
+      selectCols.add("d.current_sponsor_registrar_id AS registrar");
+      groupByCols.add("d.current_sponsor_registrar_id");
+    }
+    selectCols.add("COUNT(*) AS count_value");
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add("d.deletion_time > CURRENT_TIMESTAMP");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (!f.getRegistrarIds().isEmpty()) {
+      whereClauses.add("d.current_sponsor_registrar_id IN (:registrarIds)");
+    }
+    return assembleQuery(selectCols, "\"Domain\" d", whereClauses, groupByCols, null);
+  }
+
+  private static String buildRenewalRates(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    selectCols.add("d.tld");
+    selectCols.add(
+        "COUNT(CASE WHEN dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW') THEN 1 END)"
+            + " AS renewals");
+    selectCols.add(
+        "COUNT(CASE WHEN dh.history_type = 'DOMAIN_DELETE' THEN 1 END) AS deletions");
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add(
+        "dh.history_type IN ('DOMAIN_RENEW', 'DOMAIN_AUTORENEW', 'DOMAIN_DELETE')");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (f.getDateRange() != null) {
+      whereClauses.add("dh.history_modification_time >= :startDate");
+      whereClauses.add("dh.history_modification_time <= :endDate");
+    }
+    return assembleQuery(
+        selectCols,
+        "\"DomainHistory\" dh JOIN \"Domain\" d ON d.repo_id = dh.domain_repo_id",
+        whereClauses,
+        List.of("d.tld"),
+        null);
+  }
+
+  private static String buildExpirationCurve(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    selectCols.add("date_trunc('month', d.registration_expiration_time) AS month");
+    selectCols.add("d.tld");
+    selectCols.add("COUNT(*) AS count_value");
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add("d.deletion_time > CURRENT_TIMESTAMP");
+    whereClauses.add("d.registration_expiration_time > CURRENT_TIMESTAMP");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (f.getDateRange() != null && f.getDateRange().getEnd() != null) {
+      whereClauses.add("d.registration_expiration_time < :endDate");
+    }
+    return assembleQuery(
+        selectCols, "\"Domain\" d", whereClauses, List.of("month", "d.tld"), "month");
+  }
+
+  private static String buildPricingRules(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    Set<String> dims = Set.copyOf(desc.getDimensions());
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    List<String> groupByCols = new ArrayList<>();
+
+    if (dims.contains("registrar")) {
+      selectCols.add("p.registrar_id AS registrar");
+      groupByCols.add("p.registrar_id");
+    }
+    if (dims.contains("tld")) {
+      selectCols.add("p.tld");
+      groupByCols.add("p.tld");
+    }
+    if (dims.contains("operation")) {
+      selectCols.add("p.operation");
+      groupByCols.add("p.operation");
+    }
+    selectCols.add("AVG(p.price_amount) AS price_amount");
+    selectCols.add("p.price_currency");
+    groupByCols.add("p.price_currency");
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add("p.is_active = true");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("p.tld IN (:tlds)");
+    }
+    if (!f.getRegistrarIds().isEmpty()) {
+      whereClauses.add("p.registrar_id IN (:registrarIds)");
+    }
+    if (!f.getOperations().isEmpty()) {
+      whereClauses.add("p.operation IN (:operations)");
+    }
+    return assembleQuery(selectCols, "\"RegistryDashboardRegistrarPricing\" p",
+        whereClauses, groupByCols, null);
+  }
+
+  private static String resolveGranularity(String granularity) {
+    if (granularity != null && VALID_GRANULARITIES.contains(granularity)) {
+      return granularity;
+    }
+    return "month";
+  }
+
+  private static String assembleQuery(
+      List<String> selectCols,
+      String fromClause,
+      List<String> whereClauses,
+      List<String> groupByCols,
+      String orderBy) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("SELECT ").append(String.join(", ", selectCols));
+    sb.append(" FROM ").append(fromClause);
+    if (!whereClauses.isEmpty()) {
+      sb.append(" WHERE ").append(String.join(" AND ", whereClauses));
+    }
+    if (!groupByCols.isEmpty()) {
+      sb.append(" GROUP BY ").append(String.join(", ", groupByCols));
+    }
+    if (orderBy != null) {
+      sb.append(" ORDER BY ").append(orderBy);
+    }
+    sb.append(" LIMIT :maxRows");
+    return sb.toString();
+  }
+}

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
@@ -1,0 +1,52 @@
+package google.registry.ui.server.console.registrydash;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+/** Request body for the data exploration endpoint. Deserialized from JSON via Gson. */
+public class ExploreQueryDescriptor {
+
+  private String dataSource;
+  private List<MetricSpec> metrics;
+  private List<String> dimensions;
+  private ExploreFilters filters;
+  private String granularity;
+  private Integer limit;
+
+  public String getDataSource() { return dataSource; }
+  public List<MetricSpec> getMetrics() { return metrics != null ? metrics : ImmutableList.of(); }
+  public List<String> getDimensions() { return dimensions != null ? dimensions : ImmutableList.of(); }
+  public ExploreFilters getFilters() { return filters != null ? filters : new ExploreFilters(); }
+  public String getGranularity() { return granularity; }
+  public int getLimit() { return limit != null ? Math.min(limit, 10000) : 1000; }
+
+  public static class MetricSpec {
+    private String field;
+    private String aggregation;
+
+    public String getField() { return field; }
+    public String getAggregation() { return aggregation != null ? aggregation : "sum"; }
+  }
+
+  public static class ExploreFilters {
+    private List<String> tlds;
+    private List<String> registrarIds;
+    private List<String> activityTypes;
+    private List<String> operations;
+    private DateRange dateRange;
+
+    public List<String> getTlds() { return tlds != null ? tlds : ImmutableList.of(); }
+    public List<String> getRegistrarIds() { return registrarIds != null ? registrarIds : ImmutableList.of(); }
+    public List<String> getActivityTypes() { return activityTypes != null ? activityTypes : ImmutableList.of(); }
+    public List<String> getOperations() { return operations != null ? operations : ImmutableList.of(); }
+    public DateRange getDateRange() { return dateRange; }
+  }
+
+  public static class DateRange {
+    private String start;
+    private String end;
+
+    public String getStart() { return start; }
+    public String getEnd() { return end; }
+  }
+}

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
@@ -1,3 +1,17 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package google.registry.ui.server.console.registrydash;
 
 import com.google.common.collect.ImmutableList;
@@ -13,19 +27,41 @@ public class ExploreQueryDescriptor {
   private String granularity;
   private Integer limit;
 
-  public String getDataSource() { return dataSource; }
-  public List<MetricSpec> getMetrics() { return metrics != null ? metrics : ImmutableList.of(); }
-  public List<String> getDimensions() { return dimensions != null ? dimensions : ImmutableList.of(); }
-  public ExploreFilters getFilters() { return filters != null ? filters : new ExploreFilters(); }
-  public String getGranularity() { return granularity; }
-  public int getLimit() { return limit != null ? Math.min(limit, 10000) : 1000; }
+  public String getDataSource() {
+    return dataSource;
+  }
+
+  public List<MetricSpec> getMetrics() {
+    return metrics != null ? metrics : ImmutableList.of();
+  }
+
+  public List<String> getDimensions() {
+    return dimensions != null ? dimensions : ImmutableList.of();
+  }
+
+  public ExploreFilters getFilters() {
+    return filters != null ? filters : new ExploreFilters();
+  }
+
+  public String getGranularity() {
+    return granularity;
+  }
+
+  public int getLimit() {
+    return limit != null ? Math.min(limit, 10000) : 1000;
+  }
 
   public static class MetricSpec {
     private String field;
     private String aggregation;
 
-    public String getField() { return field; }
-    public String getAggregation() { return aggregation != null ? aggregation : "sum"; }
+    public String getField() {
+      return field;
+    }
+
+    public String getAggregation() {
+      return aggregation != null ? aggregation : "sum";
+    }
   }
 
   public static class ExploreFilters {
@@ -35,18 +71,37 @@ public class ExploreQueryDescriptor {
     private List<String> operations;
     private DateRange dateRange;
 
-    public List<String> getTlds() { return tlds != null ? tlds : ImmutableList.of(); }
-    public List<String> getRegistrarIds() { return registrarIds != null ? registrarIds : ImmutableList.of(); }
-    public List<String> getActivityTypes() { return activityTypes != null ? activityTypes : ImmutableList.of(); }
-    public List<String> getOperations() { return operations != null ? operations : ImmutableList.of(); }
-    public DateRange getDateRange() { return dateRange; }
+    public List<String> getTlds() {
+      return tlds != null ? tlds : ImmutableList.of();
+    }
+
+    public List<String> getRegistrarIds() {
+      return registrarIds != null ? registrarIds : ImmutableList.of();
+    }
+
+    public List<String> getActivityTypes() {
+      return activityTypes != null ? activityTypes : ImmutableList.of();
+    }
+
+    public List<String> getOperations() {
+      return operations != null ? operations : ImmutableList.of();
+    }
+
+    public DateRange getDateRange() {
+      return dateRange;
+    }
   }
 
   public static class DateRange {
     private String start;
     private String end;
 
-    public String getStart() { return start; }
-    public String getEnd() { return end; }
+    public String getStart() {
+      return start;
+    }
+
+    public String getEnd() {
+      return end;
+    }
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryDescriptor.java
@@ -15,17 +15,18 @@
 package google.registry.ui.server.console.registrydash;
 
 import com.google.common.collect.ImmutableList;
+import com.google.gson.annotations.Expose;
 import java.util.List;
 
 /** Request body for the data exploration endpoint. Deserialized from JSON via Gson. */
 public class ExploreQueryDescriptor {
 
-  private String dataSource;
-  private List<MetricSpec> metrics;
-  private List<String> dimensions;
-  private ExploreFilters filters;
-  private String granularity;
-  private Integer limit;
+  @Expose private String dataSource;
+  @Expose private List<MetricSpec> metrics;
+  @Expose private List<String> dimensions;
+  @Expose private ExploreFilters filters;
+  @Expose private String granularity;
+  @Expose private Integer limit;
 
   public String getDataSource() {
     return dataSource;
@@ -52,8 +53,8 @@ public class ExploreQueryDescriptor {
   }
 
   public static class MetricSpec {
-    private String field;
-    private String aggregation;
+    @Expose private String field;
+    @Expose private String aggregation;
 
     public String getField() {
       return field;
@@ -65,11 +66,11 @@ public class ExploreQueryDescriptor {
   }
 
   public static class ExploreFilters {
-    private List<String> tlds;
-    private List<String> registrarIds;
-    private List<String> activityTypes;
-    private List<String> operations;
-    private DateRange dateRange;
+    @Expose private List<String> tlds;
+    @Expose private List<String> registrarIds;
+    @Expose private List<String> activityTypes;
+    @Expose private List<String> operations;
+    @Expose private DateRange dateRange;
 
     public List<String> getTlds() {
       return tlds != null ? tlds : ImmutableList.of();
@@ -93,8 +94,8 @@ public class ExploreQueryDescriptor {
   }
 
   public static class DateRange {
-    private String start;
-    private String end;
+    @Expose private String start;
+    @Expose private String end;
 
     public String getStart() {
       return start;

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
@@ -1,0 +1,259 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.request.Action;
+import google.registry.request.Action.Service;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.ui.server.console.ConsoleApiAction;
+import google.registry.ui.server.console.ConsoleApiParams;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** POST endpoint for flexible data exploration queries on the registry dashboard. */
+@Action(
+    service = Service.CONSOLE,
+    path = RegistryDashExploreAction.PATH,
+    method = {POST},
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class RegistryDashExploreAction extends ConsoleApiAction {
+
+  static final String PATH = "/console-api/registry-dash/explore";
+
+  private final Optional<ExploreQueryDescriptor> exploreQuery;
+
+  @Inject
+  public RegistryDashExploreAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("registryDashExplore") Optional<ExploreQueryDescriptor> exploreQuery) {
+    super(consoleApiParams);
+    this.exploreQuery = exploreQuery;
+  }
+
+  @Override
+  protected void postHandler(User user) {
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_DATA_EXPLORE)) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+
+    if (exploreQuery.isEmpty()) {
+      consoleApiParams.response().setStatus(SC_BAD_REQUEST);
+      consoleApiParams.response().setPayload("{\"error\":\"Missing request body\"}");
+      return;
+    }
+
+    ExploreQueryDescriptor desc = exploreQuery.get();
+
+    // Parse and validate the data source
+    ExploreDataSource source;
+    try {
+      source = ExploreDataSource.valueOf(desc.getDataSource());
+    } catch (IllegalArgumentException | NullPointerException e) {
+      consoleApiParams.response().setStatus(SC_BAD_REQUEST);
+      consoleApiParams.response().setPayload(
+          "{\"error\":\"Unknown dataSource: " + desc.getDataSource() + "\"}");
+      return;
+    }
+
+    // Validate the descriptor against the source's allowlist
+    try {
+      source.validate(desc);
+    } catch (IllegalArgumentException e) {
+      consoleApiParams.response().setStatus(SC_BAD_REQUEST);
+      consoleApiParams.response().setPayload(
+          "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}");
+      return;
+    }
+
+    // Resolve access scoping
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+    ImmutableSet<String> accessTlds =
+        isAdmin ? ImmutableSet.of() : RegistryDashAccessUtil.getMappedTlds(user.getEmailAddress());
+    ImmutableSet<String> requestedTlds =
+        ImmutableSet.copyOf(desc.getFilters().getTlds());
+    ImmutableSet<String> effectiveTlds =
+        RegistryDashAccessUtil.applyFilter(accessTlds, requestedTlds, isAdmin);
+
+    // Build SQL
+    String sql;
+    try {
+      sql = ExploreQueryBuilder.build(source, desc, effectiveTlds);
+    } catch (IllegalArgumentException e) {
+      consoleApiParams.response().setStatus(SC_BAD_REQUEST);
+      consoleApiParams.response().setPayload(
+          "{\"error\":\"" + e.getMessage().replace("\"", "'") + "\"}");
+      return;
+    }
+
+    // Resolve date range (if present)
+    ExploreQueryDescriptor.ExploreFilters filters = desc.getFilters();
+    Instant startDate = null;
+    Instant endDate = null;
+    if (filters.getDateRange() != null) {
+      try {
+        startDate =
+            LocalDate.parse(filters.getDateRange().getStart())
+                .atStartOfDay()
+                .toInstant(ZoneOffset.UTC);
+        endDate =
+            LocalDate.parse(filters.getDateRange().getEnd())
+                .plusDays(1)
+                .atStartOfDay()
+                .toInstant(ZoneOffset.UTC);
+      } catch (Exception e) {
+        consoleApiParams.response().setStatus(SC_BAD_REQUEST);
+        consoleApiParams.response().setPayload("{\"error\":\"Invalid date range format\"}");
+        return;
+      }
+    }
+
+    // Map activity types from friendly names to DB values
+    List<String> mappedActivityTypes = new ArrayList<>();
+    for (String friendly : filters.getActivityTypes()) {
+      mappedActivityTypes.addAll(mapActivityType(friendly));
+    }
+
+    int maxRows = desc.getLimit();
+
+    // Capture final locals for lambda
+    final Instant finalStartDate = startDate;
+    final Instant finalEndDate = endDate;
+    final List<String> finalMappedActivityTypes = mappedActivityTypes;
+    final ImmutableSet<String> finalEffectiveTlds = effectiveTlds;
+
+    // Build column names for response
+    List<String> columns = buildColumnNames(source, desc);
+
+    tm().transact(
+        () -> {
+          @SuppressWarnings("unchecked")
+          jakarta.persistence.Query query =
+              tm().getEntityManager().createNativeQuery(sql);
+
+          query.setParameter("maxRows", maxRows);
+
+          if (!finalEffectiveTlds.isEmpty()) {
+            query.setParameter("tlds", finalEffectiveTlds);
+          }
+          if (finalStartDate != null) {
+            query.setParameter("startDate", finalStartDate);
+          }
+          if (finalEndDate != null) {
+            query.setParameter("endDate", finalEndDate);
+          }
+          if (!finalMappedActivityTypes.isEmpty()) {
+            query.setParameter("activityTypes", finalMappedActivityTypes);
+          }
+          if (!filters.getOperations().isEmpty()) {
+            query.setParameter("operations", filters.getOperations());
+          }
+          if (!filters.getRegistrarIds().isEmpty()) {
+            query.setParameter("registrarIds", filters.getRegistrarIds());
+          }
+
+          @SuppressWarnings("unchecked")
+          List<Object> rawResults = query.getResultList();
+
+          // Normalize rows: each may be Object[] or a single scalar
+          List<List<Object>> rows = new ArrayList<>();
+          for (Object raw : rawResults) {
+            List<Object> rowList = new ArrayList<>();
+            if (raw instanceof Object[] arr) {
+              for (Object cell : arr) {
+                rowList.add(normalizeValue(cell));
+              }
+            } else {
+              rowList.add(normalizeValue(raw));
+            }
+            rows.add(rowList);
+          }
+
+          boolean truncated = rows.size() >= maxRows;
+
+          Map<String, Object> response = new HashMap<>();
+          response.put("columns", columns);
+          response.put("rows", rows);
+          response.put("truncated", truncated);
+          response.put("totalRows", rows.size());
+
+          consoleApiParams.response().setPayload(consoleApiParams.gson().toJson(response));
+          consoleApiParams.response().setStatus(SC_OK);
+        });
+  }
+
+  private static List<String> buildColumnNames(
+      ExploreDataSource source, ExploreQueryDescriptor desc) {
+    List<String> cols = new ArrayList<>();
+    // Dimensions first
+    for (String dim : desc.getDimensions()) {
+      cols.add(dim);
+    }
+    // Metrics: field + "_" + aggregation
+    for (ExploreQueryDescriptor.MetricSpec m : desc.getMetrics()) {
+      cols.add(m.getField() + "_" + m.getAggregation());
+    }
+    // Currency column for revenue/pricing sources
+    if (source == ExploreDataSource.REVENUE || source == ExploreDataSource.PRICING_RULES) {
+      cols.add("currency");
+    }
+    return cols;
+  }
+
+  private static Object normalizeValue(Object val) {
+    if (val == null) {
+      return null;
+    }
+    if (val instanceof java.sql.Timestamp ts) {
+      return ts.toInstant().toString();
+    }
+    if (val instanceof java.time.OffsetDateTime odt) {
+      return odt.toInstant().toString();
+    }
+    if (val instanceof Instant inst) {
+      return inst.toString();
+    }
+    return val;
+  }
+
+  private static List<String> mapActivityType(String friendlyName) {
+    return switch (friendlyName) {
+      case "CREATES" -> List.of("DOMAIN_CREATE");
+      case "RENEWS" -> List.of("DOMAIN_RENEW", "DOMAIN_AUTORENEW");
+      case "TRANSFERS" -> List.of("DOMAIN_TRANSFER_APPROVE");
+      case "DELETES" -> List.of("DOMAIN_DELETE");
+      case "RESTORES" -> List.of("DOMAIN_RESTORE");
+      default -> List.of();
+    };
+  }
+}

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilderTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilderTest.java
@@ -1,0 +1,170 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+
+class ExploreQueryBuilderTest {
+
+  private static final Gson GSON = new Gson();
+
+  private ExploreQueryDescriptor parse(String json) {
+    return GSON.fromJson(json, ExploreQueryDescriptor.class);
+  }
+
+  @Test
+  void domainActivity_basicQuery_generatesValidSql() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_ACTIVITY",
+          "metrics": [{"field": "count", "aggregation": "sum"}],
+          "dimensions": ["tld", "period"],
+          "filters": {"dateRange": {"start": "2025-01-01", "end": "2025-12-31"}},
+          "granularity": "month"
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_ACTIVITY, desc, ImmutableSet.of("modem", "nft"));
+    assertThat(sql).contains("\"DomainHistory\"");
+    assertThat(sql).contains("\"Domain\"");
+    assertThat(sql).contains("date_trunc('month'");
+    assertThat(sql).contains("d.tld IN (:tlds)");
+    assertThat(sql).contains("COUNT(*)");
+    assertThat(sql).contains("GROUP BY");
+    assertThat(sql).contains("LIMIT :maxRows");
+  }
+
+  @Test
+  void domainActivity_adminNoTlds_omitsTldFilter() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_ACTIVITY",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld"],
+          "filters": {}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_ACTIVITY, desc, ImmutableSet.of());
+    assertThat(sql).doesNotContain("d.tld IN");
+  }
+
+  @Test
+  void domainActivity_withActivityTypeFilter_includesFilter() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_ACTIVITY",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld", "activity_type"],
+          "filters": {"activityTypes": ["CREATES", "RENEWS"]}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_ACTIVITY, desc, ImmutableSet.of("modem"));
+    assertThat(sql).contains(":activityTypes");
+  }
+
+  @Test
+  void revenue_basicQuery_includesCostBasisJoin() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "REVENUE",
+          "metrics": [{"field": "netAmountToRegistry"}],
+          "dimensions": ["tld", "period"],
+          "filters": {"dateRange": {"start": "2025-01-01", "end": "2025-12-31"}},
+          "granularity": "month"
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.REVENUE, desc, ImmutableSet.of("modem"));
+    assertThat(sql).contains("\"BillingEvent\"");
+    assertThat(sql).contains("RegistryDashboardCostBasis");
+    assertThat(sql).contains("rsp_retained_fee_amount");
+  }
+
+  @Test
+  void domainCounts_basicQuery_generatesSimpleCount() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_COUNTS",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld"],
+          "filters": {}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_COUNTS, desc, ImmutableSet.of());
+    assertThat(sql).contains("\"Domain\"");
+    assertThat(sql).contains("deletion_time > CURRENT_TIMESTAMP");
+    assertThat(sql).contains("COUNT(*)");
+  }
+
+  @Test
+  void renewalRates_basicQuery_includesRenewAndDelete() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "RENEWAL_RATES",
+          "metrics": [{"field": "renewals"}, {"field": "deletions"}],
+          "dimensions": ["tld"],
+          "filters": {"dateRange": {"start": "2025-01-01", "end": "2025-12-31"}}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.RENEWAL_RATES, desc, ImmutableSet.of("modem"));
+    assertThat(sql).contains("DOMAIN_RENEW");
+    assertThat(sql).contains("DOMAIN_DELETE");
+  }
+
+  @Test
+  void accessScoping_alwaysApplied_forNonEmptyTlds() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_ACTIVITY",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld"],
+          "filters": {}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_ACTIVITY, desc, ImmutableSet.of("modem"));
+    assertThat(sql).contains("d.tld IN (:tlds)");
+  }
+
+  @Test
+  void invalidGranularity_defaultsToMonth() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_ACTIVITY",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld", "period"],
+          "filters": {},
+          "granularity": "invalid_granularity"
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_ACTIVITY, desc, ImmutableSet.of());
+    assertThat(sql).contains("date_trunc('month'");
+  }
+
+  @Test
+  void limitClause_alwaysPresent() {
+    ExploreQueryDescriptor desc = parse("""
+        {
+          "dataSource": "DOMAIN_COUNTS",
+          "metrics": [{"field": "count"}],
+          "dimensions": ["tld"],
+          "filters": {}
+        }""");
+    String sql = ExploreQueryBuilder.build(
+        ExploreDataSource.DOMAIN_COUNTS, desc, ImmutableSet.of());
+    assertThat(sql).contains("LIMIT :maxRows");
+  }
+}

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -1,4 +1,3 @@
-WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
 SERVICE  PATH                                               CLASS                                          METHODS             OK MIN  USER_POLICY
 FRONTEND /_dr/epp                                           EppTlsAction                                   POST                n  APP  ADMIN
 FRONTEND /ready/frontend                                    ReadinessProbeActionFrontend                   GET                 n  NONE PUBLIC

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -1,3 +1,4 @@
+WARNING: Unable to create a system terminal, creating a dumb terminal (enable debug logging for more information)
 SERVICE  PATH                                               CLASS                                          METHODS             OK MIN  USER_POLICY
 FRONTEND /_dr/epp                                           EppTlsAction                                   POST                n  APP  ADMIN
 FRONTEND /ready/frontend                                    ReadinessProbeActionFrontend                   GET                 n  NONE PUBLIC
@@ -84,6 +85,7 @@ CONSOLE  /console-api/registry-dash/admin                   RegistryDashAdminAct
 CONSOLE  /console-api/registry-dash/cost-basis              RegistryDashCostBasisAction                    GET,POST,PUT        n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/domain-activity         RegistryDashDomainActivityAction               GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/effective-fees          UDRegistryDashEffectiveFeesAction              GET                 n  USER PUBLIC
+CONSOLE  /console-api/registry-dash/explore                 RegistryDashExploreAction                      POST                n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/filter-options          RegistryDashFilterOptionsAction                GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/forecasting             RegistryDashForecastingAction                  GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/overview                RegistryDashOverviewAction                     GET                 n  USER PUBLIC


### PR DESCRIPTION
## Summary

- Fix 400 error on explore endpoint — Gson uses `excludeFieldsWithoutExposeAnnotation()` so all fields in `ExploreQueryDescriptor` were deserializing as null
- Added `@Expose` to all fields in `ExploreQueryDescriptor`, `MetricSpec`, `ExploreFilters`, and `DateRange`

## Test plan

- [x] ExploreQueryBuilderTest passes (9/9)
- [ ] Verify on alpha-gke after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)