### PR TITLE
refactor(registry-dash): remove redundant local Registrar/TLD filters

### DIFF
--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.html
@@ -14,24 +14,8 @@
     {{ dashService.error() }}
   </div>
 
-  <!-- Filters -->
+  <!-- Source filter (Registrar/TLD filtering handled by global filter bar) -->
   <div class="effective-fees-filters" *ngIf="dashService.effectiveFees().length > 0">
-    <mat-form-field appearance="outline">
-      <mat-label>Registrar</mat-label>
-      <mat-select [value]="filterRegistrar()" (selectionChange)="onRegistrarFilterChange($event.value)">
-        <mat-option value="all">All Registrars</mat-option>
-        <mat-option *ngFor="let reg of uniqueRegistrars()" [value]="reg">{{ reg }}</mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field appearance="outline">
-      <mat-label>TLD</mat-label>
-      <mat-select [value]="filterTld()" (selectionChange)="onTldFilterChange($event.value)">
-        <mat-option value="all">All TLDs</mat-option>
-        <mat-option *ngFor="let tld of uniqueTlds()" [value]="tld">.{{ tld }}</mat-option>
-      </mat-select>
-    </mat-form-field>
-
     <mat-form-field appearance="outline">
       <mat-label>Source</mat-label>
       <mat-select [value]="filterSource()" (selectionChange)="onSourceFilterChange($event.value)">

--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.ts
@@ -34,28 +34,11 @@ export class EffectiveFeesComponent implements AfterViewInit {
   ];
 
   fetchedAt = signal<string>('');
-  filterRegistrar = signal<string>('all');
-  filterTld = signal<string>('all');
   filterSource = signal<string>('all');
 
-  uniqueRegistrars = computed(() => {
-    const fees = this.dashService.filteredEffectiveFees();
-    return [...new Set(fees.map(f => f.registrarId))].sort();
-  });
-
-  uniqueTlds = computed(() => {
-    const fees = this.dashService.filteredEffectiveFees();
-    return [...new Set(fees.map(f => f.tld))].sort();
-  });
-
   filteredFees = computed(() => {
-    // Start from globally filtered data, then apply local filters
     let fees = this.dashService.filteredEffectiveFees();
-    const reg = this.filterRegistrar();
-    const tld = this.filterTld();
     const source = this.filterSource();
-    if (reg !== 'all') fees = fees.filter(f => f.registrarId === reg);
-    if (tld !== 'all') fees = fees.filter(f => f.tld === tld);
     if (source !== 'all') fees = fees.filter(f => f.source === source);
     return fees;
   });
@@ -79,14 +62,6 @@ export class EffectiveFeesComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.dataSource.sort = this.sort;
-  }
-
-  onRegistrarFilterChange(value: string) {
-    this.filterRegistrar.set(value);
-  }
-
-  onTldFilterChange(value: string) {
-    this.filterTld.set(value);
   }
 
   onSourceFilterChange(value: string) {

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.html
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.html
@@ -132,32 +132,6 @@
     </mat-card>
   }
 
-  <div class="pricing-filters">
-    <mat-form-field>
-      <mat-label>Filter by Registrar</mat-label>
-      <mat-select [value]="filterRegistrar()" (selectionChange)="filterRegistrar.set($event.value)">
-        <mat-option value="all">All Registrars</mat-option>
-        @for (reg of uniqueRegistrars(); track reg) {
-          <mat-option [value]="reg">{{ reg }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label>Filter by TLD</mat-label>
-      <mat-select [value]="filterTld()" (selectionChange)="filterTld.set($event.value)">
-        <mat-option value="all">All TLDs</mat-option>
-        @for (tld of uniqueTlds(); track tld) {
-          <mat-option [value]="tld">.{{ tld }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    @if (filterRegistrar() !== 'all' || filterTld() !== 'all') {
-      <button mat-button (click)="clearFilters()">
-        <mat-icon>clear</mat-icon> Clear Filters
-      </button>
-    }
-  </div>
-
   @if (filteredRules().length > 0) {
     <table mat-table [dataSource]="dataSource" matSort class="mat-elevation-z1">
       <ng-container matColumnDef="registrarId">

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
@@ -51,28 +51,7 @@ export class PricingComponent implements AfterViewInit {
   @ViewChild(MatSort) sort!: MatSort;
   dataSource = new MatTableDataSource<PricingRule>([]);
 
-  filterRegistrar = signal<string>('all');
-  filterTld = signal<string>('all');
-
-  uniqueRegistrars = computed(() => {
-    const rules = this.dashService.filteredPricingRules();
-    return [...new Set(rules.map(r => r.registrarId))].sort();
-  });
-
-  uniqueTlds = computed(() => {
-    const rules = this.dashService.filteredPricingRules();
-    return [...new Set(rules.map(r => r.tld))].sort();
-  });
-
-  filteredRules = computed(() => {
-    // Start from globally filtered data, then apply local filters
-    let rules = this.dashService.filteredPricingRules();
-    const reg = this.filterRegistrar();
-    const tld = this.filterTld();
-    if (reg !== 'all') rules = rules.filter(r => r.registrarId === reg);
-    if (tld !== 'all') rules = rules.filter(r => r.tld === tld);
-    return rules;
-  });
+  filteredRules = computed(() => this.dashService.filteredPricingRules());
 
   showForm = signal(false);
   editingRule = signal<PricingRule | undefined>(undefined);
@@ -179,11 +158,6 @@ export class PricingComponent implements AfterViewInit {
     if (diff < 0) return 'diff-discount';
     if (diff > 0) return 'diff-premium';
     return 'diff-zero';
-  }
-
-  clearFilters() {
-    this.filterRegistrar.set('all');
-    this.filterTld.set('all');
   }
 
   openAddForm() {


### PR DESCRIPTION
## Summary

- Remove per-page single-select Registrar and TLD filter dropdowns from **Pricing** and **Effective Fees** pages — the global multi-select filter bar (PR #93, SRE-1904) is strictly more capable
- Simplify `filteredRules` on Pricing to pass through `dashService.filteredPricingRules()` directly
- On Effective Fees, keep `filterSource` (Default vs Custom) since that dimension isn't covered by the global bar
- Net: 95 lines deleted, 2 added

## Linear

Closes [SRE-1907](https://linear.app/unstoppable-domains/issue/SRE-1907/refactor-registry-dashboard-remove-redundant-local-registrartld)
Related: [SRE-1904](https://linear.app/unstoppable-domains/issue/SRE-1904) (predecessor — global filter bar)

## Test plan

- [x] `tsc --noEmit` clean (only pre-existing revenue-billing spec errors)
- [ ] Verify Pricing page table still reacts to global filter changes
- [ ] Verify Effective Fees page still reacts to global filter + local Source filter
- [ ] Smoke test on alpha after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)