### PR TITLE
fix(registry-dash): fix revenue billing and explore regressions

### DIFF
--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -45,7 +45,7 @@ export class ExploreComponent implements OnInit {
 
   metricColumn = computed(() => {
     const metrics = this.query().metrics;
-    return metrics.length > 0 ? metrics[0].field : 'count';
+    return metrics.length > 0 ? `${metrics[0].field}_${metrics[0].aggregation}` : 'count_sum';
   });
 
   tableColumns = computed(() => {

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
@@ -185,18 +185,20 @@ public class RegistryDashExploreAction extends ConsoleApiAction {
           @SuppressWarnings("unchecked")
           List<Object> rawResults = query.getResultList();
 
-          // Normalize rows: each may be Object[] or a single scalar
-          List<List<Object>> rows = new ArrayList<>();
+          // Normalize rows: convert positional arrays to named objects using columns
+          List<Map<String, Object>> rows = new ArrayList<>();
           for (Object raw : rawResults) {
-            List<Object> rowList = new ArrayList<>();
+            Map<String, Object> rowMap = new HashMap<>();
             if (raw instanceof Object[] arr) {
-              for (Object cell : arr) {
-                rowList.add(normalizeValue(cell));
+              for (int i = 0; i < arr.length && i < columns.size(); i++) {
+                rowMap.put(columns.get(i), normalizeValue(arr[i]));
               }
             } else {
-              rowList.add(normalizeValue(raw));
+              if (!columns.isEmpty()) {
+                rowMap.put(columns.get(0), normalizeValue(raw));
+              }
             }
-            rows.add(rowList);
+            rows.add(rowMap);
           }
 
           boolean truncated = rows.size() >= maxRows;

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashRevenueBillingAction.java
@@ -117,6 +117,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= :endDate
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY date_trunc('%s', dh.history_modification_time), d.tld, b.reason, b.cost_currency
@@ -181,6 +182,7 @@ public class RegistryDashRevenueBillingAction extends ConsoleApiAction {
         LIMIT 1
       ) cb ON true
       WHERE dh.history_modification_time >= :startDate
+        AND dh.history_modification_time <= :endDate
         AND d.tld IN :tlds
         AND b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')
       GROUP BY period, d.tld, b.reason, b.cost_currency


### PR DESCRIPTION
## Summary

- **Financials `:endDate` crash (PR #88 regression):** The scoped revenue billing SQL queries were missing `AND dh.history_modification_time <= :endDate`, causing a 400 error for non-admin users on the Financials page. Added the missing clause to both `REVENUE_SCOPED_TEMPLATE` and `REVENUE_15MIN_SCOPED`.

- **Data Exploration empty charts/tables (PR #95 regression):** Backend returned rows as positional arrays (`[["dialup", 1850]]`) but the frontend `ExploreResult.rows` type expects objects keyed by column name (`[{tld: "dialup", count_sum: 1850}]`). Fixed backend to return `Map<String, Object>` rows. Also fixed frontend `metricColumn` to use `field_aggregation` format matching actual column names.

## Test plan

- [x] Verified both defects on alpha (screenshots + XHR intercept)
- [x] Java backend compiles clean
- [x] Angular frontend compiles clean
- [x] Existing `RegistryDashRevenueBillingActionTest` passes
- [ ] CI green on `-gke` triggers
- [ ] Deploy to alpha-gke and verify Financials page loads without error
- [ ] Deploy to alpha-gke and verify Data Exploration shows chart bars + table data

🤖 Generated with [Claude Code](https://claude.com/claude-code)