### PR TITLE
fix(registry-dash): renewal rate chart shows 1% instead of correct percentage

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashForecastingAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashForecastingAction.java
@@ -292,9 +292,9 @@ public class RegistryDashForecastingAction extends ConsoleApiAction {
             long deletions = ((Number) row[2]).longValue();
             long total = renewals + deletions;
             BigDecimal renewalRate = total > 0
-                ? BigDecimal.valueOf(renewals)
-                    .divide(BigDecimal.valueOf(total), 3, RoundingMode.HALF_UP)
-                : BigDecimal.ONE;
+                ? BigDecimal.valueOf(renewals * 100)
+                    .divide(BigDecimal.valueOf(total), 1, RoundingMode.HALF_UP)
+                : BigDecimal.valueOf(100);
 
             Map<String, Object> entry = new HashMap<>();
             entry.put("tld", tld);


### PR DESCRIPTION
## Summary
- The Overview tab's "Renewal Rate by TLD" chart always showed ~1% for all TLDs
- Root cause: backend returned renewal rate as a decimal (0–1 range) but the entire frontend expects percentage scale (0–100)
- TLDs with no renewal/deletion activity defaulted to `BigDecimal.ONE` (1.0), which the frontend displayed as "1.0%" instead of "100.0%"

## Changes
- `RegistryDashForecastingAction.java`: changed renewal rate calculation from `renewals / total` (decimal) to `renewals * 100 / total` (percentage), and default from `BigDecimal.ONE` to `BigDecimal.valueOf(100)`

## Test plan
- [ ] Verify renewal rate chart on Overview tab shows correct percentages after deploy to alpha-gke
- [ ] Verify Financials tab average renewal rate displays correctly
- [ ] Verify drill-down dialog shows correct renewal rate value
- [ ] Verify "domains at risk" count (< 85% threshold) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)