### PR TITLE
feat(registry-dash): global timeframe filter

### DIFF
--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
@@ -16,11 +16,7 @@
   <h2>Domain Activity</h2>
   <p class="subtitle">Domain registration activity across all TLDs — creates, renews, transfers, deletes, and restores.</p>
 
-  <app-filter-panel>
-    <mat-button-toggle-group [value]="selectedRange()" (change)="onRangeChange($event.value)">
-      <mat-button-toggle *ngFor="let key of rangeKeys" [value]="key">{{ key }}</mat-button-toggle>
-    </mat-button-toggle-group>
-  </app-filter-panel>
+  <app-filter-panel></app-filter-panel>
 
   <div *ngIf="dashService.loading()" class="loading">
     <mat-spinner diameter="40"></mat-spinner>

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, OnInit, DestroyRef, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, DestroyRef, computed, inject } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../ud-echarts';
-import { RegistryDashService } from '../registry-dash.service';
-import { RANGE_CONFIG } from '../financials/revenue-billing/revenue-billing.component';
+import { RegistryDashService, RANGE_CONFIG } from '../registry-dash.service';
 import { DrillDownService } from '../drilldown/drilldown.service';
 import { withDrillDown } from '../ud-echarts';
 import { LongPressDirective } from '../drilldown/long-press.directive';
@@ -51,8 +50,6 @@ export class DomainActivityComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   lastHoveredActivityByTld: any = null;
   lastHoveredDomainCounts: any = null;
-  selectedRange = signal('12m');
-  rangeKeys = Object.keys(RANGE_CONFIG);
 
   data = computed(() => this.dashService.domainActivity());
 
@@ -166,9 +163,8 @@ export class DomainActivityComponent implements OnInit {
     public dashService: RegistryDashService,
     private drillDown: DrillDownService,
   ) {
-    // Refetch when selectedRange or global filters change
     combineLatest([
-      toObservable(this.selectedRange),
+      toObservable(this.dashService.selectedTimeRange),
       toObservable(this.dashService.selectedTlds),
       toObservable(this.dashService.selectedRegistrarIds),
     ]).pipe(
@@ -186,10 +182,6 @@ export class DomainActivityComponent implements OnInit {
 
   ngOnInit() {
     // Initial fetch is handled by the observable above
-  }
-
-  onRangeChange(range: string) {
-    this.selectedRange.set(range);
   }
 
   onActivityByTldClick(event: any) {

--- a/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.html
+++ b/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.html
@@ -5,18 +5,17 @@
       <div class="filter-header" (click)="toggleExpanded()">
         <mat-icon class="filter-icon">filter_list</mat-icon>
         <div class="chip-area">
-          @if (activeChips().length > 0) {
-            <mat-chip-set>
-              @for (chip of activeChips(); track chip.value) {
-                <mat-chip (removed)="removeChip(chip)" (click)="$event.stopPropagation()">
-                  {{ chip.label }}
-                  <mat-icon matChipRemove>close</mat-icon>
-                </mat-chip>
-              }
-            </mat-chip-set>
-          } @else {
-            <span class="no-filters">No filters active</span>
-          }
+          <mat-chip-set>
+            <mat-chip (click)="$event.stopPropagation()">
+              {{ dashService.selectedTimeRange() }}
+            </mat-chip>
+            @for (chip of activeChips(); track chip.value) {
+              <mat-chip (removed)="removeChip(chip)" (click)="$event.stopPropagation()">
+                {{ chip.label }}
+                <mat-icon matChipRemove>close</mat-icon>
+              </mat-chip>
+            }
+          </mat-chip-set>
         </div>
         <span class="edit-link">
           Edit <mat-icon>tune</mat-icon>
@@ -36,6 +35,14 @@
         </span>
       </div>
       <div class="filter-body">
+        <div class="time-range">
+          <mat-button-toggle-group [value]="dashService.selectedTimeRange()" (change)="onTimeRangeChange($event.value)">
+            @for (key of rangeKeys; track key) {
+              <mat-button-toggle [value]="key">{{ key }}</mat-button-toggle>
+            }
+          </mat-button-toggle-group>
+        </div>
+
         <mat-form-field appearance="outline" class="filter-select">
           <mat-label>TLDs</mat-label>
           <mat-select multiple

--- a/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.scss
+++ b/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.scss
@@ -79,6 +79,11 @@
   border-top: 1px solid #f0f0f0;
 }
 
+.time-range {
+  width: 100%;
+  padding-top: 12px;
+}
+
 .filter-select {
   width: 220px;
 

--- a/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.ts
+++ b/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.ts
@@ -15,7 +15,7 @@
 import { Component, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MaterialModule } from '../../material.module';
-import { RegistryDashService } from '../registry-dash.service';
+import { RegistryDashService, RANGE_KEYS } from '../registry-dash.service';
 
 interface FilterChip {
   label: string;
@@ -32,6 +32,7 @@ interface FilterChip {
 })
 export class FilterPanelComponent {
   protected dashService = inject(RegistryDashService);
+  rangeKeys = RANGE_KEYS;
 
   expanded = computed(() => this.dashService.filterPanelExpanded());
 
@@ -78,6 +79,10 @@ export class FilterPanelComponent {
 
   onRegistrarsChange(ids: string[]): void {
     this.dashService.selectedRegistrarIds.set(ids);
+  }
+
+  onTimeRangeChange(range: string): void {
+    this.dashService.selectedTimeRange.set(range);
   }
 
   clearFilters(): void {

--- a/console-webapp/src/app/registry-dash/financials/financials.component.html
+++ b/console-webapp/src/app/registry-dash/financials/financials.component.html
@@ -17,13 +17,6 @@
     <mat-tab label="Overview">
       <ng-template matTabContent>
         <div class="tab-content overview-tab">
-          <!-- Time Range Toggle -->
-          <div class="time-range">
-            <mat-button-toggle-group [value]="selectedOverviewRange()" (change)="onOverviewRangeChange($event.value)">
-              <mat-button-toggle *ngFor="let key of overviewRangeKeys" [value]="key">{{ key }}</mat-button-toggle>
-            </mat-button-toggle-group>
-          </div>
-
           <!-- Overview Metric Cards -->
           <div class="metric-cards" *ngIf="dashService.revenueBilling() || dashService.domainActivity() || dashService.forecasting()">
             <mat-card class="metric-card">

--- a/console-webapp/src/app/registry-dash/financials/financials.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/financials.component.ts
@@ -19,8 +19,8 @@ import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../ud-echarts';
-import { RegistryDashService } from '../registry-dash.service';
-import { RevenueBillingComponent, RANGE_CONFIG } from './revenue-billing/revenue-billing.component';
+import { RegistryDashService, RANGE_CONFIG } from '../registry-dash.service';
+import { RevenueBillingComponent } from './revenue-billing/revenue-billing.component';
 import { DrillDownService } from '../drilldown/drilldown.service';
 import { withDrillDown } from '../ud-echarts';
 import { LongPressDirective } from '../drilldown/long-press.directive';
@@ -47,18 +47,8 @@ export class FinancialsComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   lastHoveredOverviewRevenueByOp: any = null;
   selectedTab = signal(0);
-  selectedOverviewRange = signal('12m');
-  overviewRangeKeys = Object.keys(RANGE_CONFIG);
 
-  private static readonly RANGE_LABELS: Record<string, string> = {
-    '6h': '6 Hours', '12h': '12 Hours', '1d': '1 Day', '7d': '7 Days',
-    '30d': '30 Days', '3m': '3 Months', '6m': '6 Months',
-    '12m': '12 Months', '24m': '24 Months',
-  };
-
-  overviewRangeLabel = computed(() =>
-    FinancialsComponent.RANGE_LABELS[this.selectedOverviewRange()] ?? this.selectedOverviewRange()
-  );
+  overviewRangeLabel = computed(() => this.dashService.timeRangeLabel());
 
   // --- Fees by TLD tab ---
 
@@ -139,10 +129,9 @@ export class FinancialsComponent implements OnInit {
     public dashService: RegistryDashService,
     private drillDown: DrillDownService,
   ) {
-    // Re-fetch all overview data when range, tab, or global filters change
     combineLatest([
       toObservable(this.selectedTab),
-      toObservable(this.selectedOverviewRange),
+      toObservable(this.dashService.selectedTimeRange),
       toObservable(this.dashService.selectedTlds),
       toObservable(this.dashService.selectedRegistrarIds),
     ]).pipe(
@@ -166,10 +155,6 @@ export class FinancialsComponent implements OnInit {
 
   ngOnInit() {
     this.dashService.getTldFees().subscribe();
-  }
-
-  onOverviewRangeChange(range: string) {
-    this.selectedOverviewRange.set(range);
   }
 
   onTabChange(index: number) {

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
@@ -21,12 +21,6 @@
     {{ dashService.error() }}
   </div>
 
-  <!-- Forecast Horizon Toggle -->
-  <div class="time-range">
-    <mat-button-toggle-group [value]="selectedRange()" (change)="onRangeChange($event.value)">
-      <mat-button-toggle *ngFor="let key of rangeKeys" [value]="key">{{ key }}</mat-button-toggle>
-    </mat-button-toggle-group>
-  </div>
 
   <!-- Metric Cards -->
   <div class="metric-cards" *ngIf="data()">

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
@@ -20,7 +20,7 @@ import { MaterialModule } from '../../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../../ud-echarts';
 import { RegistryDashService } from '../../registry-dash.service';
-import { RANGE_CONFIG } from '../revenue-billing/revenue-billing.component';
+import { RANGE_CONFIG } from '../../registry-dash.service';
 import { DrillDownService } from '../../drilldown/drilldown.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
@@ -46,8 +46,6 @@ export class ForecastingComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   lastHoveredNetGrowth: any = null;
   lastHoveredExpiration: any = null;
-  selectedRange = signal('12m');
-  rangeKeys = Object.keys(RANGE_CONFIG);
   forecastMethod = signal<ForecastMethod>('trend');
 
   data = computed(() => this.dashService.forecasting());
@@ -269,7 +267,7 @@ export class ForecastingComponent implements OnInit {
     private drillDown: DrillDownService,
   ) {
     combineLatest([
-      toObservable(this.selectedRange),
+      toObservable(this.dashService.selectedTimeRange),
       toObservable(this.dashService.selectedTlds),
       toObservable(this.dashService.selectedRegistrarIds),
     ]).pipe(
@@ -290,10 +288,6 @@ export class ForecastingComponent implements OnInit {
 
   ngOnInit() {
     // Initial fetch is handled by the observable above
-  }
-
-  onRangeChange(range: string) {
-    this.selectedRange.set(range);
   }
 
   onForecastMethodChange(method: string) {

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
@@ -21,12 +21,6 @@
     {{ dashService.error() }}
   </div>
 
-  <!-- Time Range Toggle -->
-  <div class="time-range">
-    <mat-button-toggle-group [value]="selectedRange()" (change)="onRangeChange($event.value)">
-      <mat-button-toggle *ngFor="let key of rangeKeys" [value]="key">{{ key }}</mat-button-toggle>
-    </mat-button-toggle-group>
-  </div>
 
   <!-- Metric Cards -->
   <div class="metric-cards" *ngIf="data()">

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.spec.ts
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.spec.ts
@@ -16,8 +16,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { signal } from '@angular/core';
 import { of } from 'rxjs';
-import { RevenueBillingComponent, RANGE_CONFIG } from './revenue-billing.component';
-import { RegistryDashService, RevenueBillingData } from '../../registry-dash.service';
+import { RevenueBillingComponent } from './revenue-billing.component';
+import { RegistryDashService, RANGE_CONFIG, RevenueBillingData } from '../../registry-dash.service';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
 import { BackendService } from '../../../shared/services/backend.service';
@@ -47,6 +47,7 @@ describe('RevenueBillingComponent', () => {
       revenueBilling: signal<RevenueBillingData | undefined>(mockData),
       loading: signal(false),
       error: signal<string | undefined>(undefined),
+      selectedTimeRange: signal('12m'),
       selectedTlds: signal<string[]>([]),
       selectedRegistrarIds: signal<string[]>([]),
     });
@@ -84,10 +85,6 @@ describe('RevenueBillingComponent', () => {
 
   // --- Range selector tests ---
 
-  it('should default to 12m range', () => {
-    expect(component.selectedRange()).toBe('12m');
-  });
-
   it('should have 9 range options in the config', () => {
     expect(Object.keys(RANGE_CONFIG)).toEqual([
       '6h', '12h', '1d', '7d', '30d', '3m', '6m', '12m', '24m',
@@ -97,7 +94,7 @@ describe('RevenueBillingComponent', () => {
   it('should call getRevenueBilling with lookbackHours and granularity on range change', () => {
     fixture.detectChanges();
     mockDashService.getRevenueBilling.calls.reset();
-    component.onRangeChange('7d');
+    (mockDashService as any).selectedTimeRange.set('7d');
     fixture.detectChanges();
     expect(mockDashService.getRevenueBilling).toHaveBeenCalledWith(168, 'day', undefined, undefined);
   });
@@ -105,14 +102,13 @@ describe('RevenueBillingComponent', () => {
   it('should call getRevenueBilling with correct params for 6h range', () => {
     fixture.detectChanges();
     mockDashService.getRevenueBilling.calls.reset();
-    component.onRangeChange('6h');
+    (mockDashService as any).selectedTimeRange.set('6h');
     fixture.detectChanges();
     expect(mockDashService.getRevenueBilling).toHaveBeenCalledWith(6, '15min', undefined, undefined);
   });
 
   it('should call getRevenueBilling with correct params for 12m range', () => {
     fixture.detectChanges();
-    // 12m is the default, so the effect already fired with these params
     expect(mockDashService.getRevenueBilling).toHaveBeenCalledWith(8760, 'month', undefined, undefined);
   });
 

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, OnInit, DestroyRef, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, DestroyRef, computed, inject } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../../ud-echarts';
-import { RegistryDashService } from '../../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG } from '../../registry-dash.service';
 import { DrillDownService } from '../../drilldown/drilldown.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
@@ -36,23 +36,6 @@ const TLD_COLORS = [
   '#00C9FF', '#0A5FEA', '#4A9B30', '#9191A1',
 ];
 
-export interface RangeConfigEntry {
-  lookbackHours: number;
-  granularity: string;
-}
-
-export const RANGE_CONFIG: Record<string, RangeConfigEntry> = {
-  '6h': { lookbackHours: 6, granularity: '15min' },
-  '12h': { lookbackHours: 12, granularity: 'hour' },
-  '1d': { lookbackHours: 24, granularity: 'hour' },
-  '7d': { lookbackHours: 168, granularity: 'day' },
-  '30d': { lookbackHours: 720, granularity: 'day' },
-  '3m': { lookbackHours: 2160, granularity: 'month' },
-  '6m': { lookbackHours: 4380, granularity: 'month' },
-  '12m': { lookbackHours: 8760, granularity: 'month' },
-  '24m': { lookbackHours: 17520, granularity: 'month' },
-};
-
 @Component({
   selector: 'app-revenue-billing',
   standalone: true,
@@ -65,8 +48,6 @@ export class RevenueBillingComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   lastHoveredRevenueByTld: any = null;
   lastHoveredRevenueByOp: any = null;
-  selectedRange = signal('12m');
-  rangeKeys = Object.keys(RANGE_CONFIG);
 
   data = computed(() => this.dashService.revenueBilling());
 
@@ -168,7 +149,7 @@ export class RevenueBillingComponent implements OnInit {
     private drillDown: DrillDownService,
   ) {
     combineLatest([
-      toObservable(this.selectedRange),
+      toObservable(this.dashService.selectedTimeRange),
       toObservable(this.dashService.selectedTlds),
       toObservable(this.dashService.selectedRegistrarIds),
     ]).pipe(
@@ -186,10 +167,6 @@ export class RevenueBillingComponent implements OnInit {
 
   ngOnInit() {
     // Initial fetch is handled by the observable above
-  }
-
-  onRangeChange(range: string) {
-    this.selectedRange.set(range);
   }
 
   onRevenueByTldClick(event: any) {

--- a/console-webapp/src/app/registry-dash/overview/overview.component.html
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.html
@@ -10,7 +10,7 @@
   }
 
   @if (dashService.overview(); as overview) {
-    <p class="time-indicator">Showing data for the last 12 months</p>
+    <p class="time-indicator">Showing data for the last {{ dashService.timeRangeLabel() }}</p>
     <div class="summary-cards">
       <mat-card appearance="outlined">
         <mat-card-content>
@@ -77,7 +77,7 @@
       <mat-card appearance="outlined" class="chart-card" *ngIf="renewalRateOptions()">
         <mat-card-content>
           <h3 class="chart-title">Renewal Rate by TLD</h3>
-          <p class="chart-description">Percentage of expiring domains that were renewed (vs. deleted/expired) per TLD over the last 12 months. The dashed line marks the 85% industry benchmark.</p>
+          <p class="chart-description">Percentage of expiring domains that were renewed (vs. deleted/expired) per TLD over the selected time period. The dashed line marks the 85% industry benchmark.</p>
           <div appLongPress (longPress)="onRenewalLongPress()">
             <div echarts [options]="renewalRateOptions()!" [theme]="'ud-brand'" class="echart"
                  (chartClick)="onRenewalClick($event)"

--- a/console-webapp/src/app/registry-dash/overview/overview.component.ts
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.ts
@@ -18,7 +18,7 @@ import { combineLatest, switchMap, EMPTY, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { CommonModule } from '@angular/common';
 import { NgxEchartsDirective } from 'ngx-echarts';
-import { RegistryDashService } from '../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG } from '../registry-dash.service';
 import { UD_ECHARTS_PROVIDER, withDrillDown } from '../ud-echarts';
 import { DrillDownService } from '../drilldown/drilldown.service';
 import { LongPressDirective } from '../drilldown/long-press.directive';
@@ -149,17 +149,18 @@ export class OverviewComponent {
     protected dashService: RegistryDashService,
     protected drillDown: DrillDownService,
   ) {
-    // Re-fetch when global filters change
     combineLatest([
+      toObservable(this.dashService.selectedTimeRange),
       toObservable(this.dashService.selectedTlds),
       toObservable(this.dashService.selectedRegistrarIds),
     ]).pipe(
-      switchMap(([tlds, regIds]) => {
+      switchMap(([range, tlds, regIds]) => {
+        const config = RANGE_CONFIG[range];
         const ft = tlds.length > 0 ? tlds : undefined;
         const fr = regIds.length > 0 ? regIds : undefined;
         this.dashService.getOverview(ft, fr).subscribe();
-        this.dashService.getDomainActivity(undefined, undefined, ft, fr).subscribe();
-        return this.dashService.getForecasting(undefined, undefined, ft, fr).pipe(
+        this.dashService.getDomainActivity(config.lookbackHours, config.granularity, ft, fr).subscribe();
+        return this.dashService.getForecasting(config.lookbackHours, config.granularity, ft, fr).pipe(
           catchError(() => EMPTY)
         );
       }),

--- a/console-webapp/src/app/registry-dash/registry-dash.service.ts
+++ b/console-webapp/src/app/registry-dash/registry-dash.service.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Injectable, computed, signal } from '@angular/core';
+import { Injectable, WritableSignal, computed, signal } from '@angular/core';
 import { Observable, catchError, tap, throwError } from 'rxjs';
 import { BackendService } from '../shared/services/backend.service';
 
@@ -184,6 +184,31 @@ export interface FilterOptionsData {
   registrars: FilterRegistrarOption[];
 }
 
+export interface RangeConfigEntry {
+  lookbackHours: number;
+  granularity: string;
+}
+
+export const RANGE_CONFIG: Record<string, RangeConfigEntry> = {
+  '6h': { lookbackHours: 6, granularity: '15min' },
+  '12h': { lookbackHours: 12, granularity: 'hour' },
+  '1d': { lookbackHours: 24, granularity: 'hour' },
+  '7d': { lookbackHours: 168, granularity: 'day' },
+  '30d': { lookbackHours: 720, granularity: 'day' },
+  '3m': { lookbackHours: 2160, granularity: 'month' },
+  '6m': { lookbackHours: 4380, granularity: 'month' },
+  '12m': { lookbackHours: 8760, granularity: 'month' },
+  '24m': { lookbackHours: 17520, granularity: 'month' },
+};
+
+export const RANGE_KEYS = Object.keys(RANGE_CONFIG);
+
+export const RANGE_LABELS: Record<string, string> = {
+  '6h': '6 Hours', '12h': '12 Hours', '1d': '1 Day', '7d': '7 Days',
+  '30d': '30 Days', '3m': '3 Months', '6m': '6 Months',
+  '12m': '12 Months', '24m': '24 Months',
+};
+
 @Injectable({ providedIn: 'root' })
 export class RegistryDashService {
   overview = signal<OverviewData | undefined>(undefined);
@@ -213,6 +238,13 @@ export class RegistryDashService {
   selectedRegistrarIds = signal<string[]>([]);
   selectedTlds = signal<string[]>([]);
   filterPanelExpanded = signal(false);
+
+  // --- Global timeframe state ---
+  selectedTimeRange: WritableSignal<string> = signal('12m');
+  selectedRangeConfig = computed(() => RANGE_CONFIG[this.selectedTimeRange()]);
+  timeRangeLookbackHours = computed(() => this.selectedRangeConfig().lookbackHours);
+  timeRangeGranularity = computed(() => this.selectedRangeConfig().granularity);
+  timeRangeLabel = computed(() => RANGE_LABELS[this.selectedTimeRange()] ?? this.selectedTimeRange());
 
   availableRegistrars = computed(() => this.filterOptions()?.registrars ?? []);
   availableTlds = computed(() => this.filterOptions()?.tlds ?? []);


### PR DESCRIPTION
## Summary
- Move the per-tab timeframe selector (6h–24m) into the global filter panel, so it persists across all dashboard tabs
- Add timeframe chip in collapsed filter panel mode, toggle group in expanded mode
- Overview page now uses dynamic timeframe instead of hardcoded 12-month lookback
- "Clear All" resets TLD/Registrar filters but preserves the timeframe (it's a zoom level, not a filter)

## Changes
- **registry-dash.service.ts** — Added `RANGE_CONFIG`, `RangeConfigEntry`, `RANGE_KEYS`, `RANGE_LABELS`, and global timeframe signals (`selectedTimeRange`, `timeRangeLookbackHours`, `timeRangeGranularity`, `timeRangeLabel`)
- **filter-panel** — Added timeframe chip (collapsed) and `mat-button-toggle-group` (expanded)
- **domain-activity, revenue-billing, financials, forecasting** — Removed local `selectedRange` signals and toggle groups; now read from `dashService.selectedTimeRange`
- **overview** — Dynamic time indicator text and passes lookback/granularity to API calls
- **revenue-billing.component.spec.ts** — Updated to use service signal for range changes

## Test plan
- [x] `ng build` compiles cleanly
- [x] All 68 unit tests pass (`npm test`)
- [ ] Manual: timeframe toggle in filter panel persists across tab switches
- [ ] Manual: "Clear All" does not reset timeframe
- [ ] Manual: Overview updates dynamically with timeframe changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)