### PR TITLE
feat(registry-dash): add horizontal-bar chart type + save view dialog

### DIFF
--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
@@ -15,6 +15,7 @@
 import { Component, computed, inject, model, OnInit, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
 import { MaterialModule } from '../../../material.module';
 import { RegistryDashService } from '../../registry-dash.service';
 import { DATA_SOURCE_SCHEMAS } from '../data-source-schemas';
@@ -26,6 +27,7 @@ import {
   SavedExploreView,
 } from '../explore.models';
 import { ExploreService } from '../explore.service';
+import { SaveViewDialogComponent } from '../save-view-dialog.component';
 
 const CHART_TYPES: { value: ChartType; icon: string; label: string }[] = [
   { value: 'bar', icon: 'bar_chart', label: 'Bar' },
@@ -33,6 +35,7 @@ const CHART_TYPES: { value: ChartType; icon: string; label: string }[] = [
   { value: 'pie', icon: 'pie_chart', label: 'Pie' },
   { value: 'stacked-bar', icon: 'stacked_bar_chart', label: 'Stacked' },
   { value: 'area', icon: 'area_chart', label: 'Area' },
+  { value: 'horizontal-bar', icon: 'align_horizontal_left', label: 'Horizontal Bar' },
 ];
 
 const GRANULARITY_OPTIONS = [
@@ -50,6 +53,7 @@ const GRANULARITY_OPTIONS = [
 })
 export class ExploreBuilderComponent implements OnInit {
   private dashService = inject(RegistryDashService);
+  private dialog = inject(MatDialog);
   exploreService = inject(ExploreService);
 
   query = model.required<ExploreQuery>();
@@ -177,10 +181,17 @@ export class ExploreBuilderComponent implements OnInit {
   // --- Save / Load ---
 
   saveView(): void {
-    const name = prompt('Enter a name for this view:');
-    if (name) {
-      this.exploreService.saveRecentView(name, this.query(), this.chartType());
-    }
+    this.dialog
+      .open(SaveViewDialogComponent, {
+        width: '360px',
+        data: { title: 'Save View', label: 'View name' },
+      })
+      .afterClosed()
+      .subscribe(name => {
+        if (name) {
+          this.exploreService.saveRecentView(name, this.query(), this.chartType());
+        }
+      });
   }
 
   loadView(view: SavedExploreView): void {
@@ -194,10 +205,17 @@ export class ExploreBuilderComponent implements OnInit {
   }
 
   saveNamedView(): void {
-    const name = prompt('Enter a name for this saved view:');
-    if (name) {
-      this.exploreService.saveNamedView(name, this.query(), this.chartType());
-    }
+    this.dialog
+      .open(SaveViewDialogComponent, {
+        width: '360px',
+        data: { title: 'Save to Server', label: 'View name' },
+      })
+      .afterClosed()
+      .subscribe(name => {
+        if (name) {
+          this.exploreService.saveNamedView(name, this.query(), this.chartType());
+        }
+      });
   }
 
   deleteNamedView(view: SavedExploreView, event: Event): void {

--- a/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-chart-builder.ts
@@ -34,6 +34,8 @@ export function buildChartOptions(
       return buildAreaOptions(result, primaryDim, secondaryDim, metricColumn);
     case 'stacked-bar':
       return buildStackedBarOptions(result, primaryDim, secondaryDim, metricColumn);
+    case 'horizontal-bar':
+      return buildHorizontalBarOptions(result, primaryDim, secondaryDim, metricColumn);
     case 'bar':
     default:
       return buildBarOptions(result, primaryDim, secondaryDim, metricColumn);
@@ -136,4 +138,52 @@ function buildStackedBarOptions(
     s.stack = 'total';
   }
   return opts;
+}
+
+function buildHorizontalBarOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string | null, metric: string,
+): any {
+  if (secondaryDim) {
+    return buildGroupedHorizontalBarOptions(result, primaryDim, secondaryDim, metric);
+  }
+  const categories = [...new Set(result.rows.map(r => String(r[primaryDim] ?? '')))];
+  const values = categories.map(cat => {
+    const row = result.rows.find(r => String(r[primaryDim]) === cat);
+    return Number(row?.[metric] ?? 0);
+  });
+  const maxLabelLen = Math.max(...categories.map(c => c.length));
+  return {
+    tooltip: { trigger: 'axis' },
+    yAxis: { type: 'category', data: categories, inverse: true },
+    xAxis: { type: 'value' },
+    series: [{ type: 'bar', data: values }],
+    grid: { left: Math.min(maxLabelLen * 7 + 20, 200) },
+  };
+}
+
+function buildGroupedHorizontalBarOptions(
+  result: ExploreResult, primaryDim: string,
+  secondaryDim: string, metric: string,
+): any {
+  const categories = [...new Set(result.rows.map(r => String(r[primaryDim] ?? '')))];
+  const groups = [...new Set(result.rows.map(r => String(r[secondaryDim] ?? '')))];
+  const series = groups.map(group => ({
+    name: group,
+    type: 'bar' as const,
+    data: categories.map(cat => {
+      const row = result.rows.find(
+        r => String(r[primaryDim]) === cat && String(r[secondaryDim]) === group);
+      return Number(row?.[metric] ?? 0);
+    }),
+  }));
+  const maxLabelLen = Math.max(...categories.map(c => c.length));
+  return {
+    tooltip: { trigger: 'axis' },
+    legend: { type: 'scroll', bottom: 0 },
+    yAxis: { type: 'category', data: categories, inverse: true },
+    xAxis: { type: 'value' },
+    series,
+    grid: { left: Math.min(maxLabelLen * 7 + 20, 200), bottom: 60 },
+  };
 }

--- a/console-webapp/src/app/registry-dash/explore/explore.models.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.models.ts
@@ -20,7 +20,7 @@ export type DataSourceType =
   | 'EXPIRATION_CURVE'
   | 'PRICING_RULES';
 
-export type ChartType = 'bar' | 'line' | 'pie' | 'stacked-bar' | 'area';
+export type ChartType = 'bar' | 'line' | 'pie' | 'stacked-bar' | 'area' | 'horizontal-bar';
 
 export interface MetricSpec {
   field: string;

--- a/console-webapp/src/app/registry-dash/explore/save-view-dialog.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/save-view-dialog.component.ts
@@ -1,0 +1,58 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '../../material.module';
+
+export interface SaveViewDialogData {
+  title: string;
+  label: string;
+}
+
+@Component({
+  selector: 'app-save-view-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MaterialModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+    <mat-dialog-content>
+      <mat-form-field appearance="outline" style="width: 100%; margin-top: 8px">
+        <mat-label>{{ data.label }}</mat-label>
+        <input matInput [(ngModel)]="name" (keydown.enter)="onSave()" cdkFocusInitial />
+      </mat-form-field>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+      <button mat-flat-button color="primary" [disabled]="!name.trim()" (click)="onSave()">Save</button>
+    </mat-dialog-actions>
+  `,
+})
+export class SaveViewDialogComponent {
+  name = '';
+
+  constructor(
+    private dialogRef: MatDialogRef<SaveViewDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: SaveViewDialogData,
+  ) {}
+
+  onSave(): void {
+    const trimmed = this.name.trim();
+    if (trimmed) {
+      this.dialogRef.close(trimmed);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `horizontal-bar` as a new chart type in Data Exploration, completing chart type parity with dashboard tabs (Overview's Registrar Market Share, etc.)
- Replace native browser `prompt()` with Material dialog for save view name input

## Changes
- `explore.models.ts` — Add `'horizontal-bar'` to `ChartType` union
- `explore-chart-builder.ts` — Add `buildHorizontalBarOptions` and `buildGroupedHorizontalBarOptions` (axes swapped, `inverse: true`, dynamic `grid.left`)
- `explore-builder.component.ts` — Add horizontal-bar to CHART_TYPES array, replace `prompt()` with `MatDialog`
- `save-view-dialog.component.ts` (new) — Standalone Material dialog for view name input

## Test plan
- [x] Horizontal bar chart renders correctly with real data (validated against alpha)
- [x] Existing chart types (bar, line, pie, stacked-bar, area) still work
- [x] Save View dialog opens as Material modal (not browser prompt)
- [x] Save View label text not clipped
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)