### PR TITLE
feat(registry-dash): explore time bucket selector + time-of-day pickers

### DIFF
--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.html
@@ -55,6 +55,17 @@
     </mat-button-toggle-group>
   </div>
 
+  <!-- Time Bucket Selector -->
+  <div class="builder-section" *ngIf="showDateRange()">
+    <h4>Time Range</h4>
+    <mat-button-toggle-group [value]="selectedBucket()"
+                             (change)="onBucketChange($event.value)">
+      <mat-button-toggle *ngFor="let key of rangeKeys" [value]="key">
+        {{ key }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   <!-- Filters -->
   <div class="builder-section">
     <h4>Filters</h4>
@@ -85,22 +96,36 @@
 
       <!-- Date Range -->
       <ng-container *ngIf="showDateRange()">
-        <mat-form-field appearance="outline">
-          <mat-label>Start Date</mat-label>
-          <input matInput [matDatepicker]="startDatePicker"
-                 [value]="startDateValue()"
-                 (dateChange)="onDateStartChange($event.value)">
-          <mat-datepicker-toggle matIconSuffix [for]="startDatePicker"></mat-datepicker-toggle>
-          <mat-datepicker #startDatePicker></mat-datepicker>
-        </mat-form-field>
-        <mat-form-field appearance="outline">
-          <mat-label>End Date</mat-label>
-          <input matInput [matDatepicker]="endDatePicker"
-                 [value]="endDateValue()"
-                 (dateChange)="onDateEndChange($event.value)">
-          <mat-datepicker-toggle matIconSuffix [for]="endDatePicker"></mat-datepicker-toggle>
-          <mat-datepicker #endDatePicker></mat-datepicker>
-        </mat-form-field>
+        <div class="date-time-row">
+          <mat-form-field appearance="outline">
+            <mat-label>Start Date</mat-label>
+            <input matInput [matDatepicker]="startDatePicker"
+                   [value]="startDateValue()"
+                   (dateChange)="onDateStartChange($event.value)">
+            <mat-datepicker-toggle matIconSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #startDatePicker></mat-datepicker>
+          </mat-form-field>
+          <mat-form-field appearance="outline" class="time-field">
+            <mat-label>Start Time</mat-label>
+            <input matInput type="time" [ngModel]="startTime"
+                   (ngModelChange)="onStartTimeChange($event)">
+          </mat-form-field>
+        </div>
+        <div class="date-time-row">
+          <mat-form-field appearance="outline">
+            <mat-label>End Date</mat-label>
+            <input matInput [matDatepicker]="endDatePicker"
+                   [value]="endDateValue()"
+                   (dateChange)="onDateEndChange($event.value)">
+            <mat-datepicker-toggle matIconSuffix [for]="endDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #endDatePicker></mat-datepicker>
+          </mat-form-field>
+          <mat-form-field appearance="outline" class="time-field">
+            <mat-label>End Time</mat-label>
+            <input matInput type="time" [ngModel]="endTime"
+                   (ngModelChange)="onEndTimeChange($event)">
+          </mat-form-field>
+        </div>
       </ng-container>
     </div>
   </div>

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.scss
@@ -35,6 +35,22 @@
   }
 }
 
+.date-time-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+
+  mat-form-field {
+    flex: 1;
+    min-width: 140px;
+  }
+
+  .time-field {
+    flex: 0 0 120px;
+    min-width: 120px;
+  }
+}
+
 .builder-actions {
   display: flex;
   gap: 8px;

--- a/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore-builder/explore-builder.component.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, computed, inject, model, OnInit, output } from '@angular/core';
+import { Component, computed, inject, model, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MaterialModule } from '../../../material.module';
-import { RegistryDashService } from '../../registry-dash.service';
+import { RANGE_CONFIG, RANGE_KEYS, RegistryDashService } from '../../registry-dash.service';
 import { DATA_SOURCE_SCHEMAS } from '../data-source-schemas';
 import {
   ChartType,
@@ -62,6 +62,11 @@ export class ExploreBuilderComponent implements OnInit {
   readonly dataSourceKeys = Object.keys(DATA_SOURCE_SCHEMAS) as DataSourceType[];
   readonly chartTypes = CHART_TYPES;
   readonly granularityOptions = GRANULARITY_OPTIONS;
+  readonly rangeKeys = RANGE_KEYS;
+
+  selectedBucket = signal<string | null>(null);
+  startTime: string | null = null;
+  endTime: string | null = null;
 
   availableTlds = computed(() => this.dashService.availableTlds());
   availableRegistrars = computed(() => this.dashService.availableRegistrars());
@@ -79,6 +84,10 @@ export class ExploreBuilderComponent implements OnInit {
 
   ngOnInit(): void {
     this.exploreService.loadSavedViews();
+    const globalRange = this.dashService.selectedTimeRange();
+    if (globalRange && RANGE_CONFIG[globalRange]) {
+      this.onBucketChange(globalRange);
+    }
   }
 
   // --- Handlers ---
@@ -109,6 +118,29 @@ export class ExploreBuilderComponent implements OnInit {
     }));
   }
 
+  onBucketChange(bucket: string): void {
+    this.selectedBucket.set(bucket);
+    const config = RANGE_CONFIG[bucket];
+    if (!config) return;
+
+    const now = new Date();
+    const start = new Date(now.getTime() - config.lookbackHours * 3600_000);
+    this.startTime = null;
+    this.endTime = null;
+
+    this.query.update(q => ({
+      ...q,
+      filters: {
+        ...q.filters,
+        dateRange: {
+          start: this.formatDate(start),
+          end: this.formatDate(now),
+        },
+      },
+      granularity: config.granularity,
+    }));
+  }
+
   onGranularityChange(value: string): void {
     this.query.update(q => ({ ...q, granularity: value }));
   }
@@ -133,21 +165,26 @@ export class ExploreBuilderComponent implements OnInit {
 
   startDateValue = computed(() => {
     const s = this.query().filters.dateRange?.start;
-    return s ? new Date(s + 'T00:00:00') : null;
+    if (!s) return null;
+    const datePart = s.substring(0, 10);
+    return new Date(datePart + 'T00:00:00');
   });
 
   endDateValue = computed(() => {
     const e = this.query().filters.dateRange?.end;
-    return e ? new Date(e + 'T00:00:00') : null;
+    if (!e) return null;
+    const datePart = e.substring(0, 10);
+    return new Date(datePart + 'T00:00:00');
   });
 
   onDateStartChange(value: Date | null): void {
+    this.selectedBucket.set(null);
     this.query.update(q => ({
       ...q,
       filters: {
         ...q.filters,
         dateRange: {
-          start: value ? this.formatDate(value) : '',
+          start: value ? this.formatDateWithTime(value, this.startTime) : '',
           end: q.filters.dateRange?.end ?? '',
         },
       },
@@ -155,16 +192,55 @@ export class ExploreBuilderComponent implements OnInit {
   }
 
   onDateEndChange(value: Date | null): void {
+    this.selectedBucket.set(null);
     this.query.update(q => ({
       ...q,
       filters: {
         ...q.filters,
         dateRange: {
           start: q.filters.dateRange?.start ?? '',
-          end: value ? this.formatDate(value) : '',
+          end: value ? this.formatDateWithTime(value, this.endTime) : '',
         },
       },
     }));
+  }
+
+  onStartTimeChange(time: string): void {
+    this.startTime = time;
+    this.selectedBucket.set(null);
+    const currentStart = this.query().filters.dateRange?.start;
+    if (currentStart) {
+      const datePart = currentStart.substring(0, 10);
+      this.query.update(q => ({
+        ...q,
+        filters: {
+          ...q.filters,
+          dateRange: {
+            start: time ? `${datePart}T${time}` : datePart,
+            end: q.filters.dateRange?.end ?? '',
+          },
+        },
+      }));
+    }
+  }
+
+  onEndTimeChange(time: string): void {
+    this.endTime = time;
+    this.selectedBucket.set(null);
+    const currentEnd = this.query().filters.dateRange?.end;
+    if (currentEnd) {
+      const datePart = currentEnd.substring(0, 10);
+      this.query.update(q => ({
+        ...q,
+        filters: {
+          ...q.filters,
+          dateRange: {
+            start: q.filters.dateRange?.start ?? '',
+            end: time ? `${datePart}T${time}` : datePart,
+          },
+        },
+      }));
+    }
   }
 
   private formatDate(d: Date): string {
@@ -172,6 +248,11 @@ export class ExploreBuilderComponent implements OnInit {
     const month = String(d.getMonth() + 1).padStart(2, '0');
     const day = String(d.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+  }
+
+  private formatDateWithTime(d: Date, time: string | null): string {
+    const datePart = this.formatDate(d);
+    return time ? `${datePart}T${time}` : datePart;
   }
 
   // --- Save / Load ---

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
@@ -33,7 +33,9 @@ import google.registry.ui.server.console.ConsoleApiParams;
 import jakarta.inject.Inject;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -122,15 +124,8 @@ public class RegistryDashExploreAction extends ConsoleApiAction {
     Instant endDate = null;
     if (filters.getDateRange() != null) {
       try {
-        startDate =
-            LocalDate.parse(filters.getDateRange().getStart())
-                .atStartOfDay()
-                .toInstant(ZoneOffset.UTC);
-        endDate =
-            LocalDate.parse(filters.getDateRange().getEnd())
-                .plusDays(1)
-                .atStartOfDay()
-                .toInstant(ZoneOffset.UTC);
+        startDate = parseDateTime(filters.getDateRange().getStart(), false);
+        endDate = parseDateTime(filters.getDateRange().getEnd(), true);
       } catch (Exception e) {
         consoleApiParams.response().setStatus(SC_BAD_REQUEST);
         consoleApiParams.response().setPayload("{\"error\":\"Invalid date range format\"}");
@@ -246,6 +241,18 @@ public class RegistryDashExploreAction extends ConsoleApiAction {
       return inst.toString();
     }
     return val;
+  }
+
+  static Instant parseDateTime(String value, boolean isEndDate) {
+    try {
+      return LocalDateTime.parse(value).toInstant(ZoneOffset.UTC);
+    } catch (DateTimeParseException e) {
+      LocalDate date = LocalDate.parse(value);
+      if (isEndDate) {
+        return date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+      }
+      return date.atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
   }
 
   private static List<String> mapActivityType(String friendlyName) {

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashExploreActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashExploreActionTest.java
@@ -1,0 +1,63 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+/** Tests for date/time parsing in {@link RegistryDashExploreAction}. */
+class RegistryDashExploreActionTest {
+
+  @Test
+  void parseDateTime_dateOnlyStart_returnsStartOfDay() {
+    Instant result = RegistryDashExploreAction.parseDateTime("2026-04-21", false);
+    assertThat(result).isEqualTo(Instant.parse("2026-04-21T00:00:00Z"));
+  }
+
+  @Test
+  void parseDateTime_dateOnlyEnd_returnsNextDayStartOfDay() {
+    Instant result = RegistryDashExploreAction.parseDateTime("2026-04-21", true);
+    assertThat(result).isEqualTo(Instant.parse("2026-04-22T00:00:00Z"));
+  }
+
+  @Test
+  void parseDateTime_datetimeStart_returnsExactTime() {
+    Instant result = RegistryDashExploreAction.parseDateTime("2026-04-21T14:30:00", false);
+    assertThat(result).isEqualTo(Instant.parse("2026-04-21T14:30:00Z"));
+  }
+
+  @Test
+  void parseDateTime_datetimeEnd_returnsExactTime() {
+    Instant result = RegistryDashExploreAction.parseDateTime("2026-04-21T14:30:00", true);
+    assertThat(result).isEqualTo(Instant.parse("2026-04-21T14:30:00Z"));
+  }
+
+  @Test
+  void parseDateTime_mixedFormats_dateStartDatetimeEnd() {
+    Instant start = RegistryDashExploreAction.parseDateTime("2026-04-14", false);
+    Instant end = RegistryDashExploreAction.parseDateTime("2026-04-21T14:30:00", true);
+    assertThat(start).isEqualTo(Instant.parse("2026-04-14T00:00:00Z"));
+    assertThat(end).isEqualTo(Instant.parse("2026-04-21T14:30:00Z"));
+  }
+
+  @Test
+  void parseDateTime_invalidFormat_throws() {
+    assertThrows(Exception.class, () ->
+        RegistryDashExploreAction.parseDateTime("not-a-date", false));
+  }
+}


### PR DESCRIPTION
## Summary
- Add time range bucket selector (6h, 12h, 1d, 7d, 30d, 3m, 6m, 12m, 24m) to Data Exploration page
- Add time-of-day inputs next to date pickers for precise datetime filtering
- Backend `RegistryDashExploreAction` now accepts both `YYYY-MM-DD` and `YYYY-MM-DDTHH:mm:ss` formats
- Bucket selector reads from global timeframe on init, mutual exclusivity with manual date/time edits
- Auto-granularity: bucket selection sets granularity to match RANGE_CONFIG

## Test plan
- [x] Angular build passes
- [x] Backend unit tests pass (6/6 — date-only, datetime, mixed, invalid format)
- [x] Chrome testing against local dev test server:
  - [x] 12m pre-selected on load, dates auto-populated
  - [x] Bucket change (7d) updates dates and granularity
  - [x] Manual date change deselects bucket
  - [x] Time input (02:30 PM) sends `YYYY-MM-DDTHH:mm` in payload
  - [x] Backend returns 200 OK with mixed format
  - [x] Re-selecting bucket clears time fields
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)