### PR TITLE
feat(registry-dash): add navigate-to-explore buttons on dashboard charts

### DIFF
--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
@@ -53,7 +53,12 @@
   <!-- Charts -->
   <div class="charts-row" *ngIf="data()">
     <div class="chart-container" *ngIf="activityByTldOptions()">
-      <h3>Activity Breakdown by TLD</h3>
+      <div class="chart-title-row">
+        <h3>Activity Breakdown by TLD</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreActivityByTld()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Total domain transactions grouped by TLD and operation type for the selected time period.</p>
       <div appLongPress (longPress)="onActivityByTldLongPress()">
         <div echarts [options]="activityByTldOptions()!" [theme]="'ud-brand'" class="chart"
@@ -63,7 +68,12 @@
       </div>
     </div>
     <div class="chart-container" *ngIf="domainCountsBarOptions()">
-      <h3>Current Domain Counts by TLD</h3>
+      <div class="chart-title-row">
+        <h3>Current Domain Counts by TLD</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreDomainCounts()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Current number of active (non-deleted) domains per TLD. This count is independent of the selected time period.</p>
       <div appLongPress (longPress)="onDomainCountsLongPress()">
         <div echarts [options]="domainCountsBarOptions()!" [theme]="'ud-brand'" class="chart"

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.scss
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.scss
@@ -73,6 +73,17 @@
   margin-bottom: 24px;
 }
 
+.chart-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.explore-btn {
+  opacity: 0.5;
+  &:hover { opacity: 1; }
+}
+
 .chart-container {
   background: var(--ud-surface-muted);
   border-radius: var(--ud-radius-md);

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
@@ -19,8 +19,9 @@ import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../ud-echarts';
-import { RegistryDashService, RANGE_CONFIG } from '../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG, computeDateRange } from '../registry-dash.service';
 import { DrillDownService } from '../drilldown/drilldown.service';
+import { ExploreService } from '../explore/explore.service';
 import { withDrillDown } from '../ud-echarts';
 import { LongPressDirective } from '../drilldown/long-press.directive';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
@@ -162,6 +163,7 @@ export class DomainActivityComponent implements OnInit {
   constructor(
     public dashService: RegistryDashService,
     private drillDown: DrillDownService,
+    private exploreService: ExploreService,
   ) {
     combineLatest([
       toObservable(this.dashService.selectedTimeRange),
@@ -212,5 +214,37 @@ export class DomainActivityComponent implements OnInit {
     if (this.lastHoveredDomainCounts?.name) {
       this.drillDown.drillDownDomainCountsByTld(this.lastHoveredDomainCounts.name);
     }
+  }
+
+  private buildFilters(): { tlds?: string[]; registrarIds?: string[] } {
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+    return {
+      ...(tlds.length > 0 ? { tlds: [...tlds] } : {}),
+      ...(regIds.length > 0 ? { registrarIds: [...regIds] } : {}),
+    };
+  }
+
+  exploreActivityByTld() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'DOMAIN_ACTIVITY',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['tld', 'activity_type'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'bar');
+  }
+
+  exploreDomainCounts() {
+    this.exploreService.navigateToExplore({
+      dataSource: 'DOMAIN_COUNTS',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['tld'],
+      filters: this.buildFilters(),
+    }, 'horizontal-bar');
   }
 }

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -65,6 +65,15 @@ export class ExploreComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const pending = this.exploreService.pendingQuery();
+    if (pending) {
+      this.query.set(pending.query);
+      this.chartType.set(pending.chartType);
+      this.exploreService.pendingQuery.set(null);
+      this.runQuery();
+      return;
+    }
+
     if (this.dashService.hasActiveFilters()) {
       const tlds = this.dashService.selectedTlds();
       const regIds = this.dashService.selectedRegistrarIds();

--- a/console-webapp/src/app/registry-dash/explore/explore.service.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.service.ts
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Injectable, signal } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -26,16 +27,24 @@ const MAX_SAVED_VIEWS = 20;
 
 @Injectable({ providedIn: 'root' })
 export class ExploreService {
+  private router = inject(Router);
+
   result = signal<ExploreResult | undefined>(undefined);
   loading = signal(false);
   error = signal<string | undefined>(undefined);
   savedViews = signal<SavedExploreView[]>([]);
   savingView = signal(false);
+  pendingQuery = signal<{ query: ExploreQuery; chartType: ChartType } | null>(null);
 
   constructor(
     private backend: BackendService,
     private dashService: RegistryDashService,
   ) {}
+
+  navigateToExplore(query: ExploreQuery, chartType: ChartType): void {
+    this.pendingQuery.set({ query, chartType });
+    this.router.navigate(['/registry-dash/explore']);
+  }
 
   explore(query: ExploreQuery): Observable<ExploreResult> {
     this.loading.set(true);

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
@@ -53,7 +53,12 @@
   <!-- Charts: full-width, net growth first -->
   <div *ngIf="data()">
     <div class="chart-container full-width" *ngIf="netGrowthOptions()">
-      <h3>Net Growth Projection</h3>
+      <div class="chart-title-row">
+        <h3>Net Growth Projection</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreNetGrowth()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Net domain growth per period (creates minus deletes). Dashed lines show projected values based on the selected forecast method.</p>
       <div appLongPress (longPress)="onNetGrowthLongPress()">
         <div echarts [options]="netGrowthOptions()!" [theme]="'ud-brand'" class="chart"
@@ -62,7 +67,12 @@
       </div>
     </div>
     <div class="chart-container full-width" *ngIf="expirationCurveOptions()">
-      <h3>Domain Expirations by TLD</h3>
+      <div class="chart-title-row">
+        <h3>Domain Expirations by TLD</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreExpirationCurve()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Upcoming domain expirations grouped by TLD. Shows when domains are due to expire and may need renewal.</p>
       <div appLongPress (longPress)="onExpirationLongPress()">
         <div echarts [options]="expirationCurveOptions()!" [theme]="'ud-brand'" class="chart"

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.scss
@@ -59,6 +59,17 @@
   }
 }
 
+.chart-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.explore-btn {
+  opacity: 0.5;
+  &:hover { opacity: 1; }
+}
+
 .chart-container {
   background: var(--ud-surface-muted);
   border-radius: var(--ud-radius-md);

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
@@ -19,9 +19,9 @@ import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../../ud-echarts';
-import { RegistryDashService } from '../../registry-dash.service';
-import { RANGE_CONFIG } from '../../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG, computeDateRange } from '../../registry-dash.service';
 import { DrillDownService } from '../../drilldown/drilldown.service';
+import { ExploreService } from '../../explore/explore.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
 
@@ -265,6 +265,7 @@ export class ForecastingComponent implements OnInit {
   constructor(
     public dashService: RegistryDashService,
     private drillDown: DrillDownService,
+    private exploreService: ExploreService,
   ) {
     combineLatest([
       toObservable(this.dashService.selectedTimeRange),
@@ -363,6 +364,43 @@ export class ForecastingComponent implements OnInit {
       }
     }
     return forecast;
+  }
+
+  private buildFilters(): { tlds?: string[]; registrarIds?: string[] } {
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+    return {
+      ...(tlds.length > 0 ? { tlds: [...tlds] } : {}),
+      ...(regIds.length > 0 ? { registrarIds: [...regIds] } : {}),
+    };
+  }
+
+  exploreExpirationCurve() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'EXPIRATION_CURVE',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['month', 'tld'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'area');
+  }
+
+  exploreNetGrowth() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'DOMAIN_ACTIVITY',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['period'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'line');
   }
 
   private generateFuturePeriods(periods: string[], count: number): string[] {

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
@@ -50,7 +50,12 @@
   <!-- Charts -->
   <div *ngIf="data()">
     <div class="chart-container full-width" *ngIf="revenueLineOptions()">
-      <h3>Registry Revenue by TLD</h3>
+      <div class="chart-title-row">
+        <h3>Registry Revenue by TLD</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreRevenueByTld()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Net registry revenue per TLD over the selected period — what the registry received after RSP fees.</p>
       <div appLongPress (longPress)="onRevenueByTldLongPress()">
         <div echarts [options]="revenueLineOptions()!" [theme]="'ud-brand'" class="chart"
@@ -60,7 +65,12 @@
       </div>
     </div>
     <div class="chart-container full-width" *ngIf="operationBarOptions()">
-      <h3>Registry Revenue by Operation</h3>
+      <div class="chart-title-row">
+        <h3>Registry Revenue by Operation</h3>
+        <button mat-icon-button class="explore-btn" (click)="exploreRevenueByOperation()" matTooltip="Explore this data">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+      </div>
       <p class="chart-description">Net registry revenue by operation type over the selected period — CREATE, RENEW, TRANSFER, and RESTORE amounts after RSP fees.</p>
       <div appLongPress (longPress)="onRevenueByOpLongPress()">
         <div echarts [options]="operationBarOptions()!" [theme]="'ud-brand'" class="chart"

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.scss
@@ -53,6 +53,17 @@
   }
 }
 
+.chart-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.explore-btn {
+  opacity: 0.5;
+  &:hover { opacity: 1; }
+}
+
 .chart-container {
   background: var(--ud-surface-muted);
   border-radius: var(--ud-radius-md);

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
@@ -19,8 +19,9 @@ import { combineLatest, EMPTY, switchMap, catchError } from 'rxjs';
 import { MaterialModule } from '../../../material.module';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import { UD_ECHARTS_PROVIDER } from '../../ud-echarts';
-import { RegistryDashService, RANGE_CONFIG } from '../../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG, computeDateRange } from '../../registry-dash.service';
 import { DrillDownService } from '../../drilldown/drilldown.service';
+import { ExploreService } from '../../explore/explore.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
 
@@ -147,6 +148,7 @@ export class RevenueBillingComponent implements OnInit {
   constructor(
     public dashService: RegistryDashService,
     private drillDown: DrillDownService,
+    private exploreService: ExploreService,
   ) {
     combineLatest([
       toObservable(this.dashService.selectedTimeRange),
@@ -193,5 +195,42 @@ export class RevenueBillingComponent implements OnInit {
     if (this.lastHoveredRevenueByOp?.name) {
       this.drillDown.drillDownRevenueByOperation(this.lastHoveredRevenueByOp.name);
     }
+  }
+
+  private buildFilters(): { tlds?: string[]; registrarIds?: string[] } {
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+    return {
+      ...(tlds.length > 0 ? { tlds: [...tlds] } : {}),
+      ...(regIds.length > 0 ? { registrarIds: [...regIds] } : {}),
+    };
+  }
+
+  exploreRevenueByTld() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'REVENUE',
+      metrics: [{ field: 'netAmountToRegistry', aggregation: 'sum' }],
+      dimensions: ['period', 'tld'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'area');
+  }
+
+  exploreRevenueByOperation() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'REVENUE',
+      metrics: [{ field: 'netAmountToRegistry', aggregation: 'sum' }],
+      dimensions: ['operation'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'horizontal-bar');
   }
 }

--- a/console-webapp/src/app/registry-dash/overview/overview.component.html
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.html
@@ -37,7 +37,12 @@
     @if (barChartData().length > 0) {
       <mat-card appearance="outlined" class="chart-card">
         <mat-card-content>
-          <h3 class="chart-title">Registrar Market Share</h3>
+          <div class="chart-title-row">
+            <h3 class="chart-title">Registrar Market Share</h3>
+            <button mat-icon-button class="explore-btn" (click)="exploreRegistrarMarketShare()" matTooltip="Explore this data">
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+          </div>
           <p class="chart-description">Number of active domains managed by each registrar. Longer bars indicate a larger share of the total domain portfolio.</p>
           <div class="h-bar-chart">
             @for (bar of barChartData(); track bar.registrarId) {
@@ -63,7 +68,12 @@
     <div class="charts-row">
       <mat-card appearance="outlined" class="chart-card" *ngIf="activityLineOptions()">
         <mat-card-content>
-          <h3 class="chart-title">Domain Activity Trend</h3>
+          <div class="chart-title-row">
+            <h3 class="chart-title">Domain Activity Trend</h3>
+            <button mat-icon-button class="explore-btn" (click)="exploreActivityTrend()" matTooltip="Explore this data">
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+          </div>
           <p class="chart-description">Domain registration activity over time — creates, renews, transfers, deletes, and restores aggregated across all TLDs.</p>
           <div appLongPress (longPress)="onActivityLongPress()">
             <div echarts [options]="activityLineOptions()!" [theme]="'ud-brand'" class="echart"
@@ -76,7 +86,12 @@
 
       <mat-card appearance="outlined" class="chart-card" *ngIf="renewalRateOptions()">
         <mat-card-content>
-          <h3 class="chart-title">Renewal Rate by TLD</h3>
+          <div class="chart-title-row">
+            <h3 class="chart-title">Renewal Rate by TLD</h3>
+            <button mat-icon-button class="explore-btn" (click)="exploreRenewalRate()" matTooltip="Explore this data">
+              <mat-icon>open_in_new</mat-icon>
+            </button>
+          </div>
           <p class="chart-description">Percentage of expiring domains that were renewed (vs. deleted/expired) per TLD over the selected time period. The dashed line marks the 85% industry benchmark.</p>
           <div appLongPress (longPress)="onRenewalLongPress()">
             <div echarts [options]="renewalRateOptions()!" [theme]="'ud-brand'" class="echart"

--- a/console-webapp/src/app/registry-dash/overview/overview.component.scss
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.scss
@@ -50,11 +50,22 @@
     margin-bottom: 1.5rem;
   }
 
+  .chart-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
   .chart-title {
     margin: 0 0 4px;
     font-size: 0.95rem;
     font-weight: 600;
     color: var(--ud-text-primary);
+  }
+
+  .explore-btn {
+    opacity: 0.5;
+    &:hover { opacity: 1; }
   }
 
   .chart-description {

--- a/console-webapp/src/app/registry-dash/overview/overview.component.ts
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.ts
@@ -18,9 +18,11 @@ import { combineLatest, switchMap, EMPTY, catchError } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { CommonModule } from '@angular/common';
 import { NgxEchartsDirective } from 'ngx-echarts';
-import { RegistryDashService, RANGE_CONFIG } from '../registry-dash.service';
+import { RegistryDashService, RANGE_CONFIG, computeDateRange } from '../registry-dash.service';
 import { UD_ECHARTS_PROVIDER, withDrillDown } from '../ud-echarts';
 import { DrillDownService } from '../drilldown/drilldown.service';
+import { ExploreService } from '../explore/explore.service';
+import { ExploreQuery } from '../explore/explore.models';
 import { LongPressDirective } from '../drilldown/long-press.directive';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
 
@@ -148,6 +150,7 @@ export class OverviewComponent {
   constructor(
     protected dashService: RegistryDashService,
     protected drillDown: DrillDownService,
+    private exploreService: ExploreService,
   ) {
     combineLatest([
       toObservable(this.dashService.selectedTimeRange),
@@ -205,5 +208,50 @@ export class OverviewComponent {
     if (this.lastHoveredRenewal?.name) {
       this.drillDown.drillDownRenewalByTld(this.lastHoveredRenewal.name);
     }
+  }
+
+  private buildFilters(): { tlds?: string[]; registrarIds?: string[] } {
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+    return {
+      ...(tlds.length > 0 ? { tlds: [...tlds] } : {}),
+      ...(regIds.length > 0 ? { registrarIds: [...regIds] } : {}),
+    };
+  }
+
+  exploreRegistrarMarketShare() {
+    this.exploreService.navigateToExplore({
+      dataSource: 'DOMAIN_COUNTS',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['registrar'],
+      filters: this.buildFilters(),
+    }, 'horizontal-bar');
+  }
+
+  exploreActivityTrend() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'DOMAIN_ACTIVITY',
+      metrics: [{ field: 'count', aggregation: 'sum' }],
+      dimensions: ['period', 'activity_type'],
+      granularity: config.granularity,
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'line');
+  }
+
+  exploreRenewalRate() {
+    const config = this.dashService.selectedRangeConfig();
+    this.exploreService.navigateToExplore({
+      dataSource: 'RENEWAL_RATES',
+      metrics: [{ field: 'renewalRate', aggregation: 'sum' }],
+      dimensions: ['tld'],
+      filters: {
+        ...this.buildFilters(),
+        dateRange: computeDateRange(config.lookbackHours),
+      },
+    }, 'horizontal-bar');
   }
 }

--- a/console-webapp/src/app/registry-dash/registry-dash.service.ts
+++ b/console-webapp/src/app/registry-dash/registry-dash.service.ts
@@ -16,6 +16,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, WritableSignal, computed, signal } from '@angular/core';
 import { Observable, catchError, tap, throwError } from 'rxjs';
 import { BackendService } from '../shared/services/backend.service';
+import { DateRange } from './explore/explore.models';
 
 export interface OverviewData {
   totalDomains: number;
@@ -202,6 +203,15 @@ export const RANGE_CONFIG: Record<string, RangeConfigEntry> = {
 };
 
 export const RANGE_KEYS = Object.keys(RANGE_CONFIG);
+
+export function computeDateRange(lookbackHours: number): DateRange {
+  const end = new Date();
+  const start = new Date(end.getTime() - lookbackHours * 3600_000);
+  return {
+    start: start.toISOString().split('T')[0],
+    end: end.toISOString().split('T')[0],
+  };
+}
 
 export const RANGE_LABELS: Record<string, string> = {
   '6h': '6 Hours', '12h': '12 Hours', '1d': '1 Day', '7d': '7 Days',


### PR DESCRIPTION
## Summary
- Adds a subtle `open_in_new` icon button to each chart card across Overview, Domain Activity, Revenue Billing, and Forecasting tabs
- Clicking the button navigates to Data Exploration with the query pre-populated from that chart's configuration (data source, metrics, dimensions, chart type)
- Current global filters (TLDs, registrars, timeframe) are carried through to the explore query
- 9 charts total across 4 components, plus navigation infrastructure in ExploreService and ExploreComponent

## Test plan
- [x] Build compiles cleanly (`npm run build`)
- [x] Overview tab: all 3 explore buttons render, Registrar Market Share navigates correctly to Explore with Domain Counts / registrar / horizontal-bar
- [x] Domain Activity tab: both explore buttons render
- [x] Forecasting tab: Net Growth explore button navigates correctly to Explore with Domain Activity / period / line / monthly granularity / 12m date range
- [x] Revenue Billing / Forecasting buttons render when data is present (guarded by `*ngIf`)
- [ ] Run `ng test` for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)