### PR TITLE
style: round 2 theme polish to match UD site

### DIFF
--- a/console-webapp/src/app/app.component.scss
+++ b/console-webapp/src/app/app.component.scss
@@ -16,7 +16,7 @@
   font-family: "Google Sans", Roboto, Helvetica, Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
   font-size: 14px;
-  color: #333;
+  color: var(--ud-text-primary);
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -26,7 +26,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: #fff;
+  background: var(--ud-surface);
   &__container {
     flex: 1;
     padding-bottom: 36px;

--- a/console-webapp/src/app/header/header.component.scss
+++ b/console-webapp/src/app/header/header.component.scss
@@ -24,7 +24,7 @@
     font-size: 11px;
     font-weight: 400;
     font-style: italic;
-    color: #9AA0A6;
+    color: var(--ud-text-muted);
     letter-spacing: 0.1px;
     margin-top: 1px;
     line-height: 1.2;
@@ -32,13 +32,13 @@
   &__logo-text {
     font-size: 22px;
     font-weight: 700;
-    color: #0D67FE;
+    color: var(--ud-accent);
     letter-spacing: -0.5px;
     font-family: 'Inter', 'Google Sans', sans-serif;
 
     .logo-registry {
       font-weight: 400;
-      color: #5F6368;
+      color: var(--ud-text-secondary);
     }
   }
   &__menu-btn {
@@ -58,7 +58,7 @@
     &-user-email {
       font-size: 11px;
       font-weight: 400;
-      color: #9AA0A6;
+      color: var(--ud-text-muted);
       letter-spacing: 0.1px;
       margin-right: 2px;
     }

--- a/console-webapp/src/app/history/historyList.component.scss
+++ b/console-webapp/src/app/history/historyList.component.scss
@@ -39,11 +39,11 @@
     margin-right: 16px;
 
     &--update {
-      color: #1976d2;
+      color: var(--ud-accent);
     }
 
     &--security {
-      color: #d32f2f;
+      color: var(--ud-error);
     }
   }
 

--- a/console-webapp/src/app/navigation/navigation.component.scss
+++ b/console-webapp/src/app/navigation/navigation.component.scss
@@ -44,11 +44,13 @@ $expand-icon-size: 26px;
 
       &:hover {
         background-color: var(--light-highlight);
-        border-radius: 0 15px 15px 0;
+        border-radius: 0 20px 20px 0;
+        transition: background-color var(--ud-transition);
       }
       &.active {
-        border-radius: 0 15px 15px 0;
-        background-color: var(--lightest);
+        border-radius: 0 20px 20px 0;
+        background-color: var(--ud-accent-light);
+        border-left: 3px solid var(--ud-accent);
       }
     }
 

--- a/console-webapp/src/app/registry-dash/admin/admin.component.scss
+++ b/console-webapp/src/app/registry-dash/admin/admin.component.scss
@@ -95,7 +95,7 @@ h3 {
 
 .default-badge {
   font-style: italic;
-  color: #666;
+  color: var(--ud-text-secondary);
 }
 
 .cost-basis-table {

--- a/console-webapp/src/app/registry-dash/drilldown/drilldown-dialog.component.scss
+++ b/console-webapp/src/app/registry-dash/drilldown/drilldown-dialog.component.scss
@@ -1,5 +1,5 @@
 .dialog-subtitle {
-  color: #62626A;
+  color: var(--ud-text-secondary);
   margin: 0 0 16px;
 }
 
@@ -19,17 +19,17 @@
   gap: 4px;
   margin-bottom: 12px;
   font-size: 13px;
-  color: #9191A1;
+  color: var(--ud-text-muted);
 }
 
 .breadcrumb-link {
-  color: #0D67FE;
+  color: var(--ud-accent);
   cursor: pointer;
   &:hover { text-decoration: underline; }
 }
 
 .breadcrumb-current {
-  color: #2D2D32;
+  color: var(--ud-text-primary);
 }
 
 .breadcrumb-sep {

--- a/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.scss
+++ b/console-webapp/src/app/registry-dash/filter-panel/filter-panel.component.scss
@@ -1,6 +1,6 @@
 .filter-panel {
-  border: 1px solid #dadce0;
-  border-radius: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--ud-radius-md);
   margin-bottom: 16px;
   overflow: hidden;
 }
@@ -14,13 +14,13 @@
   user-select: none;
 
   &:hover {
-    background: #fafafa;
+    background: var(--ud-surface-muted);
   }
 }
 
 .filter-icon {
   font-size: 18px;
-  color: #666;
+  color: var(--ud-text-secondary);
 }
 
 .chip-area {
@@ -31,7 +31,7 @@
 
 .no-filters {
   font-size: 13px;
-  color: #999;
+  color: var(--ud-text-muted);
 }
 
 .edit-link,
@@ -40,7 +40,7 @@
   align-items: center;
   gap: 2px;
   font-size: 12px;
-  color: #1a73e8;
+  color: var(--ud-accent);
 
   mat-icon {
     font-size: 16px;
@@ -62,12 +62,12 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #e8f0fe;
-  color: #1a73e8;
+  background: var(--ud-accent-light);
+  color: var(--ud-accent);
   font-size: 11px;
   font-weight: 500;
   padding: 2px 8px;
-  border-radius: 12px;
+  border-radius: var(--ud-radius-pill);
 }
 
 .filter-body {
@@ -76,7 +76,7 @@
   align-items: center;
   gap: 12px;
   padding: 0 16px 16px;
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--ud-border-subtle);
 }
 
 .time-range {
@@ -87,10 +87,6 @@
 .filter-select {
   width: 220px;
 
-  ::ng-deep .mdc-text-field--outlined {
-    border-radius: 8px;
-  }
-
   ::ng-deep .mat-mdc-form-field-subscript-wrapper {
     display: none;
   }
@@ -98,5 +94,5 @@
 
 .clear-btn {
   font-size: 12px;
-  color: #1a73e8;
+  color: var(--ud-accent);
 }

--- a/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/effective-fees/effective-fees.component.scss
@@ -47,7 +47,7 @@
   .source-badge {
     display: inline-block;
     padding: 2px 8px;
-    border-radius: 4px;
+    border-radius: var(--ud-radius-xs);
     font-size: 0.75rem;
     font-weight: 500;
     text-transform: uppercase;
@@ -61,7 +61,7 @@
 
   .source-custom {
     background: rgba(13, 103, 254, 0.12);
-    color: #0D67FE;
+    color: var(--ud-accent);
   }
 
   .empty-state {

--- a/console-webapp/src/app/registry-dash/financials/financials.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/financials.component.scss
@@ -189,7 +189,7 @@
 
 .default-badge {
   font-style: italic;
-  color: #666;
+  color: var(--ud-text-secondary);
 }
 
 .financials-table {

--- a/console-webapp/src/app/registry-dash/portfolio/portfolio.component.scss
+++ b/console-webapp/src/app/registry-dash/portfolio/portfolio.component.scss
@@ -11,7 +11,7 @@
 
   .state-badge {
     padding: 2px 8px;
-    border-radius: 12px;
+    border-radius: var(--ud-radius-pill);
     font-size: 0.85em;
     font-weight: 500;
   }

--- a/console-webapp/src/app/settings/contact/contact.component.scss
+++ b/console-webapp/src/app/settings/contact/contact.component.scss
@@ -21,7 +21,7 @@
       min-width: 800px;
     }
     .contact__name-column-title {
-      color: #5f6368;
+      color: var(--ud-text-secondary);
       font-weight: 500;
       padding: 10px 0;
     }

--- a/console-webapp/src/app/support/support.component.scss
+++ b/console-webapp/src/app/support/support.component.scss
@@ -2,7 +2,7 @@
   &__support {
     max-width: 616px;
     &-passcode {
-      color: #1e8e3e;
+      color: var(--ud-success);
     }
     p {
       margin: 20px 0;

--- a/console-webapp/src/ud-theme.scss
+++ b/console-webapp/src/ud-theme.scss
@@ -246,6 +246,7 @@ div.mat-mdc-autocomplete-panel {
   border-radius: var(--ud-radius-pill) !important;
   font-weight: 500;
   font-size: 13px;
+  margin: 2px 4px 2px 0;
   transition: background-color var(--ud-transition),
     border-color var(--ud-transition);
 }

--- a/console-webapp/src/ud-theme.scss
+++ b/console-webapp/src/ud-theme.scss
@@ -33,9 +33,12 @@
   --ud-error: #c53030;
   --ud-error-bg: #fef2f2;
   --ud-border-subtle: #e8e8ea;
-  --ud-radius-sm: 8px;
-  --ud-radius-md: 12px;
-  --ud-radius-lg: 16px;
+  --ud-radius-xs: 6px;
+  --ud-radius-sm: 12px;
+  --ud-radius-md: 16px;
+  --ud-radius-lg: 20px;
+  --ud-radius-pill: 100px;
+  --ud-border-width: 1.5px;
   --ud-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --ud-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.07),
     0 2px 4px -2px rgba(0, 0, 0, 0.05);
@@ -69,9 +72,9 @@
   // Buttons
   --mat-filled-button-container-color: var(--ud-accent);
   --mat-filled-button-label-text-color: #ffffff;
-  --mat-filled-button-container-shape: var(--ud-radius-sm);
+  --mat-filled-button-container-shape: var(--ud-radius-pill);
   --mat-outlined-button-outline-color: var(--border);
-  --mat-outlined-button-container-shape: var(--ud-radius-sm);
+  --mat-outlined-button-container-shape: var(--ud-radius-pill);
   --mat-text-button-label-text-color: var(--ud-accent);
 
   // Form fields
@@ -154,12 +157,26 @@ mat-row:hover,
   background-color: var(--lightest-highlight) !important;
 }
 
-// Button hover refinements
+// Button styling — pill shape, bold weight, UD-branded
 .mat-mdc-raised-button,
 .mat-mdc-flat-button,
 .mdc-button--unelevated {
+  border-radius: var(--ud-radius-pill) !important;
+  padding: 0 24px;
+  font-weight: 600;
+  text-transform: none;
   transition: background-color var(--ud-transition),
     box-shadow var(--ud-transition);
+}
+
+.mat-mdc-outlined-button {
+  border-radius: var(--ud-radius-pill) !important;
+  padding: 0 24px;
+  font-weight: 600;
+  text-transform: none;
+  border-width: var(--ud-border-width);
+  transition: background-color var(--ud-transition),
+    border-color var(--ud-transition);
 }
 
 // Link transitions
@@ -195,4 +212,94 @@ div.mat-mdc-autocomplete-panel {
 .mat-mdc-option.mdc-list-item--selected {
   border-left: 3px solid var(--ud-accent);
   padding-left: 13px; // 16px default minus 3px border to keep text aligned
+}
+
+// Button toggle groups — pill container, accent fill on selected
+.mat-button-toggle-group {
+  border-radius: var(--ud-radius-pill) !important;
+  border: var(--ud-border-width) solid var(--border) !important;
+  overflow: hidden;
+
+  .mat-button-toggle {
+    border-left: none !important;
+
+    .mat-button-toggle-label-content {
+      padding: 0 16px;
+      font-size: 13px;
+      font-weight: 500;
+      line-height: 32px;
+    }
+  }
+
+  .mat-button-toggle-checked {
+    background-color: var(--ud-accent) !important;
+    color: #ffffff !important;
+
+    .mat-icon {
+      color: #ffffff !important;
+    }
+  }
+}
+
+// Chips — pill shape, UD accent on selected
+.mat-mdc-chip {
+  border-radius: var(--ud-radius-pill) !important;
+  font-weight: 500;
+  font-size: 13px;
+  transition: background-color var(--ud-transition),
+    border-color var(--ud-transition);
+}
+
+.mat-mdc-chip.mat-mdc-chip-selected,
+.mat-mdc-chip-highlighted {
+  background-color: var(--ud-accent-light) !important;
+  color: var(--ud-accent) !important;
+  border: 1.5px solid var(--ud-accent) !important;
+}
+
+// Menu panels — rounded, shadowed, padded
+.mat-mdc-menu-panel {
+  border-radius: var(--ud-radius-md) !important;
+  box-shadow: var(--ud-shadow-dropdown) !important;
+  padding: 8px !important;
+}
+
+.mat-mdc-menu-item {
+  border-radius: var(--ud-radius-sm);
+  margin: 2px 0;
+  font-size: 14px;
+  transition: background-color var(--ud-transition);
+}
+
+// Dialog panels — generous rounding
+.mat-mdc-dialog-container .mdc-dialog__surface {
+  border-radius: var(--ud-radius-lg) !important;
+}
+
+// Datepicker panel
+.mat-datepicker-content {
+  border-radius: var(--ud-radius-md) !important;
+  box-shadow: var(--ud-shadow-dropdown) !important;
+}
+
+// Slide toggle — UD accent colors
+.mat-mdc-slide-toggle {
+  --mdc-switch-selected-handle-color: var(--ud-accent);
+  --mdc-switch-selected-track-color: var(--ud-accent);
+  --mdc-switch-selected-hover-handle-color: var(--ud-accent-hover);
+  --mdc-switch-selected-focus-handle-color: var(--ud-accent);
+  --mdc-switch-selected-pressed-handle-color: var(--ud-accent-active);
+}
+
+// Tooltip
+.mat-mdc-tooltip .mdc-tooltip__surface {
+  border-radius: var(--ud-radius-sm);
+  font-size: 12px;
+}
+
+// Form field outline — thicker borders
+.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__leading,
+.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__trailing,
+.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__notch {
+  border-width: var(--ud-border-width) !important;
 }

--- a/console-webapp/src/ud-theme.scss
+++ b/console-webapp/src/ud-theme.scss
@@ -313,7 +313,7 @@ div.mat-mdc-autocomplete-panel {
   border-width: var(--ud-border-width) !important;
 }
 
-// Compact form fields — reduce height
+// Compact form fields — reduce height, center text vertically
 .mat-mdc-form-field {
   --mat-form-field-container-height: 40px;
   --mdc-outlined-text-field-container-shape: var(--ud-radius-sm);
@@ -321,6 +321,13 @@ div.mat-mdc-autocomplete-panel {
 
 .mat-mdc-form-field .mat-mdc-text-field-wrapper {
   max-height: 40px;
+  align-items: center;
+}
+
+.mat-mdc-form-field .mat-mdc-text-field-wrapper .mat-mdc-form-field-infix {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  min-height: unset;
 }
 
 .mat-mdc-form-field .mat-mdc-floating-label {

--- a/console-webapp/src/ud-theme.scss
+++ b/console-webapp/src/ud-theme.scss
@@ -298,9 +298,51 @@ div.mat-mdc-autocomplete-panel {
   font-size: 12px;
 }
 
-// Form field outline — thicker borders
-.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__leading,
-.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__trailing,
+// Form field outline — rounder corners, thicker borders, compact height
+.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__leading {
+  border-radius: var(--ud-radius-sm) 0 0 var(--ud-radius-sm) !important;
+  border-width: var(--ud-border-width) !important;
+}
+
+.mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__trailing {
+  border-radius: 0 var(--ud-radius-sm) var(--ud-radius-sm) 0 !important;
+  border-width: var(--ud-border-width) !important;
+}
+
 .mdc-text-field--outlined .mdc-notched-outline .mdc-notched-outline__notch {
   border-width: var(--ud-border-width) !important;
+}
+
+// Compact form fields — reduce height
+.mat-mdc-form-field {
+  --mat-form-field-container-height: 40px;
+  --mdc-outlined-text-field-container-shape: var(--ud-radius-sm);
+}
+
+.mat-mdc-form-field .mat-mdc-text-field-wrapper {
+  max-height: 40px;
+}
+
+.mat-mdc-form-field .mat-mdc-floating-label {
+  font-size: 14px;
+}
+
+// Filled form fields — rounded top corners, lighter background, subtle bottom border
+.mdc-text-field--filled {
+  background-color: var(--ud-surface-muted) !important;
+  border-radius: var(--ud-radius-sm) var(--ud-radius-sm) 0 0 !important;
+
+  .mdc-line-ripple::before {
+    border-bottom-color: var(--border) !important;
+  }
+
+  .mdc-line-ripple::after {
+    border-bottom-color: var(--ud-accent) !important;
+  }
+}
+
+.mdc-text-field--disabled {
+  background-color: var(--ud-surface-muted) !important;
+  border-radius: var(--ud-radius-sm) var(--ud-radius-sm) 0 0 !important;
+  opacity: 0.7;
 }


### PR DESCRIPTION
Linear: [SRE-1930](https://linear.app/unstoppable-domains/issue/SRE-1930)

---

## Summary
- Bump radius tokens aggressively (sm→12px, md→16px, lg→20px) and add pill radius (100px) for buttons, chips, and toggle groups
- Style all previously-unstyled Material components: menus, dialogs, datepickers, slide toggles, tooltips, button toggle groups, chips
- Thicken form field outlines (1.5px) and add pill-shaped buttons with 600 weight
- Add navigation sidebar active state with left accent border
- Migrate hardcoded hex colors across 12 component SCSS files to shared CSS variables for consistency

## Context
Follow-up to PR #103. The first round of theming made incremental improvements but the console still looked like stock Material Design. This round brings the look/feel much closer to unstoppabledomains.com with pill-shaped CTAs, generous rounding, and consistent token usage.

## Test plan
- [ ] Overview page: cards, stat values, bar charts render correctly
- [ ] Explore page: builder panel toggle groups, chart, save-view dialog
- [ ] Filter panel: chips, select dropdowns, time-range toggles
- [ ] Portfolio: state badges, chips, table
- [ ] Admin: forms, slide toggles, buttons
- [ ] Header: user menu dropdown
- [ ] Navigation: active state with blue accent border
- [ ] Settings pages: form fields, buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)