### PR TITLE
feat(registry-dash): add CSV export and transactions data source

### DIFF
--- a/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
+++ b/console-webapp/src/app/registry-dash/explore/data-source-schemas.ts
@@ -89,4 +89,21 @@ export const DATA_SOURCE_SCHEMAS: Record<DataSourceType, DataSourceSchema> = {
     filters: ['tlds', 'registrarIds', 'operations'],
     supportsGranularity: false,
   },
+  TRANSACTIONS: {
+    label: 'Transactions',
+    description: 'Individual billing transactions with domain, registrar, and dollar amounts',
+    metrics: [
+      { field: 'amount', label: 'Amount' },
+      { field: 'netAmountToRegistry', label: 'Net to Registry' },
+    ],
+    dimensions: [
+      { field: 'timestamp', label: 'Timestamp' },
+      { field: 'domain_name', label: 'Domain Name' },
+      { field: 'tld', label: 'TLD' },
+      { field: 'registrar', label: 'Registrar' },
+      { field: 'operation', label: 'Operation' },
+    ],
+    filters: ['tlds', 'registrarIds', 'operations', 'dateRange'],
+    supportsGranularity: false,
+  },
 };

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -48,7 +48,13 @@
 
   <!-- Raw Data Table -->
   <div class="data-table-wrapper" *ngIf="result() && result()!.rows.length > 0">
-    <h3>Raw Data</h3>
+    <div class="data-table-header">
+      <h3>Raw Data</h3>
+      <button mat-stroked-button (click)="exportCsv()">
+        <mat-icon>download</mat-icon>
+        Download CSV
+      </button>
+    </div>
     <div class="table-scroll">
       <table mat-table [dataSource]="result()!.rows">
         <ng-container *ngFor="let col of tableColumns()" [matColumnDef]="col">

--- a/console-webapp/src/app/registry-dash/explore/explore.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.scss
@@ -70,10 +70,17 @@
 .data-table-wrapper {
   margin-top: 24px;
 
-  h3 {
-    margin: 0 0 12px;
-    font-size: 15px;
-    font-weight: 500;
+  .data-table-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+
+    h3 {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 500;
+    }
   }
 }
 

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -91,4 +91,30 @@ export class ExploreComponent implements OnInit {
   runQuery(): void {
     this.exploreService.explore(this.query()).subscribe();
   }
+
+  exportCsv(): void {
+    const r = this.result();
+    if (!r || r.rows.length === 0) return;
+
+    const escape = (val: unknown): string => {
+      const s = val == null ? '' : String(val);
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return '"' + s.replace(/"/g, '""') + '"';
+      }
+      return s;
+    };
+
+    const header = r.columns.map(escape).join(',');
+    const rows = r.rows.map(row => r.columns.map(col => escape(row[col])).join(','));
+    const csv = '\uFEFF' + header + '\n' + rows.join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    a.href = url;
+    a.download = `explore-${this.query().dataSource.toLowerCase()}-${ts}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
 }

--- a/console-webapp/src/app/registry-dash/explore/explore.models.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.models.ts
@@ -18,7 +18,8 @@ export type DataSourceType =
   | 'DOMAIN_COUNTS'
   | 'RENEWAL_RATES'
   | 'EXPIRATION_CURVE'
-  | 'PRICING_RULES';
+  | 'PRICING_RULES'
+  | 'TRANSACTIONS';
 
 export type ChartType = 'bar' | 'line' | 'pie' | 'stacked-bar' | 'area' | 'horizontal-bar';
 

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
@@ -51,7 +51,12 @@ public enum ExploreDataSource {
   PRICING_RULES(
       ImmutableSet.of("priceAmount"),
       ImmutableSet.of("registrar", "tld", "operation"),
-      ImmutableSet.of("tlds", "registrarIds", "operations"));
+      ImmutableSet.of("tlds", "registrarIds", "operations")),
+
+  TRANSACTIONS(
+      ImmutableSet.of("amount", "netAmountToRegistry"),
+      ImmutableSet.of("timestamp", "domain_name", "tld", "registrar", "operation"),
+      ImmutableSet.of("tlds", "registrarIds", "operations", "dateRange"));
 
   private final ImmutableSet<String> allowedMetrics;
   private final ImmutableSet<String> allowedDimensions;

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
@@ -38,6 +38,7 @@ public final class ExploreQueryBuilder {
       case RENEWAL_RATES -> buildRenewalRates(desc, effectiveTlds);
       case EXPIRATION_CURVE -> buildExpirationCurve(desc, effectiveTlds);
       case PRICING_RULES -> buildPricingRules(desc, effectiveTlds);
+      case TRANSACTIONS -> buildTransactions(desc, effectiveTlds);
     };
   }
 
@@ -291,6 +292,64 @@ public final class ExploreQueryBuilder {
     }
     return assembleQuery(selectCols, "\"RegistryDashboardRegistrarPricing\" p",
         whereClauses, groupByCols, null);
+  }
+
+  private static String buildTransactions(
+      ExploreQueryDescriptor desc, ImmutableSet<String> tlds) {
+    ExploreQueryDescriptor.ExploreFilters f = desc.getFilters();
+
+    List<String> selectCols = new ArrayList<>();
+    selectCols.add("dh.history_modification_time AS timestamp");
+    selectCols.add("d.domain_name");
+    selectCols.add("d.tld");
+    selectCols.add("d.current_sponsor_registrar_id AS registrar");
+    selectCols.add("b.reason AS operation");
+    selectCols.add("b.cost_amount AS amount");
+    selectCols.add(
+        "(b.cost_amount - COALESCE(cb.rsp_retained_fee_amount, 0)) AS net_amount_to_registry");
+    selectCols.add("b.cost_currency AS currency");
+
+    String fromClause =
+        "\"BillingEvent\" b"
+            + " JOIN \"Domain\" d ON d.repo_id = b.domain_repo_id"
+            + " JOIN \"DomainHistory\" dh ON dh.history_revision_id ="
+            + " b.domain_history_revision_id"
+            + " AND dh.domain_repo_id = b.domain_repo_id"
+            + " LEFT JOIN LATERAL ("
+            + " SELECT rsp_retained_fee_amount"
+            + " FROM \"RegistryDashboardCostBasis\""
+            + " WHERE (tld = d.tld OR tld = '*')"
+            + " AND operation = b.reason"
+            + " AND effective_date <= dh.history_modification_time"
+            + " ORDER BY CASE WHEN tld = d.tld THEN 0 ELSE 1 END, effective_date DESC"
+            + " LIMIT 1"
+            + ") cb ON true";
+
+    List<String> whereClauses = new ArrayList<>();
+    whereClauses.add("b.reason IN ('CREATE', 'RENEW', 'TRANSFER', 'RESTORE')");
+    if (!tlds.isEmpty()) {
+      whereClauses.add("d.tld IN (:tlds)");
+    }
+    if (f.getDateRange() != null) {
+      whereClauses.add("dh.history_modification_time >= :startDate");
+      whereClauses.add("dh.history_modification_time <= :endDate");
+    }
+    if (!f.getOperations().isEmpty()) {
+      whereClauses.add("b.reason IN (:operations)");
+    }
+    if (!f.getRegistrarIds().isEmpty()) {
+      whereClauses.add("d.current_sponsor_registrar_id IN (:registrarIds)");
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("SELECT ").append(String.join(", ", selectCols));
+    sb.append(" FROM ").append(fromClause);
+    if (!whereClauses.isEmpty()) {
+      sb.append(" WHERE ").append(String.join(" AND ", whereClauses));
+    }
+    sb.append(" ORDER BY dh.history_modification_time DESC");
+    sb.append(" LIMIT :maxRows");
+    return sb.toString();
   }
 
   private static String resolveGranularity(String granularity) {

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashExploreAction.java
@@ -211,6 +211,11 @@ public class RegistryDashExploreAction extends ConsoleApiAction {
 
   private static List<String> buildColumnNames(
       ExploreDataSource source, ExploreQueryDescriptor desc) {
+    if (source == ExploreDataSource.TRANSACTIONS) {
+      return List.of(
+          "timestamp", "domain_name", "tld", "registrar",
+          "operation", "amount", "net_amount_to_registry", "currency");
+    }
     List<String> cols = new ArrayList<>();
     // Dimensions first
     for (String dim : desc.getDimensions()) {


### PR DESCRIPTION
Linear: [SRE-1931](https://linear.app/unstoppable-domains/issue/SRE-1931)

---

## Summary
- Add **Download CSV** button to the Raw Data table in the Data Exploration tab — any query result can be exported
- Add new **Transactions** data source that returns individual billing events (non-aggregated): timestamp, domain name, TLD, registrar, operation, amount, net-to-registry, currency
- TRANSACTIONS reuses the same BillingEvent + DomainHistory + CostBasis join as the REVENUE source, ordered most-recent-first

## Test plan
- [x] Backend compiles (`./nom_build :core:compileJava`)
- [x] Frontend builds (`ng build`)
- [x] Backend unit tests pass (`*RegistryDashExplore*`)
- [x] Local full-stack: CSV export downloads correct file with BOM + escaping
- [x] Local full-stack: TRANSACTIONS appears in dropdown, query executes without error
- [ ] Alpha proxy: verify TRANSACTIONS returns real billing data
- [ ] Alpha deploy: end-to-end with production-like data

🤖 Generated with [Claude Code](https://claude.com/claude-code)