### PR TITLE
fix(registry-dash): date-aware status for custom pricing rules

### DIFF
--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.html
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.html
@@ -181,11 +181,12 @@
         <td mat-cell *matCellDef="let row">{{ row.expiryDate ? (row.expiryDate | date:'short') : 'Never' }}</td>
       </ng-container>
       <ng-container matColumnDef="isActive">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>Active</th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Status</th>
         <td mat-cell *matCellDef="let row">
-          <mat-icon [class]="row.isActive ? 'active-icon' : 'inactive-icon'">
-            {{ row.isActive ? 'check_circle' : 'cancel' }}
-          </mat-icon>
+          <span class="status-badge" [ngClass]="getRuleStatus(row).cssClass">
+            <mat-icon class="status-icon">{{ getRuleStatus(row).icon }}</mat-icon>
+            {{ getRuleStatus(row).label }}
+          </span>
         </td>
       </ng-container>
       <ng-container matColumnDef="actions">

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.scss
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.scss
@@ -102,12 +102,41 @@
     width: 100%;
   }
 
-  .active-icon {
-    color: var(--ud-success);
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    padding: 0.125rem 0.5rem 0.125rem 0.25rem;
+    border-radius: 1rem;
+    white-space: nowrap;
   }
 
-  .inactive-icon {
+  .status-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .status-active {
+    color: var(--ud-success);
+    background: color-mix(in srgb, var(--ud-success) 10%, transparent);
+  }
+
+  .status-expired {
+    color: var(--ud-warning);
+    background: var(--ud-warning-bg);
+  }
+
+  .status-scheduled {
+    color: var(--ud-accent);
+    background: var(--ud-accent-light);
+  }
+
+  .status-inactive {
     color: var(--ud-text-muted);
+    background: color-mix(in srgb, var(--ud-text-muted) 10%, transparent);
   }
 
   .diff-discount {

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
@@ -144,6 +144,10 @@ export class PricingComponent implements AfterViewInit {
       if (property === 'defaultPrice') {
         return item.defaultPrice ?? 0;
       }
+      if (property === 'isActive') {
+        const order: Record<string, number> = { Active: 0, Scheduled: 1, Expired: 2, Inactive: 3 };
+        return order[this.getRuleStatus(item).label] ?? 4;
+      }
       return (item as any)[property];
     };
   }
@@ -151,6 +155,20 @@ export class PricingComponent implements AfterViewInit {
   getDifference(rule: PricingRule): number | null {
     if (rule.defaultPrice == null) return null;
     return rule.priceAmount - rule.defaultPrice;
+  }
+
+  getRuleStatus(rule: PricingRule): { label: string; icon: string; cssClass: string } {
+    if (!rule.isActive) {
+      return { label: 'Inactive', icon: 'cancel', cssClass: 'status-inactive' };
+    }
+    const now = new Date();
+    if (rule.effectiveDate && new Date(rule.effectiveDate) > now) {
+      return { label: 'Scheduled', icon: 'schedule', cssClass: 'status-scheduled' };
+    }
+    if (rule.expiryDate && new Date(rule.expiryDate) <= now) {
+      return { label: 'Expired', icon: 'warning', cssClass: 'status-expired' };
+    }
+    return { label: 'Active', icon: 'check_circle', cssClass: 'status-active' };
   }
 
   getDifferenceClass(rule: PricingRule): string {


### PR DESCRIPTION
Linear: [SRE-1932](https://linear.app/unstoppable-domains/issue/SRE-1932)

---

## Summary
- Replace the binary Active/Inactive icon in Custom Pricing with a computed four-state status badge
- **Active** (green): `isActive` + effective now + not expired
- **Expired** (amber): `isActive` + past expiry date — previously showed misleading green checkmark
- **Scheduled** (blue): `isActive` + future effective date
- **Inactive** (gray): `!isActive`
- All logic is client-side using existing API fields — no backend changes

## Context
A pricing gap incident occurred when an expired rule still displayed as "Active ✓". The registrar was billed at the default TLD price instead of their negotiated custom rate because no one noticed the rule had expired.

## Test plan
- [ ] Build frontend: `cd console-webapp && npm run build`
- [ ] On alpha: Registry Dashboard → Custom Pricing
- [ ] Filter to antimony + .modem — verify the $15.50 CREATE rule (expires 4/10/26) shows "Expired"
- [ ] Verify the $2.99 CREATE rule (expires 4/30/26) still shows "Active"
- [ ] Verify rules with no expiry date show "Active"
- [ ] Verify the $1.00 RENEW rule (effective 4/10/26, expires 4/10/26 same day) shows "Expired"

🤖 Generated with [Claude Code](https://claude.com/claude-code)