### PR TITLE
fix(registry-dash): use billing registrar in transactions query

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
@@ -302,7 +302,7 @@ public final class ExploreQueryBuilder {
     selectCols.add("dh.history_modification_time AS timestamp");
     selectCols.add("d.domain_name");
     selectCols.add("d.tld");
-    selectCols.add("d.current_sponsor_registrar_id AS registrar");
+    selectCols.add("b.registrar_id AS registrar");
     selectCols.add("b.reason AS operation");
     selectCols.add("b.cost_amount AS amount");
     selectCols.add(
@@ -338,7 +338,7 @@ public final class ExploreQueryBuilder {
       whereClauses.add("b.reason IN (:operations)");
     }
     if (!f.getRegistrarIds().isEmpty()) {
-      whereClauses.add("d.current_sponsor_registrar_id IN (:registrarIds)");
+      whereClauses.add("b.registrar_id IN (:registrarIds)");
     }
 
     StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Linear: [SRE-1933](https://linear.app/unstoppable-domains/issue/SRE-1933)

---

## Summary
- TRANSACTIONS data source was showing the **current domain sponsor** instead of the registrar who actually performed each operation
- After a transfer, all historical rows (CREATE, RENEW) incorrectly showed the new sponsor
- Switched to `b.registrar_id` (BillingEvent table) which records the registrar who was billed — the authoritative source for who performed the operation
- Also updated the registrar WHERE filter to match on `b.registrar_id`

## Test plan
- [ ] `./nom_build :core:compileJava` passes
- [ ] CI green
- [ ] On alpha: TRANSACTIONS query filtered to a specific registrar shows only operations that registrar performed

🤖 Generated with [Claude Code](https://claude.com/claude-code)