### PR TITLE
feat(registry-dash): AI-powered analysis with Claude

### DIFF
--- a/console-webapp/package-lock.json
+++ b/console-webapp/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "^21.1.5",
         "@angular/router": "^21.1.5",
         "echarts": "^6.0.0",
+        "marked": "^18.0.2",
         "ngx-echarts": "^21.0.0",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
@@ -9742,6 +9743,18 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/console-webapp/package.json
+++ b/console-webapp/package.json
@@ -29,6 +29,7 @@
     "@angular/platform-browser-dynamic": "^21.1.5",
     "@angular/router": "^21.1.5",
     "echarts": "^6.0.0",
+    "marked": "^18.0.2",
     "ngx-echarts": "^21.0.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -41,8 +41,8 @@
     <!-- Streaming response -->
     <div *ngIf="streaming()" class="message assistant-message streaming">
       <mat-icon class="message-icon">auto_awesome</mat-icon>
-      <div class="message-content streaming-text">
-        {{ streamedText() }}
+      <div class="message-content markdown-body">
+        <div [innerHTML]="streamedText() | markdown"></div>
         <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
       </div>
     </div>

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -41,7 +41,7 @@
     <!-- Streaming response -->
     <div *ngIf="streaming()" class="message assistant-message streaming">
       <mat-icon class="message-icon">auto_awesome</mat-icon>
-      <div class="message-content markdown-body" [innerHTML]="streamedText() | markdown"></div>
+      <div class="message-content streaming-text">{{ streamedText() }}</div>
       <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
     </div>
 

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -18,7 +18,7 @@
     </button>
     <div *ngIf="showAdvanced()" class="advanced-content">
       <textarea
-        [(ngModel)]="editableSystemPrompt"
+        [(ngModel)]="editableSystemPrompt" name="systemPrompt"
         class="system-prompt-editor"
         placeholder="System prompt (editable in dev mode)"
         rows="6"></textarea>
@@ -34,14 +34,14 @@
       </div>
       <div *ngIf="msg.role === 'assistant'" class="message assistant-message">
         <mat-icon class="message-icon">auto_awesome</mat-icon>
-        <div class="message-content markdown-body" [innerHTML]="msg.content"></div>
+        <div class="message-content markdown-body" [innerHTML]="msg.content | markdown"></div>
       </div>
     </ng-container>
 
     <!-- Streaming response -->
     <div *ngIf="streaming()" class="message assistant-message streaming">
       <mat-icon class="message-icon">auto_awesome</mat-icon>
-      <div class="message-content markdown-body" [innerHTML]="streamedText()"></div>
+      <div class="message-content markdown-body" [innerHTML]="streamedText() | markdown"></div>
       <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
     </div>
 
@@ -57,12 +57,12 @@
   <div class="follow-up-bar">
     <input
       type="text"
-      [(ngModel)]="followUpInput"
+      [(ngModel)]="followUpText" name="followUp"
       (keydown)="onFollowUpKeydown($event)"
       placeholder="Ask a follow-up question..."
       [disabled]="streaming()"
       class="follow-up-input" />
-    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpInput()">
+    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpText">
       <mat-icon>send</mat-icon>
     </button>
   </div>

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -1,0 +1,70 @@
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>
+  <!-- Context line -->
+  <div class="context-bar">
+    <span class="context-model">Model:</span>
+    <mat-button-toggle-group [value]="selectedModel()" (change)="onModelChange($event.value)">
+      <mat-button-toggle value="haiku">Haiku</mat-button-toggle>
+      <mat-button-toggle value="sonnet">Sonnet</mat-button-toggle>
+      <mat-button-toggle value="opus">Opus</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <!-- Advanced section (admin only, dev mode) -->
+  <div *ngIf="data.isAdmin" class="advanced-section">
+    <button mat-button (click)="toggleAdvanced()" class="advanced-toggle">
+      <mat-icon>{{ showAdvanced() ? 'expand_less' : 'expand_more' }}</mat-icon>
+      Advanced
+    </button>
+    <div *ngIf="showAdvanced()" class="advanced-content">
+      <textarea
+        [(ngModel)]="editableSystemPrompt"
+        class="system-prompt-editor"
+        placeholder="System prompt (editable in dev mode)"
+        rows="6"></textarea>
+    </div>
+  </div>
+
+  <!-- Conversation -->
+  <div class="conversation">
+    <ng-container *ngFor="let msg of conversationHistory()">
+      <div *ngIf="msg.role === 'user'" class="message user-message">
+        <mat-icon class="message-icon">person</mat-icon>
+        <div class="message-content">{{ msg.content }}</div>
+      </div>
+      <div *ngIf="msg.role === 'assistant'" class="message assistant-message">
+        <mat-icon class="message-icon">auto_awesome</mat-icon>
+        <div class="message-content markdown-body" [innerHTML]="msg.content"></div>
+      </div>
+    </ng-container>
+
+    <!-- Streaming response -->
+    <div *ngIf="streaming()" class="message assistant-message streaming">
+      <mat-icon class="message-icon">auto_awesome</mat-icon>
+      <div class="message-content markdown-body" [innerHTML]="streamedText()"></div>
+      <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
+    </div>
+
+    <!-- Error -->
+    <div *ngIf="error()" class="error-message">
+      <mat-icon>error</mat-icon>
+      {{ error() }}
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <div class="follow-up-bar">
+    <input
+      type="text"
+      [(ngModel)]="followUpInput"
+      (keydown)="onFollowUpKeydown($event)"
+      placeholder="Ask a follow-up question..."
+      [disabled]="streaming()"
+      class="follow-up-input" />
+    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpInput()">
+      <mat-icon>send</mat-icon>
+    </button>
+  </div>
+  <button mat-button mat-dialog-close>Close</button>
+</mat-dialog-actions>

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -41,8 +41,10 @@
     <!-- Streaming response -->
     <div *ngIf="streaming()" class="message assistant-message streaming">
       <mat-icon class="message-icon">auto_awesome</mat-icon>
-      <div class="message-content streaming-text">{{ streamedText() }}</div>
-      <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
+      <div class="message-content streaming-text">
+        {{ streamedText() }}
+        <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
+      </div>
     </div>
 
     <!-- Error -->

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
@@ -75,6 +75,11 @@
   font-style: italic;
 }
 
+.streaming-text {
+  white-space: pre-wrap;
+  font-family: inherit;
+}
+
 .stream-progress {
   margin-top: 8px;
 }

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
@@ -1,0 +1,125 @@
+:host {
+  display: block;
+}
+
+.context-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 13px;
+
+  .context-model {
+    font-weight: 500;
+    color: var(--ud-text-secondary);
+  }
+}
+
+.advanced-section {
+  margin-bottom: 12px;
+
+  .advanced-toggle {
+    font-size: 12px;
+    color: var(--ud-text-secondary);
+  }
+
+  .advanced-content {
+    margin-top: 8px;
+  }
+
+  .system-prompt-editor {
+    width: 100%;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 8px;
+    border: 1px solid var(--ud-border);
+    border-radius: var(--ud-radius-sm);
+    resize: vertical;
+  }
+}
+
+.conversation {
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.message {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--ud-border-subtle, #eee);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .message-icon {
+    flex-shrink: 0;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    color: var(--ud-text-secondary);
+  }
+
+  .message-content {
+    flex: 1;
+    font-size: 14px;
+    line-height: 1.6;
+    word-break: break-word;
+  }
+}
+
+.user-message .message-content {
+  color: var(--ud-text-secondary);
+  font-style: italic;
+}
+
+.stream-progress {
+  margin-top: 8px;
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  color: var(--ud-error, #d32f2f);
+  font-size: 13px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+mat-dialog-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.follow-up-bar {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .follow-up-input {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid var(--ud-border);
+    border-radius: var(--ud-radius-sm);
+    font-size: 14px;
+    outline: none;
+
+    &:focus {
+      border-color: var(--ud-accent);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -12,14 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, Inject, computed, signal, OnInit } from '@angular/core';
+import { Component, Inject, computed, signal, OnInit, Pipe, PipeTransform } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { MaterialModule } from '../../material.module';
 import { AiAnalysisService } from './ai-analysis.service';
 import { AiAnalyzeRequest, AiModelChoice, ConversationMessage } from './ai-analysis.models';
 import { RegistryDashService } from '../registry-dash.service';
+import { marked } from 'marked';
+
+@Pipe({ name: 'markdown', standalone: true })
+export class MarkdownPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+  transform(value: string): SafeHtml {
+    if (!value) return '';
+    const html = marked.parse(value, { async: false }) as string;
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+}
 
 export interface AiAnalysisModalData {
   title: string;
@@ -36,16 +48,16 @@ export interface AiAnalysisModalData {
 @Component({
   selector: 'app-ai-analysis-modal',
   standalone: true,
-  imports: [CommonModule, MaterialModule, FormsModule],
+  imports: [CommonModule, MaterialModule, FormsModule, MarkdownPipe],
   templateUrl: './ai-analysis-modal.component.html',
   styleUrls: ['./ai-analysis-modal.component.scss'],
 })
 export class AiAnalysisModalComponent implements OnInit {
   selectedModel = signal<AiModelChoice>('sonnet');
   conversationHistory = signal<ConversationMessage[]>([]);
-  followUpInput = signal('');
+  followUpText = '';
   showAdvanced = signal(false);
-  editableSystemPrompt = signal('');
+  editableSystemPrompt = '';
 
   streaming = computed(() => this.aiService.streaming());
   streamedText = computed(() => this.aiService.streamedText());
@@ -78,7 +90,7 @@ export class AiAnalysisModalComponent implements OnInit {
       metadata: this.data.metadata,
       chartData: this.data.chartData,
       model: this.selectedModel(),
-      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt : undefined,
       conversationHistory: history,
     });
 
@@ -91,7 +103,7 @@ export class AiAnalysisModalComponent implements OnInit {
   }
 
   async sendFollowUp() {
-    const input = this.followUpInput().trim();
+    const input = this.followUpText.trim();
     if (!input || this.streaming()) return;
 
     const updatedHistory: ConversationMessage[] = [
@@ -99,7 +111,7 @@ export class AiAnalysisModalComponent implements OnInit {
       { role: 'user', content: input },
     ];
     this.conversationHistory.set(updatedHistory);
-    this.followUpInput.set('');
+    this.followUpText = '';
 
     await this.aiService.analyze({
       page: this.data.page,
@@ -107,7 +119,7 @@ export class AiAnalysisModalComponent implements OnInit {
       metadata: this.data.metadata,
       chartData: this.data.chartData,
       model: this.selectedModel(),
-      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt : undefined,
       conversationHistory: updatedHistory,
     });
 
@@ -133,8 +145,8 @@ export class AiAnalysisModalComponent implements OnInit {
 
   toggleAdvanced() {
     this.showAdvanced.update(v => !v);
-    if (this.showAdvanced() && !this.editableSystemPrompt()) {
-      this.editableSystemPrompt.set(this.data.systemPrompt ?? '');
+    if (this.showAdvanced() && !this.editableSystemPrompt) {
+      this.editableSystemPrompt = this.data.systemPrompt ?? '';
     }
   }
 }

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Inject, computed, signal, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '../../material.module';
+import { AiAnalysisService } from './ai-analysis.service';
+import { AiAnalyzeRequest, AiModelChoice, ConversationMessage } from './ai-analysis.models';
+import { RegistryDashService } from '../registry-dash.service';
+
+export interface AiAnalysisModalData {
+  title: string;
+  page: AiAnalyzeRequest['page'];
+  promptType: string;
+  userMessage: string;
+  metadata: AiAnalyzeRequest['metadata'];
+  chartData: any;
+  systemPrompt?: string;
+  isAdmin: boolean;
+  savedModel?: AiModelChoice;
+}
+
+@Component({
+  selector: 'app-ai-analysis-modal',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, FormsModule],
+  templateUrl: './ai-analysis-modal.component.html',
+  styleUrls: ['./ai-analysis-modal.component.scss'],
+})
+export class AiAnalysisModalComponent implements OnInit {
+  selectedModel = signal<AiModelChoice>('sonnet');
+  conversationHistory = signal<ConversationMessage[]>([]);
+  followUpInput = signal('');
+  showAdvanced = signal(false);
+  editableSystemPrompt = signal('');
+
+  streaming = computed(() => this.aiService.streaming());
+  streamedText = computed(() => this.aiService.streamedText());
+  error = computed(() => this.aiService.error());
+
+  constructor(
+    public dialogRef: MatDialogRef<AiAnalysisModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AiAnalysisModalData,
+    private aiService: AiAnalysisService,
+    private dashService: RegistryDashService,
+  ) {
+    if (data.savedModel) {
+      this.selectedModel.set(data.savedModel);
+    }
+  }
+
+  ngOnInit() {
+    this.sendInitialRequest();
+  }
+
+  private async sendInitialRequest() {
+    const history: ConversationMessage[] = [
+      { role: 'user', content: this.data.userMessage },
+    ];
+    this.conversationHistory.set(history);
+
+    await this.aiService.analyze({
+      page: this.data.page,
+      promptType: this.data.promptType,
+      metadata: this.data.metadata,
+      chartData: this.data.chartData,
+      model: this.selectedModel(),
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      conversationHistory: history,
+    });
+
+    if (!this.error()) {
+      this.conversationHistory.update(h => [
+        ...h,
+        { role: 'assistant', content: this.streamedText() },
+      ]);
+    }
+  }
+
+  async sendFollowUp() {
+    const input = this.followUpInput().trim();
+    if (!input || this.streaming()) return;
+
+    const updatedHistory: ConversationMessage[] = [
+      ...this.conversationHistory(),
+      { role: 'user', content: input },
+    ];
+    this.conversationHistory.set(updatedHistory);
+    this.followUpInput.set('');
+
+    await this.aiService.analyze({
+      page: this.data.page,
+      promptType: this.data.promptType,
+      metadata: this.data.metadata,
+      chartData: this.data.chartData,
+      model: this.selectedModel(),
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      conversationHistory: updatedHistory,
+    });
+
+    if (!this.error()) {
+      this.conversationHistory.update(h => [
+        ...h,
+        { role: 'assistant', content: this.streamedText() },
+      ]);
+    }
+  }
+
+  onModelChange(model: AiModelChoice) {
+    this.selectedModel.set(model);
+    this.dashService.updateSettingsSelf({ aiModel: model }).subscribe();
+  }
+
+  onFollowUpKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.sendFollowUp();
+    }
+  }
+
+  toggleAdvanced() {
+    this.showAdvanced.update(v => !v);
+    if (this.showAdvanced() && !this.editableSystemPrompt()) {
+      this.editableSystemPrompt.set(this.data.systemPrompt ?? '');
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -133,6 +133,7 @@ export class AiAnalysisModalComponent implements OnInit {
 
   onModelChange(model: AiModelChoice) {
     this.selectedModel.set(model);
+    localStorage.setItem('ai-model-preference', model);
     this.dashService.updateSettingsSelf({ aiModel: model }).subscribe();
   }
 

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface AiAnalyzeRequest {
+  page: 'domain-activity' | 'revenue-billing' | 'forecasting';
+  promptType: string;
+  metadata: {
+    dateRange: { start: string; end: string };
+    granularity?: string;
+    filteredTlds: string[];
+    filteredRegistrars: string[];
+    [key: string]: any;
+  };
+  chartData: any;
+  model?: string;
+  systemPrompt?: string;
+  conversationHistory: ConversationMessage[];
+}
+
+export interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AiPromptOption {
+  icon: string;
+  label: string;
+  promptType: string;
+  userMessage: string;
+}
+
+export type AiModelChoice = 'haiku' | 'sonnet' | 'opus';

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 export interface AiAnalyzeRequest {
-  page: 'domain-activity' | 'revenue-billing' | 'forecasting';
+  page: 'domain-activity' | 'revenue-billing' | 'forecasting' | 'explore' | 'overview';
   promptType: string;
   metadata: {
     dateRange: { start: string; end: string };

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Injectable, signal } from '@angular/core';
+import { AiAnalyzeRequest } from './ai-analysis.models';
+
+@Injectable({ providedIn: 'root' })
+export class AiAnalysisService {
+  streaming = signal(false);
+  streamedText = signal('');
+  error = signal<string | null>(null);
+
+  async analyze(request: AiAnalyzeRequest): Promise<void> {
+    this.streaming.set(true);
+    this.streamedText.set('');
+    this.error.set(null);
+
+    try {
+      const xsrfCookie = document.cookie
+        .split('; ')
+        .find(c => c.startsWith('X-CSRF-Token='));
+      const xsrfToken = xsrfCookie?.split('=')[1] ?? '';
+
+      const response = await fetch('/console-api/registry-dash/ai/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        credentials: 'same-origin',
+      });
+
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After');
+        const minutes = retryAfter ? Math.ceil(parseInt(retryAfter, 10) / 60) : 5;
+        this.error.set(`Analysis limit reached. Try again in ${minutes} minutes.`);
+        return;
+      }
+      if (response.status === 502) {
+        this.error.set('Analysis temporarily unavailable. Please try again.');
+        return;
+      }
+      if (response.status === 503) {
+        this.error.set('AI service is busy. Please try again shortly.');
+        return;
+      }
+      if (!response.ok) {
+        this.error.set('Analysis failed. Please try again.');
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        this.error.set('Streaming not supported.');
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let accumulated = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.substring(6).trim();
+          if (data === '[DONE]') break;
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.text) {
+              accumulated += parsed.text;
+              this.streamedText.set(accumulated);
+            }
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } catch (e) {
+      this.error.set('Response interrupted. Try again?');
+    } finally {
+      this.streaming.set(false);
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { AiPromptOption } from './ai-analysis.models';
+
+export const DOMAIN_ACTIVITY_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize the key trends in domain activity — lifecycle patterns, growth or decline across TLDs.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage:
+      'Identify anomalies in domain activity — unexpected spikes, unusual create/delete ratios, outlier TLDs.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Based on this domain activity data, suggest specific actions for retention and growth.',
+  },
+];
+
+export const REVENUE_BILLING_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize revenue trends — key drivers, growth percentages, TLD performance comparison.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage:
+      'Identify revenue anomalies — unexpected spikes or drops, declining segments, unusual patterns.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Based on this revenue data, suggest pricing adjustments, registrar outreach, or growth opportunities.',
+  },
+];
+
+export const FORECASTING_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize renewal health — overall rates, TLD comparison, trajectory.',
+  },
+  {
+    icon: 'warning',
+    label: 'Identify risks',
+    promptType: 'identify_risks',
+    userMessage:
+      'Identify risks — expiration cliffs, declining registrars, TLDs with dropping renewal rates.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Suggest retention strategies, pricing recommendations, and proactive outreach based on this forecast data.',
+  },
+];
+
+export const PROMPTS_BY_PAGE: Record<string, AiPromptOption[]> = {
+  'domain-activity': DOMAIN_ACTIVITY_PROMPTS,
+  'revenue-billing': REVENUE_BILLING_PROMPTS,
+  forecasting: FORECASTING_PROMPTS,
+};

--- a/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
@@ -86,8 +86,54 @@ export const FORECASTING_PROMPTS: AiPromptOption[] = [
   },
 ];
 
+export const EXPLORE_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage: 'Summarize the key trends visible in this data.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage: 'Identify any anomalies or unusual patterns in this data.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage: 'Based on this data, what actions would you recommend?',
+  },
+];
+
+export const OVERVIEW_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize the key trends across the registry — activity patterns, renewal health, and overall performance.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage: 'Identify any anomalies or concerns in the overview metrics.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Based on these overview metrics, what should the registry team focus on?',
+  },
+];
+
 export const PROMPTS_BY_PAGE: Record<string, AiPromptOption[]> = {
   'domain-activity': DOMAIN_ACTIVITY_PROMPTS,
   'revenue-billing': REVENUE_BILLING_PROMPTS,
   forecasting: FORECASTING_PROMPTS,
+  explore: EXPLORE_PROMPTS,
+  overview: OVERVIEW_PROMPTS,
 };

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.html
@@ -1,0 +1,12 @@
+<button mat-icon-button [matMenuTriggerFor]="aiMenu"
+        matTooltip="Analyze with AI"
+        class="sparkle-button">
+  <mat-icon>auto_awesome</mat-icon>
+</button>
+
+<mat-menu #aiMenu="matMenu">
+  <button mat-menu-item *ngFor="let prompt of prompts" (click)="onPromptSelect(prompt)">
+    <mat-icon>{{ prompt.icon }}</mat-icon>
+    <span>{{ prompt.label }}</span>
+  </button>
+</mat-menu>

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.scss
@@ -1,0 +1,14 @@
+.sparkle-button {
+  opacity: 0.6;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
@@ -80,6 +80,10 @@ export class AiSparkleButtonComponent {
         return 'Revenue Billing';
       case 'forecasting':
         return 'Forecasting';
+      case 'explore':
+        return 'Data Exploration';
+      case 'overview':
+        return 'Overview';
     }
   }
 }

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
@@ -45,9 +45,8 @@ export class AiSparkleButtonComponent {
     const range = this.dashService.selectedRangeConfig();
     const tlds = this.dashService.selectedTlds();
     const regIds = this.dashService.selectedRegistrarIds();
-    const savedModel = this.dashService.settingsCache()?.['aiModel'] as
-      | AiModelChoice
-      | undefined;
+    const savedModel = (this.dashService.settingsCache()?.['aiModel']
+      || localStorage.getItem('ai-model-preference')) as AiModelChoice | undefined;
 
     const data: AiAnalysisModalData = {
       title: `${prompt.label} — ${this.pageLabel()}`,

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { MaterialModule } from '../../material.module';
+import {
+  AiAnalysisModalComponent,
+  AiAnalysisModalData,
+} from './ai-analysis-modal.component';
+import { AiPromptOption, AiAnalyzeRequest, AiModelChoice } from './ai-analysis.models';
+import { RegistryDashService } from '../registry-dash.service';
+
+@Component({
+  selector: 'app-ai-sparkle-button',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './ai-sparkle-button.component.html',
+  styleUrls: ['./ai-sparkle-button.component.scss'],
+})
+export class AiSparkleButtonComponent {
+  @Input({ required: true }) page!: AiAnalyzeRequest['page'];
+  @Input({ required: true }) prompts!: AiPromptOption[];
+  @Input({ required: true }) chartData!: any;
+  @Input() isAdmin = false;
+
+  constructor(
+    private dialog: MatDialog,
+    private dashService: RegistryDashService,
+  ) {}
+
+  onPromptSelect(prompt: AiPromptOption) {
+    const range = this.dashService.selectedRangeConfig();
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+    const savedModel = this.dashService.settingsCache()?.['aiModel'] as
+      | AiModelChoice
+      | undefined;
+
+    const data: AiAnalysisModalData = {
+      title: `${prompt.label} — ${this.pageLabel()}`,
+      page: this.page,
+      promptType: prompt.promptType,
+      userMessage: prompt.userMessage,
+      metadata: {
+        dateRange: { start: '', end: '' },
+        granularity: range?.granularity,
+        filteredTlds: tlds,
+        filteredRegistrars: regIds,
+      },
+      chartData: this.chartData,
+      isAdmin: this.isAdmin,
+      savedModel,
+    };
+
+    this.dialog.open(AiAnalysisModalComponent, {
+      width: '800px',
+      maxHeight: '90vh',
+      data,
+    });
+  }
+
+  private pageLabel(): string {
+    switch (this.page) {
+      case 'domain-activity':
+        return 'Domain Activity';
+      case 'revenue-billing':
+        return 'Revenue Billing';
+      case 'forecasting':
+        return 'Forecasting';
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html
@@ -55,9 +55,16 @@
     <div class="chart-container" *ngIf="activityByTldOptions()">
       <div class="chart-title-row">
         <h3>Activity Breakdown by TLD</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreActivityByTld()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="domain-activity"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreActivityByTld()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Total domain transactions grouped by TLD and operation type for the selected time period.</p>
       <div appLongPress (longPress)="onActivityByTldLongPress()">
@@ -70,9 +77,16 @@
     <div class="chart-container" *ngIf="domainCountsBarOptions()">
       <div class="chart-title-row">
         <h3>Current Domain Counts by TLD</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreDomainCounts()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="domain-activity"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreDomainCounts()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Current number of active (non-deleted) domains per TLD. This count is independent of the selected time period.</p>
       <div appLongPress (longPress)="onDomainCountsLongPress()">

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.scss
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.scss
@@ -79,6 +79,12 @@
   justify-content: space-between;
 }
 
+.chart-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .explore-btn {
   opacity: 0.5;
   &:hover { opacity: 1; }

--- a/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
+++ b/console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts
@@ -25,6 +25,8 @@ import { ExploreService } from '../explore/explore.service';
 import { withDrillDown } from '../ud-echarts';
 import { LongPressDirective } from '../drilldown/long-press.directive';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { DOMAIN_ACTIVITY_PROMPTS } from '../ai/ai-prompts';
 
 const ACTIVITY_COLORS: Record<string, string> = {
   CREATES: '#0D67FE',
@@ -42,13 +44,14 @@ const TLD_COLORS = [
 @Component({
   selector: 'app-domain-activity',
   standalone: true,
-  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective, FilterPanelComponent],
+  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective, FilterPanelComponent, AiSparkleButtonComponent],
   providers: [UD_ECHARTS_PROVIDER],
   templateUrl: './domain-activity.component.html',
   styleUrls: ['./domain-activity.component.scss'],
 })
 export class DomainActivityComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
+  readonly aiPrompts = DOMAIN_ACTIVITY_PROMPTS;
   lastHoveredActivityByTld: any = null;
   lastHoveredDomainCounts: any = null;
 

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -39,6 +39,16 @@
   </div>
 
   <!-- Chart -->
+  <div class="chart-title-row" *ngIf="result() && result()!.rows.length > 0">
+    <span></span>
+    <div class="chart-actions">
+      <app-ai-sparkle-button
+        page="explore"
+        [prompts]="aiPrompts"
+        [chartData]="result()">
+      </app-ai-sparkle-button>
+    </div>
+  </div>
   <app-explore-chart
     [result]="result()"
     [chartType]="chartType()"

--- a/console-webapp/src/app/registry-dash/explore/explore.component.scss
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.scss
@@ -67,6 +67,19 @@
   }
 }
 
+.chart-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.chart-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .data-table-wrapper {
   margin-top: 24px;
 

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -22,11 +22,13 @@ import { ExploreService } from './explore.service';
 import { ExploreBuilderComponent } from './explore-builder/explore-builder.component';
 import { ExploreChartComponent } from './explore-chart/explore-chart.component';
 import { ChartType, DEFAULT_QUERY, ExploreQuery } from './explore.models';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { EXPLORE_PROMPTS } from '../ai/ai-prompts';
 
 @Component({
   selector: 'app-explore',
   standalone: true,
-  imports: [CommonModule, MaterialModule, ExploreBuilderComponent, ExploreChartComponent],
+  imports: [CommonModule, MaterialModule, ExploreBuilderComponent, ExploreChartComponent, AiSparkleButtonComponent],
   templateUrl: './explore.component.html',
   styleUrls: ['./explore.component.scss'],
 })
@@ -34,6 +36,7 @@ export class ExploreComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private dashService = inject(RegistryDashService);
   exploreService = inject(ExploreService);
+  readonly aiPrompts = EXPLORE_PROMPTS;
 
   query = signal<ExploreQuery>({ ...DEFAULT_QUERY, filters: { ...DEFAULT_QUERY.filters } });
   chartType = signal<ChartType>('bar');

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html
@@ -55,9 +55,16 @@
     <div class="chart-container full-width" *ngIf="netGrowthOptions()">
       <div class="chart-title-row">
         <h3>Net Growth Projection</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreNetGrowth()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="forecasting"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreNetGrowth()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Net domain growth per period (creates minus deletes). Dashed lines show projected values based on the selected forecast method.</p>
       <div appLongPress (longPress)="onNetGrowthLongPress()">
@@ -69,9 +76,16 @@
     <div class="chart-container full-width" *ngIf="expirationCurveOptions()">
       <div class="chart-title-row">
         <h3>Domain Expirations by TLD</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreExpirationCurve()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="forecasting"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreExpirationCurve()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Upcoming domain expirations grouped by TLD. Shows when domains are due to expire and may need renewal.</p>
       <div appLongPress (longPress)="onExpirationLongPress()">

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.scss
@@ -65,6 +65,12 @@
   justify-content: space-between;
 }
 
+.chart-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .explore-btn {
   opacity: 0.5;
   &:hover { opacity: 1; }

--- a/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts
@@ -24,6 +24,8 @@ import { DrillDownService } from '../../drilldown/drilldown.service';
 import { ExploreService } from '../../explore/explore.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
+import { AiSparkleButtonComponent } from '../../ai/ai-sparkle-button.component';
+import { FORECASTING_PROMPTS } from '../../ai/ai-prompts';
 
 const TLD_COLORS = [
   '#0D67FE', '#0546B7', '#65A1DA', '#192B55',
@@ -37,13 +39,14 @@ type ForecastMethod = 'none' | 'trend' | 'confidence' | 'ema' | 'seasonal';
 @Component({
   selector: 'app-forecasting',
   standalone: true,
-  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective],
+  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective, AiSparkleButtonComponent],
   providers: [UD_ECHARTS_PROVIDER],
   templateUrl: './forecasting.component.html',
   styleUrls: ['./forecasting.component.scss'],
 })
 export class ForecastingComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
+  readonly aiPrompts = FORECASTING_PROMPTS;
   lastHoveredNetGrowth: any = null;
   lastHoveredExpiration: any = null;
   forecastMethod = signal<ForecastMethod>('trend');

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html
@@ -52,9 +52,16 @@
     <div class="chart-container full-width" *ngIf="revenueLineOptions()">
       <div class="chart-title-row">
         <h3>Registry Revenue by TLD</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreRevenueByTld()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="revenue-billing"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreRevenueByTld()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Net registry revenue per TLD over the selected period — what the registry received after RSP fees.</p>
       <div appLongPress (longPress)="onRevenueByTldLongPress()">
@@ -67,9 +74,16 @@
     <div class="chart-container full-width" *ngIf="operationBarOptions()">
       <div class="chart-title-row">
         <h3>Registry Revenue by Operation</h3>
-        <button mat-icon-button class="explore-btn" (click)="exploreRevenueByOperation()" matTooltip="Explore this data">
-          <mat-icon>open_in_new</mat-icon>
-        </button>
+        <div class="chart-actions">
+          <app-ai-sparkle-button
+            page="revenue-billing"
+            [prompts]="aiPrompts"
+            [chartData]="data()">
+          </app-ai-sparkle-button>
+          <button mat-icon-button class="explore-btn" (click)="exploreRevenueByOperation()" matTooltip="Explore this data">
+            <mat-icon>open_in_new</mat-icon>
+          </button>
+        </div>
       </div>
       <p class="chart-description">Net registry revenue by operation type over the selected period — CREATE, RENEW, TRANSFER, and RESTORE amounts after RSP fees.</p>
       <div appLongPress (longPress)="onRevenueByOpLongPress()">

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.scss
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.scss
@@ -59,6 +59,12 @@
   justify-content: space-between;
 }
 
+.chart-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .explore-btn {
   opacity: 0.5;
   &:hover { opacity: 1; }

--- a/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
+++ b/console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts
@@ -24,6 +24,8 @@ import { DrillDownService } from '../../drilldown/drilldown.service';
 import { ExploreService } from '../../explore/explore.service';
 import { withDrillDown } from '../../ud-echarts';
 import { LongPressDirective } from '../../drilldown/long-press.directive';
+import { AiSparkleButtonComponent } from '../../ai/ai-sparkle-button.component';
+import { REVENUE_BILLING_PROMPTS } from '../../ai/ai-prompts';
 
 const OPERATION_COLORS: Record<string, string> = {
   CREATE: '#0D67FE',
@@ -40,13 +42,14 @@ const TLD_COLORS = [
 @Component({
   selector: 'app-revenue-billing',
   standalone: true,
-  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective],
+  imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective, AiSparkleButtonComponent],
   providers: [UD_ECHARTS_PROVIDER],
   templateUrl: './revenue-billing.component.html',
   styleUrls: ['./revenue-billing.component.scss'],
 })
 export class RevenueBillingComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
+  readonly aiPrompts = REVENUE_BILLING_PROMPTS;
   lastHoveredRevenueByTld: any = null;
   lastHoveredRevenueByOp: any = null;
 

--- a/console-webapp/src/app/registry-dash/overview/overview.component.html
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.html
@@ -39,9 +39,16 @@
         <mat-card-content>
           <div class="chart-title-row">
             <h3 class="chart-title">Registrar Market Share</h3>
-            <button mat-icon-button class="explore-btn" (click)="exploreRegistrarMarketShare()" matTooltip="Explore this data">
-              <mat-icon>open_in_new</mat-icon>
-            </button>
+            <div class="chart-actions">
+              <app-ai-sparkle-button
+                page="overview"
+                [prompts]="aiPrompts"
+                [chartData]="dashService.overview()">
+              </app-ai-sparkle-button>
+              <button mat-icon-button class="explore-btn" (click)="exploreRegistrarMarketShare()" matTooltip="Explore this data">
+                <mat-icon>open_in_new</mat-icon>
+              </button>
+            </div>
           </div>
           <p class="chart-description">Number of active domains managed by each registrar. Longer bars indicate a larger share of the total domain portfolio.</p>
           <div class="h-bar-chart">
@@ -70,9 +77,16 @@
         <mat-card-content>
           <div class="chart-title-row">
             <h3 class="chart-title">Domain Activity Trend</h3>
-            <button mat-icon-button class="explore-btn" (click)="exploreActivityTrend()" matTooltip="Explore this data">
-              <mat-icon>open_in_new</mat-icon>
-            </button>
+            <div class="chart-actions">
+              <app-ai-sparkle-button
+                page="overview"
+                [prompts]="aiPrompts"
+                [chartData]="dashService.domainActivity()">
+              </app-ai-sparkle-button>
+              <button mat-icon-button class="explore-btn" (click)="exploreActivityTrend()" matTooltip="Explore this data">
+                <mat-icon>open_in_new</mat-icon>
+              </button>
+            </div>
           </div>
           <p class="chart-description">Domain registration activity over time — creates, renews, transfers, deletes, and restores aggregated across all TLDs.</p>
           <div appLongPress (longPress)="onActivityLongPress()">
@@ -88,9 +102,16 @@
         <mat-card-content>
           <div class="chart-title-row">
             <h3 class="chart-title">Renewal Rate by TLD</h3>
-            <button mat-icon-button class="explore-btn" (click)="exploreRenewalRate()" matTooltip="Explore this data">
-              <mat-icon>open_in_new</mat-icon>
-            </button>
+            <div class="chart-actions">
+              <app-ai-sparkle-button
+                page="overview"
+                [prompts]="aiPrompts"
+                [chartData]="dashService.forecasting()">
+              </app-ai-sparkle-button>
+              <button mat-icon-button class="explore-btn" (click)="exploreRenewalRate()" matTooltip="Explore this data">
+                <mat-icon>open_in_new</mat-icon>
+              </button>
+            </div>
           </div>
           <p class="chart-description">Percentage of expiring domains that were renewed (vs. deleted/expired) per TLD over the selected time period. The dashed line marks the 85% industry benchmark.</p>
           <div appLongPress (longPress)="onRenewalLongPress()">

--- a/console-webapp/src/app/registry-dash/overview/overview.component.scss
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.scss
@@ -56,6 +56,12 @@
     justify-content: space-between;
   }
 
+  .chart-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   .chart-title {
     margin: 0 0 4px;
     font-size: 0.95rem;

--- a/console-webapp/src/app/registry-dash/overview/overview.component.ts
+++ b/console-webapp/src/app/registry-dash/overview/overview.component.ts
@@ -25,6 +25,8 @@ import { ExploreService } from '../explore/explore.service';
 import { ExploreQuery } from '../explore/explore.models';
 import { LongPressDirective } from '../drilldown/long-press.directive';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { OVERVIEW_PROMPTS } from '../ai/ai-prompts';
 
 const CHART_COLORS = [
   '#0D67FE', '#0546B7', '#65A1DA', '#192B55',
@@ -42,13 +44,14 @@ const ACTIVITY_COLORS: Record<string, string> = {
 
 @Component({
   selector: 'app-registry-dash-overview',
-  imports: [MaterialModule, CommonModule, NgxEchartsDirective, LongPressDirective, FilterPanelComponent],
+  imports: [MaterialModule, CommonModule, NgxEchartsDirective, LongPressDirective, FilterPanelComponent, AiSparkleButtonComponent],
   providers: [UD_ECHARTS_PROVIDER],
   templateUrl: './overview.component.html',
   styleUrls: ['./overview.component.scss'],
 })
 export class OverviewComponent {
   private destroyRef = inject(DestroyRef);
+  readonly aiPrompts = OVERVIEW_PROMPTS;
   lastHoveredActivity: any = null;
   lastHoveredRenewal: any = null;
   barChartData = computed(() => {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -181,6 +181,7 @@ dependencies {
   implementation deps['com.jcraft:jsch']
   implementation deps['com.zaxxer:HikariCP']
   implementation deps['com.squareup.okhttp3:okhttp']
+  testImplementation deps['com.squareup.okhttp3:mockwebserver']
   implementation deps['dnsjava:dnsjava']
   testRuntimeOnly deps['guru.nidi:graphviz-java-all-j2v8']
   testImplementation deps['io.github.classgraph:classgraph']

--- a/core/gradle.lockfile
+++ b/core/gradle.lockfile
@@ -223,6 +223,7 @@ com.ibm.icu:icu4j:73.2=compileClasspath,deploy_jar,nonprodCompileClasspath,nonpr
 com.jcraft:jsch:0.1.55=compileClasspath,deploy_jar,nonprodCompileClasspath,nonprodRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.lmax:disruptor:3.4.2=compileClasspath,deploy_jar,nonprodCompileClasspath,nonprodRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.puppycrawl.tools:checkstyle:9.3=checkstyle
+com.squareup.okhttp3:mockwebserver:4.12.0=testCompileClasspath,testRuntimeClasspath
 com.squareup.okhttp3:okhttp:4.12.0=compileClasspath,deploy_jar,nonprodCompileClasspath,nonprodRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.squareup.okio:okio-bom:3.0.0=deploy_jar,nonprodRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 com.squareup.okio:okio-fakefilesystem-jvm:3.4.0=compileClasspath,deploy_jar,nonprodCompileClasspath,nonprodRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath

--- a/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
+++ b/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
@@ -1,0 +1,46 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.List;
+
+/** Request payload for the AI analysis endpoint. */
+public class AiAnalyzeRequest {
+
+  public String page;
+  public String promptType;
+  public JsonObject metadata;
+  public JsonElement chartData;
+  public String model;
+  public String systemPrompt;
+  public List<ConversationMessage> conversationHistory;
+
+  /** A single message in the conversation history. */
+  public static class ConversationMessage {
+    public String role;
+    public String content;
+  }
+
+  public boolean isValid() {
+    return page != null
+        && promptType != null
+        && chartData != null
+        && (page.equals("domain-activity")
+            || page.equals("revenue-billing")
+            || page.equals("forecasting"));
+  }
+}

--- a/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
+++ b/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
@@ -41,6 +41,8 @@ public class AiAnalyzeRequest {
         && chartData != null
         && (page.equals("domain-activity")
             || page.equals("revenue-billing")
-            || page.equals("forecasting"));
+            || page.equals("forecasting")
+            || page.equals("explore")
+            || page.equals("overview"));
   }
 }

--- a/core/src/main/java/google/registry/ai/AiRateLimiter.java
+++ b/core/src/main/java/google/registry/ai/AiRateLimiter.java
@@ -35,7 +35,7 @@ public class AiRateLimiter {
 
   @Inject
   @VisibleForTesting
-  AiRateLimiter(Clock clock, @Named("aiRateLimitPerHour") int maxPerHour) {
+  public AiRateLimiter(Clock clock, @Named("aiRateLimitPerHour") int maxPerHour) {
     this.clock = clock;
     this.maxPerHour = maxPerHour;
   }

--- a/core/src/main/java/google/registry/ai/AiRateLimiter.java
+++ b/core/src/main/java/google/registry/ai/AiRateLimiter.java
@@ -1,0 +1,70 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import com.google.common.annotations.VisibleForTesting;
+import google.registry.util.Clock;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.joda.time.Duration;
+
+@Singleton
+public class AiRateLimiter {
+
+  private static final Duration WINDOW = Duration.standardHours(1);
+
+  private final Clock clock;
+  private final int maxPerHour;
+  private final ConcurrentHashMap<String, Deque<Long>> requests = new ConcurrentHashMap<>();
+
+  @Inject
+  @VisibleForTesting
+  AiRateLimiter(Clock clock, @Named("aiRateLimitPerHour") int maxPerHour) {
+    this.clock = clock;
+    this.maxPerHour = maxPerHour;
+  }
+
+  public boolean tryAcquire(String userEmail) {
+    long now = clock.nowUtc().getMillis();
+    long cutoff = now - WINDOW.getMillis();
+    Deque<Long> timestamps =
+        requests.computeIfAbsent(userEmail, k -> new ConcurrentLinkedDeque<>());
+
+    while (!timestamps.isEmpty() && timestamps.peekFirst() <= cutoff) {
+      timestamps.pollFirst();
+    }
+
+    if (timestamps.size() >= maxPerHour) {
+      return false;
+    }
+    timestamps.addLast(now);
+    return true;
+  }
+
+  public long getRetryAfterSeconds(String userEmail) {
+    long now = clock.nowUtc().getMillis();
+    Deque<Long> timestamps = requests.get(userEmail);
+    if (timestamps == null || timestamps.isEmpty()) {
+      return 0;
+    }
+    long oldest = timestamps.peekFirst();
+    long expiresAt = oldest + WINDOW.getMillis();
+    return Math.max(1, (expiresAt - now) / 1000);
+  }
+}

--- a/core/src/main/java/google/registry/ai/AnthropicClient.java
+++ b/core/src/main/java/google/registry/ai/AnthropicClient.java
@@ -40,8 +40,8 @@ public class AnthropicClient {
   private static final int MAX_TOKENS = 4096;
   private static final Map<String, String> MODEL_MAP = Map.of(
       "haiku", "claude-haiku-4-5-20251001",
-      "sonnet", "claude-sonnet-4-6-20250514",
-      "opus", "claude-opus-4-6-20250514");
+      "sonnet", "claude-sonnet-4-5-20250929",
+      "opus", "claude-opus-4-6");
   private static final Gson GSON = new Gson();
 
   private final OkHttpClient httpClient;

--- a/core/src/main/java/google/registry/ai/AnthropicClient.java
+++ b/core/src/main/java/google/registry/ai/AnthropicClient.java
@@ -1,0 +1,143 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Singleton
+public class AnthropicClient {
+
+  private static final String ANTHROPIC_VERSION = "2023-06-01";
+  private static final int MAX_TOKENS = 4096;
+  private static final Map<String, String> MODEL_MAP = Map.of(
+      "haiku", "claude-haiku-4-5-20251001",
+      "sonnet", "claude-sonnet-4-6-20250514",
+      "opus", "claude-opus-4-6-20250514");
+  private static final Gson GSON = new Gson();
+
+  private final OkHttpClient httpClient;
+  private final String baseUrl;
+  private final String apiKey;
+  private final String defaultModel;
+
+  @Inject
+  public AnthropicClient(
+      @Named("anthropicHttpClient") OkHttpClient httpClient,
+      @Named("anthropicApiBaseUrl") String baseUrl,
+      @Named("anthropicApiKey") String apiKey,
+      @Named("anthropicDefaultModel") String defaultModel) {
+    this.httpClient = httpClient;
+    this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    this.apiKey = apiKey;
+    this.defaultModel = defaultModel;
+  }
+
+  public void streamMessage(
+      String systemPrompt,
+      List<AiAnalyzeRequest.ConversationMessage> conversationHistory,
+      String modelOverride,
+      Consumer<String> onChunk) throws IOException {
+
+    String model = resolveModelId(modelOverride != null ? modelOverride : defaultModel);
+
+    JsonObject body = new JsonObject();
+    body.addProperty("model", model);
+    body.addProperty("max_tokens", MAX_TOKENS);
+    body.addProperty("stream", true);
+    body.addProperty("system", systemPrompt);
+
+    JsonArray messages = new JsonArray();
+    if (conversationHistory != null) {
+      for (AiAnalyzeRequest.ConversationMessage msg : conversationHistory) {
+        JsonObject msgObj = new JsonObject();
+        msgObj.addProperty("role", msg.role);
+        msgObj.addProperty("content", msg.content);
+        messages.add(msgObj);
+      }
+    }
+    body.add("messages", messages);
+
+    RequestBody requestBody = RequestBody.create(
+        GSON.toJson(body), MediaType.parse("application/json"));
+
+    Request request = new Request.Builder()
+        .url(baseUrl + "/v1/messages")
+        .post(requestBody)
+        .addHeader("x-api-key", apiKey)
+        .addHeader("anthropic-version", ANTHROPIC_VERSION)
+        .addHeader("Content-Type", "application/json")
+        .build();
+
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (response.code() == 429) {
+        throw new AnthropicRateLimitException("Anthropic API rate limited: " + response.code());
+      }
+      if (!response.isSuccessful()) {
+        throw new IOException("Anthropic API error: " + response.code());
+      }
+
+      try (BufferedReader reader = new BufferedReader(
+          new InputStreamReader(response.body().byteStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (!line.startsWith("data: ")) continue;
+          String data = line.substring(6).trim();
+          if (data.equals("[DONE]")) break;
+
+          try {
+            JsonObject event = GSON.fromJson(data, JsonObject.class);
+            if (event.has("type")
+                && event.get("type").getAsString().equals("content_block_delta")) {
+              JsonObject delta = event.getAsJsonObject("delta");
+              if (delta.has("text")) {
+                onChunk.accept(delta.get("text").getAsString());
+              }
+            }
+          } catch (Exception e) {
+            // Skip non-JSON or non-delta lines
+          }
+        }
+      }
+    }
+  }
+
+  public static String resolveModelId(String shortName) {
+    return MODEL_MAP.getOrDefault(shortName, MODEL_MAP.get("sonnet"));
+  }
+
+  /** Thrown when Anthropic returns 429. */
+  public static class AnthropicRateLimitException extends IOException {
+    public AnthropicRateLimitException(String message) {
+      super(message);
+    }
+  }
+}

--- a/core/src/main/java/google/registry/ai/AnthropicModule.java
+++ b/core/src/main/java/google/registry/ai/AnthropicModule.java
@@ -45,6 +45,10 @@ public final class AnthropicModule {
   static String provideAnthropicApiKey(
       SecretManagerClient secretManagerClient,
       @Config("anthropicApiKeySecretName") String secretName) {
+    String envKey = System.getenv("ANTHROPIC_API_KEY");
+    if (envKey != null && !envKey.isEmpty()) {
+      return envKey;
+    }
     return secretManagerClient.getSecretData(secretName, Optional.of(LATEST_SECRET_VERSION));
   }
 

--- a/core/src/main/java/google/registry/ai/AnthropicModule.java
+++ b/core/src/main/java/google/registry/ai/AnthropicModule.java
@@ -1,0 +1,72 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import dagger.Module;
+import dagger.Provides;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.privileges.secretmanager.SecretManagerClient;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+
+@Module
+public final class AnthropicModule {
+
+  private static final String LATEST_SECRET_VERSION = "latest";
+
+  @Provides
+  @Singleton
+  @Named("anthropicHttpClient")
+  static OkHttpClient provideAnthropicHttpClient() {
+    return new OkHttpClient.Builder()
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .build();
+  }
+
+  @Provides
+  @Singleton
+  @Named("anthropicApiKey")
+  static String provideAnthropicApiKey(
+      SecretManagerClient secretManagerClient,
+      @Config("anthropicApiKeySecretName") String secretName) {
+    return secretManagerClient.getSecretData(secretName, Optional.of(LATEST_SECRET_VERSION));
+  }
+
+  @Provides
+  @Named("anthropicApiBaseUrl")
+  @SuppressWarnings("UseBinds")
+  static String provideAnthropicApiBaseUrl(@Config("anthropicApiBaseUrl") String baseUrl) {
+    return baseUrl;
+  }
+
+  @Provides
+  @Named("anthropicDefaultModel")
+  @SuppressWarnings("UseBinds")
+  static String provideAnthropicDefaultModel(@Config("anthropicDefaultModel") String model) {
+    return model;
+  }
+
+  @Provides
+  @Singleton
+  @Named("aiRateLimitPerHour")
+  @SuppressWarnings("UseBinds")
+  static int provideAiRateLimitPerHour(@Config("anthropicRateLimitPerHour") int limit) {
+    return limit;
+  }
+}

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1449,6 +1449,30 @@ public final class RegistryConfig {
       return config.mosapi.tldThreadCount;
     }
 
+    @Provides
+    @Config("anthropicApiBaseUrl")
+    public static String provideAnthropicApiBaseUrl(RegistryConfigSettings config) {
+      return config.ai.apiBaseUrl;
+    }
+
+    @Provides
+    @Config("anthropicApiKeySecretName")
+    public static String provideAnthropicApiKeySecretName(RegistryConfigSettings config) {
+      return config.ai.apiKeySecretName;
+    }
+
+    @Provides
+    @Config("anthropicDefaultModel")
+    public static String provideAnthropicDefaultModel(RegistryConfigSettings config) {
+      return config.ai.defaultModel;
+    }
+
+    @Provides
+    @Config("anthropicRateLimitPerHour")
+    public static int provideAnthropicRateLimitPerHour(RegistryConfigSettings config) {
+      return config.ai.rateLimitPerHour;
+    }
+
     private static String formatComments(String text) {
       return Splitter.on('\n').omitEmptyStrings().trimResults().splitToList(text).stream()
           .map(s -> "# " + s)

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -43,6 +43,7 @@ public class RegistryConfigSettings {
   public BulkPricingPackageMonitoring bulkPricingPackageMonitoring;
   public Bsa bsa;
   public MosApi mosapi;
+  public Ai ai;
 
   /** Configuration options that apply to the entire GCP project. */
   public static class GcpProject {
@@ -255,6 +256,14 @@ public class RegistryConfigSettings {
     public String orderStatusUrl;
     public String unblockableDomainsUrl;
     public String uploadUnavailableDomainsUrl;
+  }
+
+  /** Configuration for AI (Anthropic) integration. */
+  public static class Ai {
+    public String apiBaseUrl;
+    public String apiKeySecretName;
+    public String defaultModel;
+    public int rateLimitPerHour;
   }
 
   /** Configuration for Mosapi. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -639,3 +639,12 @@ mosapi:
   # ICANN MoSAPI Specification, Section 12.3</a>
   tldThreadCount: 4
 
+ai:
+  # Anthropic API base URL
+  apiBaseUrl: https://api.anthropic.com
+  # Secret Manager secret name for the Anthropic API key
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  # Default model (haiku, sonnet, opus)
+  defaultModel: sonnet
+  # Rate limit: max requests per user per hour
+  rateLimitPerHour: 120

--- a/core/src/main/java/google/registry/module/RegistryComponent.java
+++ b/core/src/main/java/google/registry/module/RegistryComponent.java
@@ -19,6 +19,7 @@ import dagger.Component;
 import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
+import google.registry.ai.AnthropicModule;
 import google.registry.batch.BatchModule;
 import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CloudTasksUtilsModule;
@@ -59,6 +60,7 @@ import jakarta.inject.Singleton;
 @Singleton
 @Component(
     modules = {
+      AnthropicModule.class,
       AuthModule.class,
       BatchModule.class,
       BigqueryModule.class,

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -131,6 +131,7 @@ import google.registry.ui.server.console.PasswordResetVerifyAction;
 import google.registry.ui.server.console.RegistrarsAction;
 import google.registry.ui.server.console.domains.ConsoleBulkDomainAction;
 import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
+import google.registry.ui.server.console.registrydash.RegistryDashAiAction;
 import google.registry.ui.server.console.registrydash.RegistryDashExploreAction;
 import google.registry.ui.server.console.registrydash.RegistryDashCostBasisAction;
 import google.registry.ui.server.console.registrydash.RegistryDashDomainActivityAction;
@@ -349,6 +350,8 @@ interface RequestComponent {
   RegistryDashForecastingAction registryDashForecastingAction();
 
   RegistryDashSettingsAction registryDashSettingsAction();
+
+  RegistryDashAiAction registryDashAiAction();
 
   UDRegistryDashTldFeesAction udRegistryDashTldFeesAction();
 

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
@@ -454,4 +454,11 @@ public final class ConsoleModule {
       @OptionalJsonPayload Optional<JsonElement> payload) {
     return payload;
   }
+
+  @Provides
+  @Parameter("aiAnalyzePayload")
+  public static Optional<JsonElement> provideAiAnalyzePayload(
+      @OptionalJsonPayload Optional<JsonElement> payload) {
+    return payload;
+  }
 }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -99,6 +99,12 @@ public class RegistryDashAiAction extends ConsoleApiAction {
 
     String systemPrompt = buildSystemPrompt(request, user);
     String model = request.model;
+    String resolvedModel = AnthropicClient.resolveModelId(model != null ? model : "sonnet");
+
+    logger.atInfo().log(
+        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s, historySize=%d",
+        userEmail, request.page, request.promptType, resolvedModel,
+        request.conversationHistory != null ? request.conversationHistory.size() : 0);
 
     try {
       PrintWriter writer = consoleApiParams.response().getWriter();

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -50,6 +50,8 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   private static final int SC_TOO_MANY_REQUESTS = 429;
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  private static final Gson PLAIN_GSON = new Gson();
+
   private final Optional<JsonElement> payload;
   private final AnthropicClient anthropicClient;
   private final AiRateLimiter rateLimiter;
@@ -80,7 +82,7 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       return;
     }
 
-    AiAnalyzeRequest request = gson.fromJson(payload.get(), AiAnalyzeRequest.class);
+    AiAnalyzeRequest request = PLAIN_GSON.fromJson(payload.get(), AiAnalyzeRequest.class);
     if (!request.isValid()) {
       setFailedResponse("Invalid request: page and chartData are required", SC_BAD_REQUEST);
       return;

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -118,7 +118,7 @@ public class RegistryDashAiAction extends ConsoleApiAction {
           request.conversationHistory,
           model,
           chunk -> {
-            writer.write("data: " + gson.toJson(new TextChunk(chunk)) + "\n\n");
+            writer.write("data: " + PLAIN_GSON.toJson(new TextChunk(chunk)) + "\n\n");
             writer.flush();
           });
 

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -1,0 +1,191 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+
+import com.google.common.flogger.FluentLogger;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.AiAnalyzeRequest;
+import google.registry.ai.AiRateLimiter;
+import google.registry.ai.AnthropicClient;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.request.Action;
+import google.registry.request.Action.Service;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.ui.server.console.ConsoleApiAction;
+import google.registry.ui.server.console.ConsoleApiParams;
+import google.registry.util.RegistryEnvironment;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+
+@Action(
+    service = Service.CONSOLE,
+    path = RegistryDashAiAction.PATH,
+    method = Action.Method.POST,
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class RegistryDashAiAction extends ConsoleApiAction {
+
+  static final String PATH = "/console-api/registry-dash/ai/analyze";
+  private static final int SC_TOO_MANY_REQUESTS = 429;
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private final Optional<JsonElement> payload;
+  private final AnthropicClient anthropicClient;
+  private final AiRateLimiter rateLimiter;
+  private final Gson gson;
+
+  @Inject
+  public RegistryDashAiAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
+      AnthropicClient anthropicClient,
+      AiRateLimiter rateLimiter) {
+    super(consoleApiParams);
+    this.payload = payload;
+    this.anthropicClient = anthropicClient;
+    this.rateLimiter = rateLimiter;
+    this.gson = consoleApiParams.gson();
+  }
+
+  @Override
+  protected void postHandler(User user) {
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_DASHBOARD_OVERVIEW)) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+
+    if (payload.isEmpty()) {
+      setFailedResponse("Request body is required", SC_BAD_REQUEST);
+      return;
+    }
+
+    AiAnalyzeRequest request = gson.fromJson(payload.get(), AiAnalyzeRequest.class);
+    if (!request.isValid()) {
+      setFailedResponse("Invalid request: page and chartData are required", SC_BAD_REQUEST);
+      return;
+    }
+
+    String userEmail = user.getEmailAddress();
+    if (!rateLimiter.tryAcquire(userEmail)) {
+      consoleApiParams.response().setStatus(SC_TOO_MANY_REQUESTS);
+      consoleApiParams.response().setHeader(
+          "Retry-After", String.valueOf(rateLimiter.getRetryAfterSeconds(userEmail)));
+      setFailedResponse("Rate limit exceeded", SC_TOO_MANY_REQUESTS);
+      return;
+    }
+
+    String systemPrompt = buildSystemPrompt(request, user);
+    String model = request.model;
+
+    try {
+      PrintWriter writer = consoleApiParams.response().getWriter();
+      consoleApiParams.response().setHeader("Content-Type", "text/event-stream");
+      consoleApiParams.response().setHeader("Cache-Control", "no-cache");
+      consoleApiParams.response().setHeader("Connection", "keep-alive");
+      consoleApiParams.response().setStatus(200);
+
+      anthropicClient.streamMessage(
+          systemPrompt,
+          request.conversationHistory,
+          model,
+          chunk -> {
+            writer.write("data: " + gson.toJson(new TextChunk(chunk)) + "\n\n");
+            writer.flush();
+          });
+
+      writer.write("data: [DONE]\n\n");
+      writer.flush();
+
+    } catch (AnthropicClient.AnthropicRateLimitException e) {
+      logger.atWarning().withCause(e).log("Anthropic rate limit hit");
+      consoleApiParams.response().setStatus(503);
+      consoleApiParams.response().setHeader("Retry-After", "30");
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Anthropic API error");
+      consoleApiParams.response().setStatus(502);
+    }
+  }
+
+  private String buildSystemPrompt(AiAnalyzeRequest request, User user) {
+    boolean isProduction = RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION;
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+
+    if (!isProduction && isAdmin
+        && request.systemPrompt != null && !request.systemPrompt.isEmpty()) {
+      return request.systemPrompt;
+    }
+
+    return getDefaultSystemPrompt(request.page, request.promptType, request.chartData,
+        request.metadata);
+  }
+
+  private String getDefaultSystemPrompt(
+      String page, String promptType, JsonElement chartData, JsonObject metadata) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("You are an expert domain registry analyst. ");
+    sb.append("You are analyzing data from the ").append(page)
+        .append(" page of a domain registry dashboard.\n\n");
+
+    sb.append("## Analysis Type\n");
+    switch (promptType) {
+      case "summarize_trends":
+        sb.append("Summarize the key trends in this data. Identify growth or decline patterns, ");
+        sb.append("compare across TLDs, and highlight the most significant changes.\n");
+        break;
+      case "find_anomalies":
+        sb.append("Identify anomalies, outliers, and unusual patterns in this data. ");
+        sb.append("Look for unexpected spikes, drops, or ratios that warrant investigation.\n");
+        break;
+      case "suggest_actions":
+        sb.append("Based on this data, suggest specific actionable recommendations. ");
+        sb.append("Focus on opportunities for growth, risk mitigation, and operational ");
+        sb.append("improvements.\n");
+        break;
+      case "identify_risks":
+        sb.append("Identify risks in this data. Look for expiration cliffs, declining ");
+        sb.append("registrars, and patterns that could lead to revenue loss.\n");
+        break;
+      default:
+        sb.append("Analyze this data and provide insights.\n");
+    }
+
+    sb.append("\n## Context\n");
+    if (metadata != null) {
+      if (metadata.has("dateRange")) {
+        sb.append("Date range: ").append(metadata.get("dateRange")).append("\n");
+      }
+      if (metadata.has("filteredTlds") && metadata.getAsJsonArray("filteredTlds").size() > 0) {
+        sb.append("Filtered to TLDs: ").append(metadata.get("filteredTlds")).append("\n");
+      }
+    }
+
+    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n");
+    sb.append("\nProvide your analysis in clear markdown. Use specific numbers from the data. ");
+    sb.append("Keep your response concise and actionable.");
+
+    return sb.toString();
+  }
+
+  private record TextChunk(String text) {}
+}

--- a/core/src/test/java/google/registry/ai/AiRateLimiterTest.java
+++ b/core/src/test/java/google/registry/ai/AiRateLimiterTest.java
@@ -1,0 +1,75 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class AiRateLimiterTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @Test
+  void testAllowsRequestsUnderLimit() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 5);
+    for (int i = 0; i < 5; i++) {
+      assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    }
+  }
+
+  @Test
+  void testBlocksRequestsOverLimit() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 3);
+    for (int i = 0; i < 3; i++) {
+      assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    }
+    assertThat(limiter.tryAcquire("user@test.com")).isFalse();
+  }
+
+  @Test
+  void testSlidingWindowExpiry() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 2);
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("user@test.com")).isFalse();
+
+    clock.advanceBy(Duration.standardMinutes(61));
+
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+  }
+
+  @Test
+  void testIndependentPerUser() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 1);
+    assertThat(limiter.tryAcquire("a@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("a@test.com")).isFalse();
+    assertThat(limiter.tryAcquire("b@test.com")).isTrue();
+  }
+
+  @Test
+  void testGetRetryAfterSeconds() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 1);
+    limiter.tryAcquire("user@test.com");
+    limiter.tryAcquire("user@test.com");
+
+    long retryAfter = limiter.getRetryAfterSeconds("user@test.com");
+    assertThat(retryAfter).isGreaterThan(0);
+    assertThat(retryAfter).isAtMost(3600);
+  }
+}

--- a/core/src/test/java/google/registry/ai/AnthropicClientTest.java
+++ b/core/src/test/java/google/registry/ai/AnthropicClientTest.java
@@ -118,7 +118,7 @@ class AnthropicClientTest {
   @Test
   void testModelMapping() {
     assertThat(AnthropicClient.resolveModelId("haiku")).isEqualTo("claude-haiku-4-5-20251001");
-    assertThat(AnthropicClient.resolveModelId("sonnet")).isEqualTo("claude-sonnet-4-6-20250514");
-    assertThat(AnthropicClient.resolveModelId("opus")).isEqualTo("claude-opus-4-6-20250514");
+    assertThat(AnthropicClient.resolveModelId("sonnet")).isEqualTo("claude-sonnet-4-5-20250929");
+    assertThat(AnthropicClient.resolveModelId("opus")).isEqualTo("claude-opus-4-6");
   }
 }

--- a/core/src/test/java/google/registry/ai/AnthropicClientTest.java
+++ b/core/src/test/java/google/registry/ai/AnthropicClientTest.java
@@ -1,0 +1,124 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicClientTest {
+
+  private MockWebServer server;
+  private AnthropicClient client;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    client = new AnthropicClient(
+        new OkHttpClient(),
+        server.url("/").toString(),
+        "test-api-key",
+        "sonnet");
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void testStreamingRequest_sendsCorrectHeaders() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody("event: content_block_delta\n"
+            + "data: {\"type\":\"content_block_delta\",\"delta\":"
+            + "{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n"
+            + "event: message_stop\n"
+            + "data: {\"type\":\"message_stop\"}\n\n"));
+
+    List<String> chunks = new ArrayList<>();
+    client.streamMessage("system prompt", List.of(), "sonnet", chunks::add);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-api-key")).isEqualTo("test-api-key");
+    assertThat(request.getHeader("anthropic-version")).isEqualTo("2023-06-01");
+    assertThat(request.getHeader("Content-Type")).startsWith("application/json");
+    assertThat(request.getBody().readUtf8()).contains("\"stream\":true");
+  }
+
+  @Test
+  void testStreamingRequest_parsesTextChunks() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody("event: content_block_delta\n"
+            + "data: {\"type\":\"content_block_delta\",\"delta\":"
+            + "{\"type\":\"text_delta\",\"text\":\"Hello \"}}\n\n"
+            + "event: content_block_delta\n"
+            + "data: {\"type\":\"content_block_delta\",\"delta\":"
+            + "{\"type\":\"text_delta\",\"text\":\"world\"}}\n\n"
+            + "event: message_stop\n"
+            + "data: {\"type\":\"message_stop\"}\n\n"));
+
+    List<String> chunks = new ArrayList<>();
+    client.streamMessage("system prompt", List.of(), "sonnet", chunks::add);
+
+    assertThat(chunks).containsExactly("Hello ", "world").inOrder();
+  }
+
+  @Test
+  void testStreamingRequest_handlesApiError() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(500)
+        .setBody("{\"error\":{\"message\":\"Internal error\"}}"));
+
+    List<String> chunks = new ArrayList<>();
+    IOException thrown = assertThrows(IOException.class,
+        () -> client.streamMessage("system prompt", List.of(), "sonnet", chunks::add));
+    assertThat(thrown.getMessage()).contains("500");
+  }
+
+  @Test
+  void testStreamingRequest_handlesRateLimit() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(429)
+        .setBody("{\"error\":{\"message\":\"Rate limited\"}}"));
+
+    List<String> chunks = new ArrayList<>();
+    AnthropicClient.AnthropicRateLimitException thrown =
+        assertThrows(AnthropicClient.AnthropicRateLimitException.class,
+            () -> client.streamMessage("system prompt", List.of(), "sonnet", chunks::add));
+    assertThat(thrown.getMessage()).contains("429");
+  }
+
+  @Test
+  void testModelMapping() {
+    assertThat(AnthropicClient.resolveModelId("haiku")).isEqualTo("claude-haiku-4-5-20251001");
+    assertThat(AnthropicClient.resolveModelId("sonnet")).isEqualTo("claude-sonnet-4-6-20250514");
+    assertThat(AnthropicClient.resolveModelId("opus")).isEqualTo("claude-opus-4-6-20250514");
+  }
+}

--- a/core/src/test/java/google/registry/module/TestRegistryComponent.java
+++ b/core/src/test/java/google/registry/module/TestRegistryComponent.java
@@ -17,6 +17,7 @@ package google.registry.module;
 import com.google.monitoring.metrics.MetricReporter;
 import dagger.Component;
 import dagger.Lazy;
+import google.registry.ai.AnthropicModule;
 import google.registry.batch.BatchModule;
 import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CloudTasksUtilsModule;
@@ -50,6 +51,7 @@ import jakarta.inject.Singleton;
 @Singleton
 @Component(
     modules = {
+      AnthropicModule.class,
       AuthModule.class,
       BatchModule.class,
       BigqueryModule.class,

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -40,8 +40,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class RegistryDashAiActionTest {
 
   private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -1,0 +1,131 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import google.registry.ai.AiRateLimiter;
+import google.registry.ai.AnthropicClient;
+import google.registry.model.console.User;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.request.auth.AuthResult;
+import google.registry.testing.ConsoleApiParamsUtils;
+import google.registry.testing.DatabaseHelper;
+import google.registry.testing.FakeClock;
+import google.registry.testing.FakeResponse;
+import google.registry.ui.server.console.ConsoleApiParams;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryDashAiActionTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  @Mock private AnthropicClient anthropicClient;
+  private AiRateLimiter rateLimiter;
+  private ConsoleApiParams params;
+  private FakeResponse response;
+
+  @BeforeEach
+  void setUp() {
+    User fteUser = DatabaseHelper.createAdminUser("fte@test.com");
+    AuthResult authResult = AuthResult.createUser(fteUser);
+    params = ConsoleApiParamsUtils.createFake(authResult);
+    response = (FakeResponse) params.response();
+    rateLimiter = new AiRateLimiter(clock, 120);
+    when(params.request().getMethod()).thenReturn("POST");
+  }
+
+  @Test
+  void testSuccess_streamsResponse() throws Exception {
+    String payload = "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+        + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
+        + "{\"role\":\"user\",\"content\":\"Summarize trends\"}"
+        + "]}";
+    JsonElement json = JsonParser.parseString(payload);
+
+    doAnswer(invocation -> {
+      Consumer<String> onChunk = invocation.getArgument(3);
+      onChunk.accept("Hello ");
+      onChunk.accept("world");
+      return null;
+    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    String written = response.getStringWriter().toString();
+    assertThat(written).contains("Hello ");
+    assertThat(written).contains("world");
+    assertThat(written).contains("[DONE]");
+  }
+
+  @Test
+  void testBadRequest_missingPayload() {
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.empty(), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testBadRequest_invalidPage() {
+    String payload = "{\"page\":\"invalid\",\"promptType\":\"summarize_trends\","
+        + "\"chartData\":{},\"conversationHistory\":[]}";
+    JsonElement json = JsonParser.parseString(payload);
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testRateLimitExceeded() {
+    AiRateLimiter strictLimiter = new AiRateLimiter(clock, 0);
+    String payload = "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+        + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
+        + "{\"role\":\"user\",\"content\":\"test\"}"
+        + "]}";
+    JsonElement json = JsonParser.parseString(payload);
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, strictLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(429);
+  }
+}

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -81,6 +81,7 @@ CONSOLE  /console-api/password-reset-verify                 PasswordResetVerifyA
 CONSOLE  /console-api/registrar                             ConsoleUpdateRegistrarAction                   POST                n  USER PUBLIC
 CONSOLE  /console-api/registrars                            RegistrarsAction                               GET,POST            n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/admin                   RegistryDashAdminAction                        GET,POST            n  USER PUBLIC
+CONSOLE  /console-api/registry-dash/ai/analyze              RegistryDashAiAction                           POST                n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/cost-basis              RegistryDashCostBasisAction                    GET,POST,PUT        n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/domain-activity         RegistryDashDomainActivityAction               GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/effective-fees          UDRegistryDashEffectiveFeesAction              GET                 n  USER PUBLIC

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -52,6 +52,7 @@ ext {
 
       // OkHttp 5.0 is in alpha.
       'com.squareup.okhttp3:okhttp:[4.10.0, 5.0.0)!!',
+      'com.squareup.okhttp3:mockwebserver:[4.10.0, 5.0.0)!!',
 
       // This packages has a broken versioning scheme. There are v1beta3-* and
       // v1b4-* packages that are way older than v1b3-rev2024MMDD-* that need to

--- a/docs/superpowers/plans/2026-04-23-registry-dash-ai-analysis.md
+++ b/docs/superpowers/plans/2026-04-23-registry-dash-ai-analysis.md
@@ -1,0 +1,2113 @@
+# Registry Dashboard AI Analysis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add AI-powered analysis (sparkle button → prompt menu → streaming modal with follow-ups) to three registry dashboard pages: Domain Activity, Revenue Billing, and Forecasting.
+
+**Architecture:** Backend Java action proxies requests to the Anthropic Messages API with SSE streaming. Angular frontend renders a reusable sparkle button per chart, opens a MatDialog modal, and streams the response via `fetch()` + `ReadableStream`. Rate limiting is in-memory per user. System prompts are editable in dev, backend-controlled in production.
+
+**Tech Stack:** Java 21, Dagger 2, OkHttp 4.x, Jakarta Servlets, Angular 17+ (signals, standalone components), Angular Material (MatDialog, MatMenu), Server-Sent Events.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-registry-dash-ai-analysis-design.md`
+
+---
+
+## File Map
+
+### Backend — New Files
+| File | Responsibility |
+|------|---------------|
+| `core/src/main/java/google/registry/ai/AnthropicClient.java` | OkHttp client for Anthropic Messages API (streaming) |
+| `core/src/main/java/google/registry/ai/AnthropicModule.java` | Dagger module: API key from Secret Manager, OkHttpClient, config bindings |
+| `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java` | POJO for the JSON request payload |
+| `core/src/main/java/google/registry/ai/AiRateLimiter.java` | In-memory per-user rate limiter |
+| `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java` | POST action: auth, rate limit, build messages, stream response |
+| `core/src/test/java/google/registry/ai/AnthropicClientTest.java` | Unit tests for AnthropicClient |
+| `core/src/test/java/google/registry/ai/AiRateLimiterTest.java` | Unit tests for rate limiter |
+| `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java` | Action integration tests |
+
+### Backend — Modified Files
+| File | Change |
+|------|--------|
+| `core/src/main/java/google/registry/config/RegistryConfigSettings.java` | Add `Ai` inner class |
+| `core/src/main/java/google/registry/config/RegistryConfig.java` | Add `@Config` providers for AI settings |
+| `core/src/main/java/google/registry/config/files/default-config.yaml` | Add `ai:` section |
+| `core/src/main/java/google/registry/ui/server/console/ConsoleModule.java` | Add `@Parameter("aiAnalyzePayload")` provider |
+| `core/src/main/java/google/registry/module/RequestComponent.java` | Add `RegistryDashAiAction` binding |
+
+### Frontend — New Files
+| File | Responsibility |
+|------|---------------|
+| `console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts` | TypeScript interfaces for request/response |
+| `console-webapp/src/app/registry-dash/ai/ai-prompts.ts` | Predefined prompt templates per page |
+| `console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts` | SSE streaming service using fetch + ReadableStream |
+| `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts` | MatDialog modal: streaming markdown, follow-ups, model switcher |
+| `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html` | Modal template |
+| `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss` | Modal styles |
+| `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts` | Reusable sparkle button with MatMenu |
+| `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.html` | Sparkle button template |
+| `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.scss` | Sparkle button styles |
+
+### Frontend — Modified Files
+| File | Change |
+|------|--------|
+| `console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts` | Import and wire sparkle button |
+| `console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html` | Add sparkle buttons to chart headers |
+| `console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts` | Import and wire sparkle button |
+| `console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html` | Add sparkle buttons to chart headers |
+| `console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts` | Import and wire sparkle button |
+| `console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html` | Add sparkle buttons to chart headers |
+
+---
+
+## Task 1: Backend Config — Add AI Section to YAML + RegistryConfigSettings
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/config/files/default-config.yaml`
+- Modify: `core/src/main/java/google/registry/config/RegistryConfigSettings.java`
+- Modify: `core/src/main/java/google/registry/config/RegistryConfig.java`
+
+- [ ] **Step 1: Add `ai` section to default-config.yaml**
+
+Append before the end of the file (after the `mosapi:` section):
+
+```yaml
+ai:
+  # Anthropic API base URL
+  apiBaseUrl: https://api.anthropic.com
+  # Secret Manager secret name for the Anthropic API key
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  # Default model (haiku, sonnet, opus)
+  defaultModel: sonnet
+  # Rate limit: max requests per user per hour
+  rateLimitPerHour: 120
+```
+
+- [ ] **Step 2: Add `Ai` inner class to RegistryConfigSettings.java**
+
+Add the field to the top-level class (after the `mosapi` field ~line 45):
+
+```java
+public Ai ai;
+```
+
+Add the inner class (before the closing brace of RegistryConfigSettings):
+
+```java
+public static class Ai {
+  public String apiBaseUrl;
+  public String apiKeySecretName;
+  public String defaultModel;
+  public int rateLimitPerHour;
+}
+```
+
+- [ ] **Step 3: Add @Config providers in RegistryConfig.java**
+
+Add these inside the `ConfigModule` class (after the mosapi providers, ~line 1430):
+
+```java
+@Provides
+@Config("anthropicApiBaseUrl")
+public static String provideAnthropicApiBaseUrl(RegistryConfigSettings config) {
+  return config.ai.apiBaseUrl;
+}
+
+@Provides
+@Config("anthropicApiKeySecretName")
+public static String provideAnthropicApiKeySecretName(RegistryConfigSettings config) {
+  return config.ai.apiKeySecretName;
+}
+
+@Provides
+@Config("anthropicDefaultModel")
+public static String provideAnthropicDefaultModel(RegistryConfigSettings config) {
+  return config.ai.defaultModel;
+}
+
+@Provides
+@Config("anthropicRateLimitPerHour")
+public static int provideAnthropicRateLimitPerHour(RegistryConfigSettings config) {
+  return config.ai.rateLimitPerHour;
+}
+```
+
+- [ ] **Step 4: Verify the build compiles**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:compileJava 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/java/google/registry/config/files/default-config.yaml \
+  core/src/main/java/google/registry/config/RegistryConfigSettings.java \
+  core/src/main/java/google/registry/config/RegistryConfig.java
+git commit -m "feat(registry-dash): add AI config section for Anthropic API settings"
+```
+
+---
+
+## Task 2: Backend — AiRateLimiter
+
+**Files:**
+- Create: `core/src/main/java/google/registry/ai/AiRateLimiter.java`
+- Create: `core/src/test/java/google/registry/ai/AiRateLimiterTest.java`
+
+- [ ] **Step 1: Write the test**
+
+```java
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class AiRateLimiterTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @Test
+  void testAllowsRequestsUnderLimit() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 5);
+    for (int i = 0; i < 5; i++) {
+      assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    }
+  }
+
+  @Test
+  void testBlocksRequestsOverLimit() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 3);
+    for (int i = 0; i < 3; i++) {
+      assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    }
+    assertThat(limiter.tryAcquire("user@test.com")).isFalse();
+  }
+
+  @Test
+  void testSlidingWindowExpiry() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 2);
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("user@test.com")).isFalse();
+
+    clock.advanceBy(Duration.standardMinutes(61));
+
+    assertThat(limiter.tryAcquire("user@test.com")).isTrue();
+  }
+
+  @Test
+  void testIndependentPerUser() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 1);
+    assertThat(limiter.tryAcquire("a@test.com")).isTrue();
+    assertThat(limiter.tryAcquire("a@test.com")).isFalse();
+    assertThat(limiter.tryAcquire("b@test.com")).isTrue();
+  }
+
+  @Test
+  void testGetRetryAfterSeconds() {
+    AiRateLimiter limiter = new AiRateLimiter(clock, 1);
+    limiter.tryAcquire("user@test.com");
+    limiter.tryAcquire("user@test.com");
+
+    long retryAfter = limiter.getRetryAfterSeconds("user@test.com");
+    assertThat(retryAfter).isGreaterThan(0);
+    assertThat(retryAfter).isAtMost(3600);
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ai.AiRateLimiterTest" 2>&1 | tail -20
+```
+
+Expected: FAIL — class AiRateLimiter not found
+
+- [ ] **Step 3: Implement AiRateLimiter**
+
+```java
+package google.registry.ai;
+
+import com.google.common.annotations.VisibleForTesting;
+import google.registry.util.Clock;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.joda.time.Duration;
+
+@Singleton
+public class AiRateLimiter {
+
+  private static final Duration WINDOW = Duration.standardHours(1);
+
+  private final Clock clock;
+  private final int maxPerHour;
+  private final ConcurrentHashMap<String, Deque<Long>> requests = new ConcurrentHashMap<>();
+
+  @Inject
+  public AiRateLimiter(Clock clock, @jakarta.inject.Named("aiRateLimitPerHour") int maxPerHour) {
+    this.clock = clock;
+    this.maxPerHour = maxPerHour;
+  }
+
+  @VisibleForTesting
+  AiRateLimiter(Clock clock, int maxPerHour) {
+    this.clock = clock;
+    this.maxPerHour = maxPerHour;
+  }
+
+  public boolean tryAcquire(String userEmail) {
+    long now = clock.nowUtc().getMillis();
+    long cutoff = now - WINDOW.getMillis();
+    Deque<Long> timestamps = requests.computeIfAbsent(userEmail, k -> new ConcurrentLinkedDeque<>());
+
+    while (!timestamps.isEmpty() && timestamps.peekFirst() <= cutoff) {
+      timestamps.pollFirst();
+    }
+
+    if (timestamps.size() >= maxPerHour) {
+      return false;
+    }
+    timestamps.addLast(now);
+    return true;
+  }
+
+  public long getRetryAfterSeconds(String userEmail) {
+    long now = clock.nowUtc().getMillis();
+    Deque<Long> timestamps = requests.get(userEmail);
+    if (timestamps == null || timestamps.isEmpty()) {
+      return 0;
+    }
+    long oldest = timestamps.peekFirst();
+    long expiresAt = oldest + WINDOW.getMillis();
+    return Math.max(1, (expiresAt - now) / 1000);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ai.AiRateLimiterTest" 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL, all 5 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ai/AiRateLimiter.java \
+  core/src/test/java/google/registry/ai/AiRateLimiterTest.java
+git commit -m "feat(registry-dash): add in-memory per-user AI rate limiter"
+```
+
+---
+
+## Task 3: Backend — AiAnalyzeRequest POJO
+
+**Files:**
+- Create: `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java`
+
+- [ ] **Step 1: Create the request POJO**
+
+```java
+package google.registry.ai;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.List;
+
+public class AiAnalyzeRequest {
+
+  public String page;
+  public String promptType;
+  public JsonObject metadata;
+  public JsonElement chartData;
+  public String model;
+  public String systemPrompt;
+  public List<ConversationMessage> conversationHistory;
+
+  public static class ConversationMessage {
+    public String role;
+    public String content;
+  }
+
+  public boolean isValid() {
+    return page != null
+        && promptType != null
+        && chartData != null
+        && (page.equals("domain-activity")
+            || page.equals("revenue-billing")
+            || page.equals("forecasting"));
+  }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:compileJava 2>&1 | tail -10
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
+git commit -m "feat(registry-dash): add AiAnalyzeRequest POJO"
+```
+
+---
+
+## Task 4: Backend — AnthropicClient + AnthropicModule
+
+**Files:**
+- Create: `core/src/main/java/google/registry/ai/AnthropicClient.java`
+- Create: `core/src/main/java/google/registry/ai/AnthropicModule.java`
+- Create: `core/src/test/java/google/registry/ai/AnthropicClientTest.java`
+
+- [ ] **Step 1: Write the test**
+
+```java
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnthropicClientTest {
+
+  private MockWebServer server;
+  private AnthropicClient client;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+    client = new AnthropicClient(
+        new OkHttpClient(),
+        server.url("/").toString(),
+        "test-api-key",
+        "sonnet");
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void testStreamingRequest_sendsCorrectHeaders() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n"
+            + "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"));
+
+    List<String> chunks = new ArrayList<>();
+    client.streamMessage("system prompt", List.of(), "sonnet", chunks::add);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getHeader("x-api-key")).isEqualTo("test-api-key");
+    assertThat(request.getHeader("anthropic-version")).isEqualTo("2023-06-01");
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json");
+    assertThat(request.getBody().readUtf8()).contains("\"stream\":true");
+  }
+
+  @Test
+  void testStreamingRequest_parsesTextChunks() throws Exception {
+    server.enqueue(new MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/event-stream")
+        .setBody("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello \"}}\n\n"
+            + "event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"world\"}}\n\n"
+            + "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"));
+
+    List<String> chunks = new ArrayList<>();
+    client.streamMessage("system prompt", List.of(), "sonnet", chunks::add);
+
+    assertThat(chunks).containsExactly("Hello ", "world").inOrder();
+  }
+
+  @Test
+  void testStreamingRequest_handlesApiError() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(500).setBody("{\"error\":{\"message\":\"Internal error\"}}"));
+
+    List<String> chunks = new ArrayList<>();
+    IOException thrown = assertThrows(IOException.class,
+        () -> client.streamMessage("system prompt", List.of(), "sonnet", chunks::add));
+    assertThat(thrown.getMessage()).contains("500");
+  }
+
+  @Test
+  void testStreamingRequest_handlesRateLimit() throws Exception {
+    server.enqueue(new MockResponse().setResponseCode(429).setBody("{\"error\":{\"message\":\"Rate limited\"}}"));
+
+    List<String> chunks = new ArrayList<>();
+    AnthropicClient.AnthropicRateLimitException thrown =
+        assertThrows(AnthropicClient.AnthropicRateLimitException.class,
+            () -> client.streamMessage("system prompt", List.of(), "sonnet", chunks::add));
+    assertThat(thrown.getMessage()).contains("429");
+  }
+
+  @Test
+  void testModelMapping() {
+    assertThat(AnthropicClient.resolveModelId("haiku")).isEqualTo("claude-haiku-4-5-20251001");
+    assertThat(AnthropicClient.resolveModelId("sonnet")).isEqualTo("claude-sonnet-4-6-20250514");
+    assertThat(AnthropicClient.resolveModelId("opus")).isEqualTo("claude-opus-4-6-20250514");
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ai.AnthropicClientTest" 2>&1 | tail -20
+```
+
+Expected: FAIL — class AnthropicClient not found
+
+- [ ] **Step 3: Add `okhttp3:mockwebserver` test dependency if not present**
+
+Check first:
+```bash
+grep -c "mockwebserver" /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2/core/build.gradle
+```
+
+If 0, add to `core/build.gradle` in the `dependencies` block:
+```gradle
+testImplementation deps['com.squareup.okhttp3:mockwebserver']
+```
+
+And ensure the version is in `dependencies.gradle`:
+```gradle
+'com.squareup.okhttp3:mockwebserver:[4.10.0, 5.0.0)!!',
+```
+
+- [ ] **Step 4: Implement AnthropicClient**
+
+```java
+package google.registry.ai;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+@Singleton
+public class AnthropicClient {
+
+  private static final String ANTHROPIC_VERSION = "2023-06-01";
+  private static final int MAX_TOKENS = 4096;
+  private static final Map<String, String> MODEL_MAP = Map.of(
+      "haiku", "claude-haiku-4-5-20251001",
+      "sonnet", "claude-sonnet-4-6-20250514",
+      "opus", "claude-opus-4-6-20250514");
+  private static final Gson GSON = new Gson();
+
+  private final OkHttpClient httpClient;
+  private final String baseUrl;
+  private final String apiKey;
+  private final String defaultModel;
+
+  @Inject
+  public AnthropicClient(
+      @Named("anthropicHttpClient") OkHttpClient httpClient,
+      @Named("anthropicApiBaseUrl") String baseUrl,
+      @Named("anthropicApiKey") String apiKey,
+      @Named("anthropicDefaultModel") String defaultModel) {
+    this.httpClient = httpClient;
+    this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    this.apiKey = apiKey;
+    this.defaultModel = defaultModel;
+  }
+
+  public void streamMessage(
+      String systemPrompt,
+      List<AiAnalyzeRequest.ConversationMessage> conversationHistory,
+      String modelOverride,
+      Consumer<String> onChunk) throws IOException {
+
+    String model = resolveModelId(modelOverride != null ? modelOverride : defaultModel);
+
+    JsonObject body = new JsonObject();
+    body.addProperty("model", model);
+    body.addProperty("max_tokens", MAX_TOKENS);
+    body.addProperty("stream", true);
+    body.addProperty("system", systemPrompt);
+
+    JsonArray messages = new JsonArray();
+    if (conversationHistory != null) {
+      for (AiAnalyzeRequest.ConversationMessage msg : conversationHistory) {
+        JsonObject msgObj = new JsonObject();
+        msgObj.addProperty("role", msg.role);
+        msgObj.addProperty("content", msg.content);
+        messages.add(msgObj);
+      }
+    }
+    body.add("messages", messages);
+
+    RequestBody requestBody = RequestBody.create(
+        GSON.toJson(body), MediaType.parse("application/json"));
+
+    Request request = new Request.Builder()
+        .url(baseUrl + "/v1/messages")
+        .post(requestBody)
+        .addHeader("x-api-key", apiKey)
+        .addHeader("anthropic-version", ANTHROPIC_VERSION)
+        .addHeader("Content-Type", "application/json")
+        .build();
+
+    try (Response response = httpClient.newCall(request).execute()) {
+      if (response.code() == 429) {
+        throw new AnthropicRateLimitException("Anthropic API rate limited: " + response.code());
+      }
+      if (!response.isSuccessful()) {
+        throw new IOException("Anthropic API error: " + response.code());
+      }
+
+      try (BufferedReader reader = new BufferedReader(
+          new InputStreamReader(response.body().byteStream(), StandardCharsets.UTF_8))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          if (!line.startsWith("data: ")) continue;
+          String data = line.substring(6).trim();
+          if (data.equals("[DONE]")) break;
+
+          try {
+            JsonObject event = GSON.fromJson(data, JsonObject.class);
+            if (event.has("type") && event.get("type").getAsString().equals("content_block_delta")) {
+              JsonObject delta = event.getAsJsonObject("delta");
+              if (delta.has("text")) {
+                onChunk.accept(delta.get("text").getAsString());
+              }
+            }
+          } catch (Exception e) {
+            // Skip non-JSON or non-delta lines
+          }
+        }
+      }
+    }
+  }
+
+  public static String resolveModelId(String shortName) {
+    return MODEL_MAP.getOrDefault(shortName, MODEL_MAP.get("sonnet"));
+  }
+
+  public static class AnthropicRateLimitException extends IOException {
+    public AnthropicRateLimitException(String message) {
+      super(message);
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Implement AnthropicModule**
+
+```java
+package google.registry.ai;
+
+import dagger.Module;
+import dagger.Provides;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.privileges.secretmanager.SecretManagerClient;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import okhttp3.OkHttpClient;
+
+@Module
+public final class AnthropicModule {
+
+  private static final String LATEST_SECRET_VERSION = "latest";
+
+  @Provides
+  @Singleton
+  @Named("anthropicHttpClient")
+  static OkHttpClient provideAnthropicHttpClient() {
+    return new OkHttpClient.Builder()
+        .readTimeout(120, TimeUnit.SECONDS)
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .build();
+  }
+
+  @Provides
+  @Singleton
+  @Named("anthropicApiKey")
+  static String provideAnthropicApiKey(
+      SecretManagerClient secretManagerClient,
+      @Config("anthropicApiKeySecretName") String secretName) {
+    return secretManagerClient.getSecretData(secretName, Optional.of(LATEST_SECRET_VERSION));
+  }
+
+  @Provides
+  @Named("anthropicApiBaseUrl")
+  static String provideAnthropicApiBaseUrl(@Config("anthropicApiBaseUrl") String baseUrl) {
+    return baseUrl;
+  }
+
+  @Provides
+  @Named("anthropicDefaultModel")
+  static String provideAnthropicDefaultModel(@Config("anthropicDefaultModel") String model) {
+    return model;
+  }
+
+  @Provides
+  @Singleton
+  @Named("aiRateLimitPerHour")
+  static int provideAiRateLimitPerHour(@Config("anthropicRateLimitPerHour") int limit) {
+    return limit;
+  }
+}
+```
+
+- [ ] **Step 6: Run the test**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ai.AnthropicClientTest" 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL, all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ai/AnthropicClient.java \
+  core/src/main/java/google/registry/ai/AnthropicModule.java \
+  core/src/test/java/google/registry/ai/AnthropicClientTest.java
+git commit -m "feat(registry-dash): add AnthropicClient with SSE streaming and Dagger module"
+```
+
+---
+
+## Task 5: Backend — RegistryDashAiAction + DI Wiring
+
+**Files:**
+- Create: `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java`
+- Create: `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java`
+- Modify: `core/src/main/java/google/registry/ui/server/console/ConsoleModule.java`
+- Modify: `core/src/main/java/google/registry/module/RequestComponent.java`
+
+- [ ] **Step 1: Add the JSON payload provider in ConsoleModule.java**
+
+Add after the existing `provideSettingsPayload` provider:
+
+```java
+@Provides
+@Parameter("aiAnalyzePayload")
+public static Optional<JsonElement> provideAiAnalyzePayload(
+    @OptionalJsonPayload Optional<JsonElement> payload) {
+  return payload;
+}
+```
+
+- [ ] **Step 2: Add the action binding in RequestComponent.java**
+
+Add in the registry-dash section (after `RegistryDashSettingsAction`):
+
+```java
+RegistryDashAiAction registryDashAiAction();
+```
+
+- [ ] **Step 3: Add AnthropicModule to RequestComponent's @Subcomponent modules list**
+
+In RequestComponent.java, add `AnthropicModule.class` to the modules array:
+
+```java
+@RequestScope
+@Subcomponent(
+    modules = {
+      // ... existing modules ...
+      AnthropicModule.class,
+      // ... rest of modules ...
+    })
+```
+
+- [ ] **Step 4: Implement RegistryDashAiAction**
+
+```java
+package google.registry.ui.server.console.registrydash;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_TOO_MANY_REQUESTS;
+
+import com.google.common.flogger.FluentLogger;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import google.registry.ai.AiAnalyzeRequest;
+import google.registry.ai.AiRateLimiter;
+import google.registry.ai.AnthropicClient;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.request.Action;
+import google.registry.request.Action.Service;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.ui.server.console.ConsoleApiAction;
+import google.registry.ui.server.console.ConsoleApiParams;
+import google.registry.util.RegistryEnvironment;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+
+@Action(
+    service = Service.CONSOLE,
+    path = RegistryDashAiAction.PATH,
+    method = Action.Method.POST,
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class RegistryDashAiAction extends ConsoleApiAction {
+
+  static final String PATH = "/console-api/registry-dash/ai/analyze";
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private final Optional<JsonElement> payload;
+  private final AnthropicClient anthropicClient;
+  private final AiRateLimiter rateLimiter;
+  private final Gson gson;
+
+  @Inject
+  public RegistryDashAiAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
+      AnthropicClient anthropicClient,
+      AiRateLimiter rateLimiter) {
+    super(consoleApiParams);
+    this.payload = payload;
+    this.anthropicClient = anthropicClient;
+    this.rateLimiter = rateLimiter;
+    this.gson = consoleApiParams.gson();
+  }
+
+  @Override
+  protected void postHandler(User user) {
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_DASHBOARD_OVERVIEW)) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+
+    if (payload.isEmpty()) {
+      setFailedResponse("Request body is required", SC_BAD_REQUEST);
+      return;
+    }
+
+    AiAnalyzeRequest request = gson.fromJson(payload.get(), AiAnalyzeRequest.class);
+    if (!request.isValid()) {
+      setFailedResponse("Invalid request: page and chartData are required", SC_BAD_REQUEST);
+      return;
+    }
+
+    String userEmail = user.getEmailAddress();
+    if (!rateLimiter.tryAcquire(userEmail)) {
+      consoleApiParams.response().setStatus(SC_TOO_MANY_REQUESTS);
+      consoleApiParams.response().setHeader(
+          "Retry-After", String.valueOf(rateLimiter.getRetryAfterSeconds(userEmail)));
+      setFailedResponse("Rate limit exceeded", SC_TOO_MANY_REQUESTS);
+      return;
+    }
+
+    String systemPrompt = buildSystemPrompt(request, user);
+    String model = request.model;
+
+    try {
+      PrintWriter writer = consoleApiParams.response().getWriter();
+      consoleApiParams.response().setHeader("Content-Type", "text/event-stream");
+      consoleApiParams.response().setHeader("Cache-Control", "no-cache");
+      consoleApiParams.response().setHeader("Connection", "keep-alive");
+      consoleApiParams.response().setStatus(200);
+
+      anthropicClient.streamMessage(
+          systemPrompt,
+          request.conversationHistory,
+          model,
+          chunk -> {
+            writer.write("data: " + gson.toJson(new TextChunk(chunk)) + "\n\n");
+            writer.flush();
+          });
+
+      writer.write("data: [DONE]\n\n");
+      writer.flush();
+
+    } catch (AnthropicClient.AnthropicRateLimitException e) {
+      logger.atWarning().withCause(e).log("Anthropic rate limit hit");
+      consoleApiParams.response().setStatus(503);
+      consoleApiParams.response().setHeader("Retry-After", "30");
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Anthropic API error");
+      consoleApiParams.response().setStatus(502);
+    }
+  }
+
+  private String buildSystemPrompt(AiAnalyzeRequest request, User user) {
+    boolean isProduction = RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION;
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+
+    if (!isProduction && isAdmin && request.systemPrompt != null && !request.systemPrompt.isEmpty()) {
+      return request.systemPrompt;
+    }
+
+    return getDefaultSystemPrompt(request.page, request.promptType, request.chartData, request.metadata);
+  }
+
+  private String getDefaultSystemPrompt(
+      String page, String promptType, JsonElement chartData, com.google.gson.JsonObject metadata) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("You are an expert domain registry analyst. ");
+    sb.append("You are analyzing data from the ").append(page).append(" page of a domain registry dashboard.\n\n");
+
+    sb.append("## Analysis Type\n");
+    switch (promptType) {
+      case "summarize_trends":
+        sb.append("Summarize the key trends in this data. Identify growth or decline patterns, ");
+        sb.append("compare across TLDs, and highlight the most significant changes.\n");
+        break;
+      case "find_anomalies":
+        sb.append("Identify anomalies, outliers, and unusual patterns in this data. ");
+        sb.append("Look for unexpected spikes, drops, or ratios that warrant investigation.\n");
+        break;
+      case "suggest_actions":
+        sb.append("Based on this data, suggest specific actionable recommendations. ");
+        sb.append("Focus on opportunities for growth, risk mitigation, and operational improvements.\n");
+        break;
+      case "identify_risks":
+        sb.append("Identify risks in this data. Look for expiration cliffs, declining registrars, ");
+        sb.append("and patterns that could lead to revenue loss.\n");
+        break;
+      default:
+        sb.append("Analyze this data and provide insights.\n");
+    }
+
+    sb.append("\n## Context\n");
+    if (metadata != null) {
+      if (metadata.has("dateRange")) {
+        sb.append("Date range: ").append(metadata.get("dateRange")).append("\n");
+      }
+      if (metadata.has("filteredTlds") && metadata.getAsJsonArray("filteredTlds").size() > 0) {
+        sb.append("Filtered to TLDs: ").append(metadata.get("filteredTlds")).append("\n");
+      }
+    }
+
+    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n");
+    sb.append("\nProvide your analysis in clear markdown. Use specific numbers from the data. ");
+    sb.append("Keep your response concise and actionable.");
+
+    return sb.toString();
+  }
+
+  private record TextChunk(String text) {}
+}
+```
+
+- [ ] **Step 5: Write the action test**
+
+```java
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import google.registry.ai.AiAnalyzeRequest;
+import google.registry.ai.AiRateLimiter;
+import google.registry.ai.AnthropicClient;
+import google.registry.model.console.User;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.request.auth.AuthResult;
+import google.registry.testing.ConsoleApiParamsUtils;
+import google.registry.testing.DatabaseHelper;
+import google.registry.testing.FakeClock;
+import google.registry.testing.FakeResponse;
+import google.registry.ui.server.console.ConsoleApiParams;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.function.Consumer;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(MockitoExtension.class)
+class RegistryDashAiActionTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  @Mock private AnthropicClient anthropicClient;
+  private AiRateLimiter rateLimiter;
+  private User fteUser;
+  private ConsoleApiParams params;
+  private FakeResponse response;
+
+  @BeforeEach
+  void setUp() {
+    fteUser = DatabaseHelper.createAdminUser("fte@test.com");
+    AuthResult authResult = AuthResult.createUser(fteUser);
+    params = ConsoleApiParamsUtils.createFake(authResult);
+    response = (FakeResponse) params.response();
+    rateLimiter = new AiRateLimiter(clock, 120);
+    org.mockito.Mockito.when(params.request().getMethod()).thenReturn("POST");
+  }
+
+  @Test
+  void testSuccess_streamsResponse() throws Exception {
+    String payload = """
+        {"page":"domain-activity","promptType":"summarize_trends",
+         "chartData":{"activity":[]},"conversationHistory":[
+           {"role":"user","content":"Summarize trends"}
+         ]}""";
+    JsonElement json = JsonParser.parseString(payload);
+
+    doAnswer(invocation -> {
+      Consumer<String> onChunk = invocation.getArgument(3);
+      onChunk.accept("Hello ");
+      onChunk.accept("world");
+      return null;
+    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    String written = response.getStringWriter().toString();
+    assertThat(written).contains("Hello ");
+    assertThat(written).contains("world");
+    assertThat(written).contains("[DONE]");
+  }
+
+  @Test
+  void testBadRequest_missingPayload() {
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.empty(), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testBadRequest_invalidPage() {
+    String payload = """
+        {"page":"invalid","promptType":"summarize_trends",
+         "chartData":{},"conversationHistory":[]}""";
+    JsonElement json = JsonParser.parseString(payload);
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testRateLimitExceeded() {
+    AiRateLimiter strictLimiter = new AiRateLimiter(clock, 0);
+    String payload = """
+        {"page":"domain-activity","promptType":"summarize_trends",
+         "chartData":{"activity":[]},"conversationHistory":[
+           {"role":"user","content":"test"}
+         ]}""";
+    JsonElement json = JsonParser.parseString(payload);
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, strictLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(429);
+  }
+}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ui.server.console.registrydash.RegistryDashAiActionTest" 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL, all tests pass
+
+- [ ] **Step 7: Regenerate the routing golden file**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build nomulus && cd core && java -jar build/libs/nomulus.jar -e localhost get_routing_map -c google.registry.module.RequestComponent > src/test/resources/google/registry/module/routing.txt
+```
+
+Strip any jline warning lines from the top of the output if present.
+
+- [ ] **Step 8: Run the routing test to verify**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.module.RoutingMapTest" 2>&1 | tail -20
+```
+
+Expected: BUILD SUCCESSFUL
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java \
+  core/src/main/java/google/registry/ui/server/console/ConsoleModule.java \
+  core/src/main/java/google/registry/module/RequestComponent.java \
+  core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java \
+  core/src/test/resources/google/registry/module/routing.txt
+git commit -m "feat(registry-dash): add RegistryDashAiAction with SSE streaming and DI wiring"
+```
+
+---
+
+## Task 6: Frontend — Models and Prompt Templates
+
+**Files:**
+- Create: `console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-prompts.ts`
+
+- [ ] **Step 1: Create models file**
+
+```typescript
+export interface AiAnalyzeRequest {
+  page: 'domain-activity' | 'revenue-billing' | 'forecasting';
+  promptType: string;
+  metadata: {
+    dateRange: { start: string; end: string };
+    granularity?: string;
+    filteredTlds: string[];
+    filteredRegistrars: string[];
+    [key: string]: any;
+  };
+  chartData: any;
+  model?: string;
+  systemPrompt?: string;
+  conversationHistory: ConversationMessage[];
+}
+
+export interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface AiPromptOption {
+  icon: string;
+  label: string;
+  promptType: string;
+  userMessage: string;
+}
+
+export type AiModelChoice = 'haiku' | 'sonnet' | 'opus';
+```
+
+- [ ] **Step 2: Create prompts file**
+
+```typescript
+import { AiPromptOption } from './ai-analysis.models';
+
+export const DOMAIN_ACTIVITY_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage: 'Summarize the key trends in domain activity — lifecycle patterns, growth or decline across TLDs.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage: 'Identify anomalies in domain activity — unexpected spikes, unusual create/delete ratios, outlier TLDs.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage: 'Based on this domain activity data, suggest specific actions for retention and growth.',
+  },
+];
+
+export const REVENUE_BILLING_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage: 'Summarize revenue trends — key drivers, growth percentages, TLD performance comparison.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage: 'Identify revenue anomalies — unexpected spikes or drops, declining segments, unusual patterns.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage: 'Based on this revenue data, suggest pricing adjustments, registrar outreach, or growth opportunities.',
+  },
+];
+
+export const FORECASTING_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage: 'Summarize renewal health — overall rates, TLD comparison, trajectory.',
+  },
+  {
+    icon: 'warning',
+    label: 'Identify risks',
+    promptType: 'identify_risks',
+    userMessage: 'Identify risks — expiration cliffs, declining registrars, TLDs with dropping renewal rates.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage: 'Suggest retention strategies, pricing recommendations, and proactive outreach based on this forecast data.',
+  },
+];
+
+export const PROMPTS_BY_PAGE: Record<string, AiPromptOption[]> = {
+  'domain-activity': DOMAIN_ACTIVITY_PROMPTS,
+  'revenue-billing': REVENUE_BILLING_PROMPTS,
+  'forecasting': FORECASTING_PROMPTS,
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts \
+  console-webapp/src/app/registry-dash/ai/ai-prompts.ts
+git commit -m "feat(registry-dash): add AI analysis models and prompt templates"
+```
+
+---
+
+## Task 7: Frontend — AI Analysis Service (SSE Streaming)
+
+**Files:**
+- Create: `console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts`
+
+- [ ] **Step 1: Implement the service**
+
+```typescript
+import { Injectable, signal } from '@angular/core';
+import { AiAnalyzeRequest, AiModelChoice, ConversationMessage } from './ai-analysis.models';
+
+@Injectable({ providedIn: 'root' })
+export class AiAnalysisService {
+  streaming = signal(false);
+  streamedText = signal('');
+  error = signal<string | null>(null);
+
+  async analyze(request: AiAnalyzeRequest): Promise<void> {
+    this.streaming.set(true);
+    this.streamedText.set('');
+    this.error.set(null);
+
+    try {
+      const xsrfCookie = document.cookie
+        .split('; ')
+        .find(c => c.startsWith('X-CSRF-Token='));
+      const xsrfToken = xsrfCookie?.split('=')[1] ?? '';
+
+      const response = await fetch('/console-api/registry-dash/ai/analyze', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        credentials: 'same-origin',
+      });
+
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After');
+        const minutes = retryAfter ? Math.ceil(parseInt(retryAfter, 10) / 60) : 5;
+        this.error.set(`Analysis limit reached. Try again in ${minutes} minutes.`);
+        return;
+      }
+      if (response.status === 502) {
+        this.error.set('Analysis temporarily unavailable. Please try again.');
+        return;
+      }
+      if (response.status === 503) {
+        this.error.set('AI service is busy. Please try again shortly.');
+        return;
+      }
+      if (!response.ok) {
+        this.error.set('Analysis failed. Please try again.');
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        this.error.set('Streaming not supported.');
+        return;
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let accumulated = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.substring(6).trim();
+          if (data === '[DONE]') break;
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed.text) {
+              accumulated += parsed.text;
+              this.streamedText.set(accumulated);
+            }
+          } catch {
+            // skip malformed chunks
+          }
+        }
+      }
+    } catch (e) {
+      this.error.set('Response interrupted. Try again?');
+    } finally {
+      this.streaming.set(false);
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+git commit -m "feat(registry-dash): add AI analysis service with SSE streaming"
+```
+
+---
+
+## Task 8: Frontend — AI Analysis Modal Component
+
+**Files:**
+- Create: `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss`
+
+- [ ] **Step 1: Create the component TypeScript**
+
+```typescript
+import { Component, Inject, computed, signal, OnInit, DestroyRef, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MaterialModule } from '../../material.module';
+import { AiAnalysisService } from './ai-analysis.service';
+import { AiAnalyzeRequest, AiModelChoice, ConversationMessage } from './ai-analysis.models';
+import { RegistryDashService } from '../registry-dash.service';
+
+export interface AiAnalysisModalData {
+  title: string;
+  page: AiAnalyzeRequest['page'];
+  promptType: string;
+  userMessage: string;
+  metadata: AiAnalyzeRequest['metadata'];
+  chartData: any;
+  systemPrompt?: string;
+  isAdmin: boolean;
+  savedModel?: AiModelChoice;
+}
+
+@Component({
+  selector: 'app-ai-analysis-modal',
+  standalone: true,
+  imports: [CommonModule, MaterialModule, FormsModule],
+  templateUrl: './ai-analysis-modal.component.html',
+  styleUrls: ['./ai-analysis-modal.component.scss'],
+})
+export class AiAnalysisModalComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
+  selectedModel = signal<AiModelChoice>('sonnet');
+  conversationHistory = signal<ConversationMessage[]>([]);
+  followUpInput = signal('');
+  showAdvanced = signal(false);
+  editableSystemPrompt = signal('');
+
+  streaming = computed(() => this.aiService.streaming());
+  streamedText = computed(() => this.aiService.streamedText());
+  error = computed(() => this.aiService.error());
+
+  constructor(
+    public dialogRef: MatDialogRef<AiAnalysisModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: AiAnalysisModalData,
+    private aiService: AiAnalysisService,
+    private dashService: RegistryDashService,
+  ) {
+    if (data.savedModel) {
+      this.selectedModel.set(data.savedModel);
+    }
+  }
+
+  ngOnInit() {
+    this.sendInitialRequest();
+  }
+
+  private async sendInitialRequest() {
+    const history: ConversationMessage[] = [
+      { role: 'user', content: this.data.userMessage },
+    ];
+    this.conversationHistory.set(history);
+
+    await this.aiService.analyze({
+      page: this.data.page,
+      promptType: this.data.promptType,
+      metadata: this.data.metadata,
+      chartData: this.data.chartData,
+      model: this.selectedModel(),
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      conversationHistory: history,
+    });
+
+    if (!this.error()) {
+      this.conversationHistory.update(h => [
+        ...h,
+        { role: 'assistant', content: this.streamedText() },
+      ]);
+    }
+  }
+
+  async sendFollowUp() {
+    const input = this.followUpInput().trim();
+    if (!input || this.streaming()) return;
+
+    const updatedHistory: ConversationMessage[] = [
+      ...this.conversationHistory(),
+      { role: 'user', content: input },
+    ];
+    this.conversationHistory.set(updatedHistory);
+    this.followUpInput.set('');
+
+    await this.aiService.analyze({
+      page: this.data.page,
+      promptType: this.data.promptType,
+      metadata: this.data.metadata,
+      chartData: this.data.chartData,
+      model: this.selectedModel(),
+      systemPrompt: this.showAdvanced() ? this.editableSystemPrompt() : undefined,
+      conversationHistory: updatedHistory,
+    });
+
+    if (!this.error()) {
+      this.conversationHistory.update(h => [
+        ...h,
+        { role: 'assistant', content: this.streamedText() },
+      ]);
+    }
+  }
+
+  onModelChange(model: AiModelChoice) {
+    this.selectedModel.set(model);
+    this.dashService.updateSettingsSelf({ aiModel: model }).subscribe();
+  }
+
+  onFollowUpKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.sendFollowUp();
+    }
+  }
+
+  toggleAdvanced() {
+    this.showAdvanced.update(v => !v);
+    if (this.showAdvanced() && !this.editableSystemPrompt()) {
+      this.editableSystemPrompt.set(this.data.systemPrompt ?? '');
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create the modal template**
+
+```html
+<h2 mat-dialog-title>{{ data.title }}</h2>
+<mat-dialog-content>
+  <!-- Context line -->
+  <div class="context-bar">
+    <span class="context-model">Model:</span>
+    <mat-button-toggle-group [value]="selectedModel()" (change)="onModelChange($event.value)">
+      <mat-button-toggle value="haiku">Haiku</mat-button-toggle>
+      <mat-button-toggle value="sonnet">Sonnet</mat-button-toggle>
+      <mat-button-toggle value="opus">Opus</mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <!-- Advanced section (admin only, dev mode) -->
+  <div *ngIf="data.isAdmin" class="advanced-section">
+    <button mat-button (click)="toggleAdvanced()" class="advanced-toggle">
+      <mat-icon>{{ showAdvanced() ? 'expand_less' : 'expand_more' }}</mat-icon>
+      Advanced
+    </button>
+    <div *ngIf="showAdvanced()" class="advanced-content">
+      <textarea
+        [(ngModel)]="editableSystemPrompt"
+        class="system-prompt-editor"
+        placeholder="System prompt (editable in dev mode)"
+        rows="6"></textarea>
+    </div>
+  </div>
+
+  <!-- Conversation -->
+  <div class="conversation">
+    <ng-container *ngFor="let msg of conversationHistory(); let last = last">
+      <div *ngIf="msg.role === 'user'" class="message user-message">
+        <mat-icon class="message-icon">person</mat-icon>
+        <div class="message-content">{{ msg.content }}</div>
+      </div>
+      <div *ngIf="msg.role === 'assistant'" class="message assistant-message">
+        <mat-icon class="message-icon">auto_awesome</mat-icon>
+        <div class="message-content markdown-body" [innerHTML]="msg.content"></div>
+      </div>
+    </ng-container>
+
+    <!-- Streaming response -->
+    <div *ngIf="streaming()" class="message assistant-message streaming">
+      <mat-icon class="message-icon">auto_awesome</mat-icon>
+      <div class="message-content markdown-body" [innerHTML]="streamedText()"></div>
+      <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
+    </div>
+
+    <!-- Error -->
+    <div *ngIf="error()" class="error-message">
+      <mat-icon>error</mat-icon>
+      {{ error() }}
+    </div>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  <div class="follow-up-bar">
+    <input
+      type="text"
+      [(ngModel)]="followUpInput"
+      (keydown)="onFollowUpKeydown($event)"
+      placeholder="Ask a follow-up question..."
+      [disabled]="streaming()"
+      class="follow-up-input" />
+    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpInput()">
+      <mat-icon>send</mat-icon>
+    </button>
+  </div>
+  <button mat-button mat-dialog-close>Close</button>
+</mat-dialog-actions>
+```
+
+- [ ] **Step 3: Create the modal styles**
+
+```scss
+:host {
+  display: block;
+}
+
+.context-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  font-size: 13px;
+
+  .context-model {
+    font-weight: 500;
+    color: var(--ud-text-secondary);
+  }
+}
+
+.advanced-section {
+  margin-bottom: 12px;
+
+  .advanced-toggle {
+    font-size: 12px;
+    color: var(--ud-text-secondary);
+  }
+
+  .advanced-content {
+    margin-top: 8px;
+  }
+
+  .system-prompt-editor {
+    width: 100%;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 8px;
+    border: 1px solid var(--ud-border);
+    border-radius: var(--ud-radius-sm);
+    resize: vertical;
+  }
+}
+
+.conversation {
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.message {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--ud-border-subtle, #eee);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .message-icon {
+    flex-shrink: 0;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    color: var(--ud-text-secondary);
+  }
+
+  .message-content {
+    flex: 1;
+    font-size: 14px;
+    line-height: 1.6;
+    word-break: break-word;
+  }
+}
+
+.user-message .message-content {
+  color: var(--ud-text-secondary);
+  font-style: italic;
+}
+
+.stream-progress {
+  margin-top: 8px;
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  color: var(--ud-error, #d32f2f);
+  font-size: 13px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+mat-dialog-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.follow-up-bar {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .follow-up-input {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid var(--ud-border);
+    border-radius: var(--ud-radius-sm);
+    font-size: 14px;
+    outline: none;
+
+    &:focus {
+      border-color: var(--ud-accent);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Verify frontend build**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2/console-webapp && npx ng build 2>&1 | tail -20
+```
+
+Expected: Build success (or warnings only)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts \
+  console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html \
+  console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+git commit -m "feat(registry-dash): add AI analysis modal with streaming and follow-ups"
+```
+
+---
+
+## Task 9: Frontend — Sparkle Button Component
+
+**Files:**
+- Create: `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.html`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.scss`
+
+- [ ] **Step 1: Create the component TypeScript**
+
+```typescript
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { MaterialModule } from '../../material.module';
+import { AiAnalysisModalComponent, AiAnalysisModalData } from './ai-analysis-modal.component';
+import { AiPromptOption, AiAnalyzeRequest, AiModelChoice } from './ai-analysis.models';
+import { RegistryDashService } from '../registry-dash.service';
+
+@Component({
+  selector: 'app-ai-sparkle-button',
+  standalone: true,
+  imports: [CommonModule, MaterialModule],
+  templateUrl: './ai-sparkle-button.component.html',
+  styleUrls: ['./ai-sparkle-button.component.scss'],
+})
+export class AiSparkleButtonComponent {
+  @Input({ required: true }) page!: AiAnalyzeRequest['page'];
+  @Input({ required: true }) prompts!: AiPromptOption[];
+  @Input({ required: true }) chartData!: any;
+  @Input() isAdmin = false;
+
+  constructor(
+    private dialog: MatDialog,
+    private dashService: RegistryDashService,
+  ) {}
+
+  onPromptSelect(prompt: AiPromptOption) {
+    const range = this.dashService.selectedRangeConfig();
+    const tlds = this.dashService.selectedTlds();
+    const regIds = this.dashService.selectedRegistrarIds();
+
+    const savedModel = this.dashService.settingsCache()?.['aiModel'] as AiModelChoice | undefined;
+
+    const data: AiAnalysisModalData = {
+      title: `${prompt.label} — ${this.pageLabel()}`,
+      page: this.page,
+      promptType: prompt.promptType,
+      userMessage: prompt.userMessage,
+      metadata: {
+        dateRange: { start: '', end: '' },
+        granularity: range?.granularity,
+        filteredTlds: tlds,
+        filteredRegistrars: regIds,
+      },
+      chartData: this.chartData,
+      isAdmin: this.isAdmin,
+      savedModel,
+    };
+
+    this.dialog.open(AiAnalysisModalComponent, {
+      width: '800px',
+      maxHeight: '90vh',
+      data,
+    });
+  }
+
+  private pageLabel(): string {
+    switch (this.page) {
+      case 'domain-activity': return 'Domain Activity';
+      case 'revenue-billing': return 'Revenue Billing';
+      case 'forecasting': return 'Forecasting';
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create the sparkle button template**
+
+```html
+<button mat-icon-button [matMenuTriggerFor]="aiMenu"
+        matTooltip="Analyze with AI"
+        class="sparkle-button">
+  <mat-icon>auto_awesome</mat-icon>
+</button>
+
+<mat-menu #aiMenu="matMenu">
+  <button mat-menu-item *ngFor="let prompt of prompts" (click)="onPromptSelect(prompt)">
+    <mat-icon>{{ prompt.icon }}</mat-icon>
+    <span>{{ prompt.label }}</span>
+  </button>
+</mat-menu>
+```
+
+- [ ] **Step 3: Create the sparkle button styles**
+
+```scss
+.sparkle-button {
+  opacity: 0.6;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts \
+  console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.html \
+  console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.scss
+git commit -m "feat(registry-dash): add reusable AI sparkle button with prompt menu"
+```
+
+---
+
+## Task 10: Frontend — Integrate Sparkle Buttons into Pages
+
+**Files:**
+- Modify: `console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.ts`
+- Modify: `console-webapp/src/app/registry-dash/domain-activity/domain-activity.component.html`
+- Modify: `console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.ts`
+- Modify: `console-webapp/src/app/registry-dash/financials/revenue-billing/revenue-billing.component.html`
+- Modify: `console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.ts`
+- Modify: `console-webapp/src/app/registry-dash/financials/forecasting/forecasting.component.html`
+
+- [ ] **Step 1: Update domain-activity.component.ts**
+
+Add imports:
+```typescript
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { DOMAIN_ACTIVITY_PROMPTS } from '../ai/ai-prompts';
+```
+
+Add to `imports` array in `@Component`:
+```typescript
+imports: [CommonModule, MaterialModule, NgxEchartsDirective, LongPressDirective, FilterPanelComponent, AiSparkleButtonComponent],
+```
+
+Add property:
+```typescript
+readonly aiPrompts = DOMAIN_ACTIVITY_PROMPTS;
+```
+
+- [ ] **Step 2: Update domain-activity.component.html**
+
+Replace each chart's `<h3>` with a header row that includes the sparkle button. For the first chart:
+
+```html
+<div class="chart-header">
+  <h3>Activity Breakdown by TLD</h3>
+  <app-ai-sparkle-button
+    page="domain-activity"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+For the second chart:
+
+```html
+<div class="chart-header">
+  <h3>Current Domain Counts by TLD</h3>
+  <app-ai-sparkle-button
+    page="domain-activity"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+- [ ] **Step 3: Add `chart-header` CSS to domain-activity.component.scss**
+
+```scss
+.chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h3 {
+    margin: 0;
+  }
+}
+```
+
+- [ ] **Step 4: Update revenue-billing.component.ts**
+
+Add imports:
+```typescript
+import { AiSparkleButtonComponent } from '../../ai/ai-sparkle-button.component';
+import { REVENUE_BILLING_PROMPTS } from '../../ai/ai-prompts';
+```
+
+Add to `imports` array:
+```typescript
+AiSparkleButtonComponent
+```
+
+Add property:
+```typescript
+readonly aiPrompts = REVENUE_BILLING_PROMPTS;
+```
+
+- [ ] **Step 5: Update revenue-billing.component.html**
+
+Replace each chart's `<h3>` with a header row:
+
+```html
+<div class="chart-header">
+  <h3>Registry Revenue by TLD</h3>
+  <app-ai-sparkle-button
+    page="revenue-billing"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+```html
+<div class="chart-header">
+  <h3>Registry Revenue by Operation</h3>
+  <app-ai-sparkle-button
+    page="revenue-billing"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+- [ ] **Step 6: Add `chart-header` CSS to revenue-billing.component.scss**
+
+Same pattern as domain-activity:
+```scss
+.chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h3 {
+    margin: 0;
+  }
+}
+```
+
+- [ ] **Step 7: Update forecasting.component.ts**
+
+Add imports:
+```typescript
+import { AiSparkleButtonComponent } from '../../ai/ai-sparkle-button.component';
+import { FORECASTING_PROMPTS } from '../../ai/ai-prompts';
+```
+
+Add to `imports` array:
+```typescript
+AiSparkleButtonComponent
+```
+
+Add property:
+```typescript
+readonly aiPrompts = FORECASTING_PROMPTS;
+```
+
+- [ ] **Step 8: Update forecasting.component.html**
+
+Replace each chart's `<h3>` with a header row:
+
+```html
+<div class="chart-header">
+  <h3>Net Growth Projection</h3>
+  <app-ai-sparkle-button
+    page="forecasting"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+```html
+<div class="chart-header">
+  <h3>Domain Expirations by TLD</h3>
+  <app-ai-sparkle-button
+    page="forecasting"
+    [prompts]="aiPrompts"
+    [chartData]="data()">
+  </app-ai-sparkle-button>
+</div>
+```
+
+- [ ] **Step 9: Add `chart-header` CSS to forecasting.component.scss**
+
+Same pattern:
+```scss
+.chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  h3 {
+    margin: 0;
+  }
+}
+```
+
+- [ ] **Step 10: Verify frontend build**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2/console-webapp && npx ng build 2>&1 | tail -20
+```
+
+Expected: Build success
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/domain-activity/ \
+  console-webapp/src/app/registry-dash/financials/revenue-billing/ \
+  console-webapp/src/app/registry-dash/financials/forecasting/
+git commit -m "feat(registry-dash): integrate AI sparkle buttons into all three dashboard pages"
+```
+
+---
+
+## Task 11: Verification — Full Backend Test Suite
+
+- [ ] **Step 1: Run all AI-related backend tests**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.ai.*" --tests "google.registry.ui.server.console.registrydash.RegistryDashAiActionTest" 2>&1 | tail -30
+```
+
+Expected: All tests pass
+
+- [ ] **Step 2: Run the routing test**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2 && ./nom_build :core:test --tests "google.registry.module.RoutingMapTest" 2>&1 | tail -10
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Run frontend tests**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2/console-webapp && npm test 2>&1 | tail -30
+```
+
+Expected: All tests pass (existing tests should still work; new components don't have specs yet but shouldn't break anything)
+
+---
+
+## Task 12: Verification — Manual E2E Test Plan
+
+This task is a checklist for manual testing on the local dev server.
+
+- [ ] **Step 1: Set up Anthropic API key in local dev**
+
+The local dev server won't have Secret Manager access. For local testing, you'll need to either:
+- Set the key as an environment variable and modify the module to check env vars first
+- Or create a `nomulus-config-local.yaml` override with a hardcoded test key (DO NOT commit)
+
+- [ ] **Step 2: Start the local dev server**
+
+Run:
+```bash
+cd /Users/tjones/conductor/workspaces/nomulus/jerusalem-v2/console-webapp && npm run start:dev
+```
+
+- [ ] **Step 3: Test Domain Activity page**
+
+1. Navigate to Domain Activity
+2. Verify sparkle button appears on each chart header
+3. Click sparkle → verify 3 prompt options appear
+4. Select "Summarize trends" → verify modal opens with model switcher
+5. Verify streaming response renders incrementally
+6. Type a follow-up → verify conversation continues
+7. Switch model to Haiku → verify next request uses haiku
+
+- [ ] **Step 4: Test Revenue Billing page**
+
+Same flow as Domain Activity but on the Revenue Billing tab
+
+- [ ] **Step 5: Test Forecasting page**
+
+Same flow but verify the "Identify risks" option appears instead of "Find anomalies"
+
+- [ ] **Step 6: Test error scenarios**
+
+1. Disconnect network → verify "Analysis temporarily unavailable" message
+2. Send many rapid requests → verify rate limit message appears
+3. Close modal during streaming → verify no errors in console

--- a/docs/superpowers/specs/2026-04-22-registry-dash-ai-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-22-registry-dash-ai-analysis-design.md
@@ -1,0 +1,206 @@
+# Registry Dashboard AI Analysis — Tier 1 Design Spec
+
+## Context
+
+The registry dashboard provides charts and tables across Domain Activity, Revenue Billing, Forecasting, and other pages. Users currently interpret data manually. This feature adds AI-powered analysis via Claude — predefined analysis prompts on each chart plus conversational follow-ups — to surface trends, anomalies, and actionable recommendations automatically.
+
+## Scope
+
+**Tier 1 only.** Three pages: Domain Activity, Revenue Billing, Forecasting. Sparkle button with predefined prompt menu, analysis modal with streaming response and follow-up input. Backend proxy to Anthropic API.
+
+## Architecture
+
+### Approach: Hybrid (Backend System Prompts + Frontend User Messages)
+
+```
+Angular Frontend                    Java Backend                     Anthropic API
+─────────────────                   ────────────                     ─────────────
+User clicks ✨ →                    
+Picks prompt from menu →           
+AiAnalysisService builds payload → POST /console-api/registry-dash/ai/analyze
+                                    → Auth check
+                                    → Rate limit check (120 req/hr per user)
+                                    → Load system prompt by page + promptType
+                                    → Build messages array
+                                    → Call Anthropic Messages API (streaming) ──→ POST /v1/messages
+                                    ← SSE chunks piped back ←──────────────────── SSE stream
+← Modal renders streamed markdown  
+User types follow-up →             
+Append to conversationHistory →     → Same flow, with history
+```
+
+### Dev vs Production Prompt Strategy
+
+- **Development** (`RegistryEnvironment != PRODUCTION`): System prompts editable live in the UI. The analysis modal includes a collapsible "Advanced" section (FTE/admin only) with a textarea showing the current system prompt. Edit the prompt, hit Send, see results immediately. Edited prompt sent as `systemPrompt` field — backend passes through. Default prompts loaded from Angular constants but freely editable per-session.
+- **Production** (`RegistryEnvironment == PRODUCTION`): System prompts stored in backend config (YAML or DB). Backend ignores frontend `systemPrompt` field. Loaded by `page` + `promptType` key. Hot-reloadable without deploy if DB-backed.
+- **Migration path**: Iterate on prompts in the UI → copy finalized prompts to backend config → backend takes over.
+
+## Frontend Design
+
+### Sparkle Button
+
+- `✨ Analyze` button per-chart inside each tab's template, in the chart header bar
+- Reusable `AiSparkleButtonComponent` (standalone Angular component)
+- Clicking opens a `MatMenu` dropdown with 2-3 page-specific prompt options
+- **Note:** Revenue Billing and Forecasting are tabs within `financials.component.ts`, not top-level pages. The sparkle button goes in each tab's own component template (`revenue-billing.component.ts`, `forecasting.component.ts`).
+
+### Prompt Menu (per page)
+
+**Domain Activity:**
+- 📊 Summarize trends — lifecycle patterns, growth/decline
+- 🔍 Find anomalies — spikes, unusual create/delete ratios
+- 💡 Suggest actions — retention, growth opportunities
+
+**Revenue Billing:**
+- 📊 Summarize trends — revenue drivers, growth percentages
+- 🔍 Find anomalies — spikes, declining segments
+- 💡 Suggest actions — pricing adjustments, registrar outreach
+
+**Forecasting:**
+- 📊 Summarize trends — renewal health overview
+- ⚠️ Identify risks — expiration cliffs, declining registrars
+- 💡 Suggest actions — retention strategies, pricing recommendations
+
+### Analysis Modal
+
+Uses `MatDialog` (same pattern as existing `DrillDownDialogComponent`).
+
+**Header:**
+- Title (e.g., "Revenue Trend Analysis")
+- Context line: model name, active filters, date range
+- Model switcher: segmented toggle (Haiku / **Sonnet** / Opus)
+- Close button
+
+**Body:**
+- Streamed markdown rendered incrementally
+- Scrollable for longer responses
+
+**Advanced Section (FTE/admin only):**
+- Collapsible, hidden by default
+- Textarea showing the current system prompt for this page + promptType
+- Editable — changes apply to the next request only (not persisted)
+- Default value loaded from Angular prompt constants
+
+**Footer:**
+- Text input: "Ask a follow-up question..."
+- Send button
+- Follow-ups append to conversation history and re-call the same endpoint
+
+### Model Preference
+
+- Default model stored per user via existing `/console-api/registry-dash/settings` endpoint
+- Model override available in the modal header (per-request)
+- Resolution order: request override → user setting → server default (sonnet)
+- Three options: Haiku (fast/cheap), Sonnet (default/balanced), Opus (deep analysis)
+
+## Data Payloads
+
+### Common Request Shape
+
+```typescript
+interface AiAnalyzeRequest {
+  page: 'domain-activity' | 'revenue-billing' | 'forecasting';
+  promptType: string;       // e.g., 'summarize_trends', 'find_anomalies', 'suggest_actions'
+  metadata: {
+    dateRange: { start: string; end: string };
+    granularity?: string;
+    filteredTlds: string[];
+    filteredRegistrars: string[];
+    [key: string]: any;     // page-specific metadata
+  };
+  chartData: any;           // page-specific, matches existing API response shape
+  model?: string;           // 'haiku' | 'sonnet' | 'opus'
+  systemPrompt?: string;    // dev only — ignored in production
+  conversationHistory: ConversationMessage[];
+}
+
+interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+```
+
+### Page-Specific chartData
+
+**Domain Activity** — `{ activity: [{period, tld, type, count}], currentCounts: {tld: count} }`
+
+**Revenue Billing** — `{ periodRevenue: [{period, tld, operation, amount, netAmountToRegistry}], totals: {totalRevenue, totalNetAmountToRegistry, byOperation} }`
+
+**Forecasting** — `{ renewalRates: [{period, tld, registrarId, rate, eligibleDomains, renewedDomains}], expirationCurve: [{period, tld, expiringDomains, projectedRenewals, revenueAtRisk}] }`
+
+All chartData shapes match what the frontend already receives from existing API endpoints — no transformation needed.
+
+## Backend Design
+
+### New Action: RegistryDashAiAction
+
+- **Path:** `POST /console-api/registry-dash/ai/analyze`
+- **Auth:** `@Auth(Auth.AUTH_PUBLIC_LOGGED_IN)` — same as all registry-dash endpoints
+- **Permission:** `ConsolePermission.VIEW_DASHBOARD_OVERVIEW` — if a user can see the dashboard, they can use AI analysis on any page they're viewing. Page-level access is already enforced by frontend routing.
+- **Location:** `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java`
+- **Pattern:** Extends `ConsoleApiAction`, follows existing action class conventions
+- **SSE note:** Cannot use `consoleApiParams.response().setPayload()` — must write directly to servlet `OutputStream` with manual flushing for streaming.
+
+### AnthropicClient
+
+- **Location:** `core/src/main/java/google/registry/ai/AnthropicClient.java`
+- Uses `OkHttpClient` (same as MosApiClient pattern, see `MosApiModule` for DI template)
+- API key from Google Secret Manager, secret name: `ud_rsp_anthropic_api_key`
+- Default model from config, overridable per request
+- Streaming support: reads response body as stream, yields chunks
+
+### Streaming: Server-Sent Events (SSE)
+
+- Response `Content-Type: text/event-stream`
+- Java action reads chunks from Anthropic's streaming response
+- Each chunk written as `data: {"text": "..."}\n\n` to servlet response
+- Flush after each chunk for real-time delivery
+- Angular reads via `fetch()` + `ReadableStream`, appends text to modal incrementally
+- SSE chosen over WebSocket: unidirectional (server→client), works over standard HTTP, matches Anthropic's own streaming protocol. Sufficient through Tier 3.
+
+### Rate Limiting
+
+- In-memory counter per user email
+- Default: 120 requests/hour (configurable)
+- Returns HTTP 429 with `Retry-After` header when exceeded
+- Resets on sliding window
+
+### Error Handling
+
+| Failure | Backend Response | User Sees |
+|---------|-----------------|-----------|
+| Rate limit exceeded | 429 + Retry-After | "Analysis limit reached. Try again in X minutes." |
+| Anthropic API error (500/timeout) | 502 | "Analysis temporarily unavailable. Please try again." |
+| Anthropic rate limit (429) | 503 + Retry-After | "AI service is busy. Please try again shortly." |
+| Invalid API key | 500 (logged) | "Analysis service not configured. Contact admin." |
+| Stream interrupted | SSE error event | Partial text shown + "Response interrupted. Try again?" |
+
+## New Files
+
+### Backend (Java)
+- `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java`
+- `core/src/main/java/google/registry/ai/AnthropicClient.java`
+- `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java`
+- Updates to `ConsoleModule.java` — DI wiring, JSON payload provider
+- Updates to `RequestComponent` routing
+
+### Frontend (Angular)
+- `console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts`
+- `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts`
+- `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts`
+- `console-webapp/src/app/registry-dash/ai/ai-prompts.ts` (dev phase prompt templates)
+- `console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts`
+- Updates to `domain-activity.component.ts` — add sparkle button
+- Updates to `revenue-billing.component.ts` — add sparkle button
+- Updates to `forecasting.component.ts` — add sparkle button
+- Updates to `backend.service.ts` — AI analyze endpoint
+- Updates to settings model — AI model preference field
+
+## Verification
+
+1. **Unit tests**: AnthropicClient (mock OkHttp responses), RegistryDashAiAction (auth, rate limiting, payload validation)
+2. **Frontend tests**: AiAnalysisService (mock streaming responses), modal rendering, sparkle button menu
+3. **Integration test**: Click sparkle on Revenue Billing → select "Summarize trends" → verify modal opens with streaming response → type follow-up → verify conversation continues
+4. **Error scenarios**: Verify each error state renders the correct user-facing message
+5. **Model switching**: Change model in modal, verify request uses the override; change in settings, verify persistence
+6. **Manual E2E on local dev server**: Run console locally with Anthropic API key, test all 3 pages with real data


### PR DESCRIPTION
## Summary
- Add AI-powered analysis to three registry dashboard pages (Domain Activity, Revenue Billing, Forecasting)
- Sparkle button per chart opens a prompt menu → streaming analysis modal with follow-up conversation
- Backend proxies to Anthropic Messages API via SSE with per-user rate limiting (120 req/hr)
- System prompts editable in dev (FTE/admin), backend-controlled in production

## Architecture
- **Backend**: `RegistryDashAiAction` (POST `/console-api/registry-dash/ai/analyze`) → `AnthropicClient` (OkHttp SSE) → streamed response via servlet `PrintWriter`
- **Frontend**: `AiSparkleButtonComponent` (MatMenu) → `AiAnalysisModalComponent` (MatDialog) → `AiAnalysisService` (fetch + ReadableStream)
- **Auth**: `VIEW_DASHBOARD_OVERVIEW` permission
- **Config**: API key from Secret Manager (`ud_rsp_anthropic_api_key`), model/rate-limit in YAML

## New Files
### Backend
- `core/.../ai/AnthropicClient.java` — OkHttp client with SSE streaming
- `core/.../ai/AnthropicModule.java` — Dagger DI module
- `core/.../ai/AiAnalyzeRequest.java` — Request POJO
- `core/.../ai/AiRateLimiter.java` — Sliding window rate limiter
- `core/.../registrydash/RegistryDashAiAction.java` — POST action

### Frontend
- `console-webapp/.../ai/ai-analysis.service.ts` — SSE streaming service
- `console-webapp/.../ai/ai-analysis-modal.component.*` — Analysis dialog
- `console-webapp/.../ai/ai-sparkle-button.component.*` — Reusable sparkle button
- `console-webapp/.../ai/ai-analysis.models.ts` — TypeScript interfaces
- `console-webapp/.../ai/ai-prompts.ts` — Per-page prompt templates

## Test plan
- [ ] AnthropicClientTest: 5 tests (SSE parsing, headers, error handling, rate limits, model mapping)
- [ ] AiRateLimiterTest: 5 tests (under/over limit, sliding window, per-user, retry-after)
- [ ] RegistryDashAiActionTest: 4 tests (streaming success, missing payload, invalid page, rate limit)
- [ ] Angular build passes
- [ ] Manual E2E: sparkle button → prompt menu → streaming modal → follow-up on all 3 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)