### PR TITLE
fix(registry-dash): null-safe AI config for env-specific YAML

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1452,25 +1452,25 @@ public final class RegistryConfig {
     @Provides
     @Config("anthropicApiBaseUrl")
     public static String provideAnthropicApiBaseUrl(RegistryConfigSettings config) {
-      return config.ai.apiBaseUrl;
+      return config.ai != null ? config.ai.apiBaseUrl : "https://api.anthropic.com";
     }
 
     @Provides
     @Config("anthropicApiKeySecretName")
     public static String provideAnthropicApiKeySecretName(RegistryConfigSettings config) {
-      return config.ai.apiKeySecretName;
+      return config.ai != null ? config.ai.apiKeySecretName : "ud_rsp_anthropic_api_key";
     }
 
     @Provides
     @Config("anthropicDefaultModel")
     public static String provideAnthropicDefaultModel(RegistryConfigSettings config) {
-      return config.ai.defaultModel;
+      return config.ai != null ? config.ai.defaultModel : "sonnet";
     }
 
     @Provides
     @Config("anthropicRateLimitPerHour")
     public static int provideAnthropicRateLimitPerHour(RegistryConfigSettings config) {
-      return config.ai.rateLimitPerHour;
+      return config.ai != null ? config.ai.rateLimitPerHour : 120;
     }
 
     private static String formatComments(String text) {


### PR DESCRIPTION
## Summary
- Config providers for AI settings NPE when env-specific YAML doesn't have `ai:` section
- Adds null-safe defaults matching `default-config.yaml` values

One-line fix per provider — `config.ai != null ? config.ai.field : default`.

## Test plan
- [x] Verified error in alpha-gke logs: `config.ai is null`
- [ ] Deploy to alpha-gke and verify AI analysis works