### PR TITLE
feat(registry-dash): admin system prompt editor

### DIFF
--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -12,16 +12,26 @@
 
   <!-- Advanced section (admin only, dev mode) -->
   <div *ngIf="data.isAdmin" class="advanced-section">
-    <button mat-button (click)="toggleAdvanced()" class="advanced-toggle">
-      <mat-icon>{{ showAdvanced() ? 'expand_less' : 'expand_more' }}</mat-icon>
-      Advanced
-    </button>
+    <div class="advanced-header">
+      <button mat-button (click)="toggleAdvanced()" class="advanced-toggle">
+        <mat-icon>{{ showAdvanced() ? 'expand_less' : 'expand_more' }}</mat-icon>
+        Advanced
+      </button>
+      <button *ngIf="showAdvanced()" mat-button (click)="resetToDefault()"
+              class="reset-button" [disabled]="loadingPrompt()">
+        <mat-icon>restart_alt</mat-icon>
+        Reset to Default
+      </button>
+    </div>
     <div *ngIf="showAdvanced()" class="advanced-content">
+      <div class="prompt-label">System Prompt (changes apply to this session only)</div>
+      <mat-progress-bar *ngIf="loadingPrompt()" mode="indeterminate" class="prompt-loading"></mat-progress-bar>
       <textarea
-        [(ngModel)]="editableSystemPrompt" name="systemPrompt"
+        [ngModel]="editableSystemPrompt" (ngModelChange)="onSystemPromptChange($event)"
+        name="systemPrompt"
         class="system-prompt-editor"
-        placeholder="System prompt (editable in dev mode)"
-        rows="6"></textarea>
+        placeholder="Loading default system prompt..."
+        rows="12"></textarea>
     </div>
   </div>
 
@@ -64,7 +74,7 @@
       placeholder="Ask a follow-up question..."
       [disabled]="streaming()"
       class="follow-up-input" />
-    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpText">
+    <button mat-icon-button (click)="sendFollowUp()" [disabled]="streaming() || !followUpText.trim()">
       <mat-icon>send</mat-icon>
     </button>
   </div>

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
@@ -18,13 +18,34 @@
 .advanced-section {
   margin-bottom: 12px;
 
+  .advanced-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
   .advanced-toggle {
+    font-size: 12px;
+    color: var(--ud-text-secondary);
+  }
+
+  .reset-button {
     font-size: 12px;
     color: var(--ud-text-secondary);
   }
 
   .advanced-content {
     margin-top: 8px;
+  }
+
+  .prompt-label {
+    font-size: 11px;
+    color: var(--ud-text-secondary);
+    margin-bottom: 4px;
+  }
+
+  .prompt-loading {
+    margin-bottom: 4px;
   }
 
   .system-prompt-editor {

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -58,6 +58,8 @@ export class AiAnalysisModalComponent implements OnInit {
   followUpText = '';
   showAdvanced = signal(false);
   editableSystemPrompt = '';
+  defaultSystemPrompt = '';
+  loadingPrompt = signal(false);
 
   streaming = computed(() => this.aiService.streaming());
   streamedText = computed(() => this.aiService.streamedText());
@@ -144,10 +146,48 @@ export class AiAnalysisModalComponent implements OnInit {
     }
   }
 
-  toggleAdvanced() {
+  async toggleAdvanced() {
     this.showAdvanced.update(v => !v);
     if (this.showAdvanced() && !this.editableSystemPrompt) {
-      this.editableSystemPrompt = this.data.systemPrompt ?? '';
+      const storageKey = `ai-prompt-${this.data.page}-${this.data.promptType}`;
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        this.editableSystemPrompt = saved;
+      }
+      await this.fetchDefaultPrompt();
+      if (!saved && this.defaultSystemPrompt) {
+        this.editableSystemPrompt = this.defaultSystemPrompt;
+      }
+    }
+  }
+
+  async resetToDefault() {
+    await this.fetchDefaultPrompt();
+    this.editableSystemPrompt = this.defaultSystemPrompt;
+    const storageKey = `ai-prompt-${this.data.page}-${this.data.promptType}`;
+    localStorage.removeItem(storageKey);
+  }
+
+  private async fetchDefaultPrompt() {
+    if (this.defaultSystemPrompt) return;
+    this.loadingPrompt.set(true);
+    try {
+      this.defaultSystemPrompt = await this.aiService.getDefaultPrompt(
+        this.data.page, this.data.promptType);
+    } catch {
+      // Fall back silently — editor still works with manual input
+    } finally {
+      this.loadingPrompt.set(false);
+    }
+  }
+
+  onSystemPromptChange(value: string) {
+    this.editableSystemPrompt = value;
+    const storageKey = `ai-prompt-${this.data.page}-${this.data.promptType}`;
+    if (value && value !== this.defaultSystemPrompt) {
+      localStorage.setItem(storageKey, value);
+    } else {
+      localStorage.removeItem(storageKey);
     }
   }
 }

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -21,6 +21,18 @@ export class AiAnalysisService {
   streamedText = signal('');
   error = signal<string | null>(null);
 
+  async getDefaultPrompt(page: string, promptType: string): Promise<string> {
+    const response = await fetch(
+      `/console-api/registry-dash/ai/analyze?page=${encodeURIComponent(page)}&promptType=${encodeURIComponent(promptType)}`,
+      { credentials: 'same-origin' },
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch default prompt: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.systemPrompt;
+  }
+
   async analyze(request: AiAnalyzeRequest): Promise<void> {
     this.streaming.set(true);
     this.streamedText.set('');
@@ -46,6 +58,17 @@ export class AiAnalysisService {
         return;
       }
       if (response.status === 502) {
+        try {
+          const body = await response.text();
+          const match = body.match(/data: (.+)/);
+          if (match) {
+            const parsed = JSON.parse(match[1]);
+            if (parsed.error) {
+              this.error.set(`API error: ${parsed.error}`);
+              return;
+            }
+          }
+        } catch { /* fall through */ }
         this.error.set('Analysis temporarily unavailable. Please try again.');
         return;
       }

--- a/core/src/main/java/google/registry/ai/AnthropicClient.java
+++ b/core/src/main/java/google/registry/ai/AnthropicClient.java
@@ -102,7 +102,10 @@ public class AnthropicClient {
         throw new AnthropicRateLimitException("Anthropic API rate limited: " + response.code());
       }
       if (!response.isSuccessful()) {
-        throw new IOException("Anthropic API error: " + response.code());
+        String errorBody = response.body() != null
+            ? response.body().string() : "no response body";
+        throw new IOException(
+            "Anthropic API error: " + response.code() + " - " + errorBody);
       }
 
       try (BufferedReader reader = new BufferedReader(

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
@@ -40,10 +40,10 @@ import google.registry.ui.server.SendEmailUtils;
 import google.registry.ui.server.console.ConsoleEppPasswordAction.EppPasswordData;
 import google.registry.ui.server.console.ConsoleOteAction.OteCreateData;
 import google.registry.ui.server.console.ConsoleRegistryLockAction.ConsoleRegistryLockPostInput;
-import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
-import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
 import google.registry.ui.server.console.ConsoleUsersAction.UserData;
 import google.registry.ui.server.console.PasswordResetRequestAction.PasswordResetRequestData;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -460,5 +460,17 @@ public final class ConsoleModule {
   public static Optional<JsonElement> provideAiAnalyzePayload(
       @OptionalJsonPayload Optional<JsonElement> payload) {
     return payload;
+  }
+
+  @Provides
+  @Parameter("aiPage")
+  public static Optional<String> provideAiPage(HttpServletRequest req) {
+    return extractOptionalParameter(req, "page");
+  }
+
+  @Provides
+  @Parameter("aiPromptType")
+  public static Optional<String> provideAiPromptType(HttpServletRequest req) {
+    return extractOptionalParameter(req, "promptType");
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 @Action(
     service = Service.CONSOLE,
     path = RegistryDashAiAction.PATH,
-    method = Action.Method.POST,
+    method = {Action.Method.GET, Action.Method.POST},
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)
 public class RegistryDashAiAction extends ConsoleApiAction {
 
@@ -53,6 +53,8 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   private static final Gson PLAIN_GSON = new Gson();
 
   private final Optional<JsonElement> payload;
+  private final Optional<String> aiPage;
+  private final Optional<String> aiPromptType;
   private final AnthropicClient anthropicClient;
   private final AiRateLimiter rateLimiter;
   private final Gson gson;
@@ -61,13 +63,38 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   public RegistryDashAiAction(
       ConsoleApiParams consoleApiParams,
       @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
+      @Parameter("aiPage") Optional<String> aiPage,
+      @Parameter("aiPromptType") Optional<String> aiPromptType,
       AnthropicClient anthropicClient,
       AiRateLimiter rateLimiter) {
     super(consoleApiParams);
     this.payload = payload;
+    this.aiPage = aiPage;
+    this.aiPromptType = aiPromptType;
     this.anthropicClient = anthropicClient;
     this.rateLimiter = rateLimiter;
     this.gson = consoleApiParams.gson();
+  }
+
+  @Override
+  protected void getHandler(User user) {
+    boolean isProduction = RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION;
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+
+    if (isProduction || !isAdmin) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+
+    if (aiPage.isEmpty() || aiPromptType.isEmpty()) {
+      setFailedResponse("page and promptType query parameters are required", SC_BAD_REQUEST);
+      return;
+    }
+
+    String prompt = getDefaultSystemPrompt(aiPage.get(), aiPromptType.get(), null, null);
+    JsonObject result = new JsonObject();
+    result.addProperty("systemPrompt", prompt);
+    consoleApiParams.response().setPayload(PLAIN_GSON.toJson(result));
   }
 
   @Override
@@ -131,15 +158,25 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       consoleApiParams.response().setHeader("Retry-After", "30");
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Anthropic API error");
-      consoleApiParams.response().setStatus(502);
+      try {
+        PrintWriter writer = consoleApiParams.response().getWriter();
+        consoleApiParams.response().setHeader(
+            "Content-Type", "text/event-stream");
+        consoleApiParams.response().setStatus(502);
+        String detail = e.getMessage() != null ? e.getMessage() : "";
+        writer.write("data: " + PLAIN_GSON.toJson(
+            new ErrorChunk(detail)) + "\n\n");
+        writer.flush();
+      } catch (IOException ignored) {
+        consoleApiParams.response().setStatus(502);
+      }
     }
   }
 
   private String buildSystemPrompt(AiAnalyzeRequest request, User user) {
-    boolean isProduction = RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION;
     boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
 
-    if (!isProduction && isAdmin
+    if (isAdmin
         && request.systemPrompt != null && !request.systemPrompt.isEmpty()) {
       return request.systemPrompt;
     }
@@ -188,7 +225,11 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       }
     }
 
-    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n");
+    sb.append("\n## Data\n```json\n");
+    sb.append(chartData != null
+        ? gson.toJson(chartData)
+        : "[chart data will be injected at request time]");
+    sb.append("\n```\n");
     sb.append("\nProvide your analysis in clear markdown. Use specific numbers from the data. ");
     sb.append("Keep your response concise and actionable.");
 
@@ -196,4 +237,6 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   }
 
   private record TextChunk(String text) {}
+
+  private record ErrorChunk(String error) {}
 }

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -84,7 +84,8 @@ class RegistryDashAiActionTest {
     }).when(anthropicClient).streamMessage(any(), any(), any(), any());
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter);
+        params, Optional.of(json), Optional.empty(), Optional.empty(),
+        anthropicClient, rateLimiter);
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -97,7 +98,8 @@ class RegistryDashAiActionTest {
   @Test
   void testBadRequest_missingPayload() {
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.empty(), anthropicClient, rateLimiter);
+        params, Optional.empty(), Optional.empty(), Optional.empty(),
+        anthropicClient, rateLimiter);
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
@@ -110,7 +112,37 @@ class RegistryDashAiActionTest {
     JsonElement json = JsonParser.parseString(payload);
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter);
+        params, Optional.of(json), Optional.empty(), Optional.empty(),
+        anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testGetDefaultPrompt_returnsSystemPrompt() {
+    when(params.request().getMethod()).thenReturn("GET");
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.empty(),
+        Optional.of("domain-activity"), Optional.of("summarize_trends"),
+        anthropicClient, rateLimiter);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    String payload = response.getPayload();
+    assertThat(payload).contains("systemPrompt");
+    assertThat(payload).contains("domain-activity");
+  }
+
+  @Test
+  void testGetDefaultPrompt_missingParams() {
+    when(params.request().getMethod()).thenReturn("GET");
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.empty(),
+        Optional.empty(), Optional.empty(),
+        anthropicClient, rateLimiter);
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
@@ -126,7 +158,8 @@ class RegistryDashAiActionTest {
     JsonElement json = JsonParser.parseString(payload);
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, strictLimiter);
+        params, Optional.of(json), Optional.empty(), Optional.empty(),
+        anthropicClient, strictLimiter);
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(429);


### PR DESCRIPTION
## Summary

- Add GET endpoint to fetch default system prompt templates for prompt engineering workflow
- Pre-populate the Advanced textarea with the backend's computed default prompt (was empty before)
- Add localStorage persistence for edited prompts and "Reset to Default" button
- Allow FTE admins to override system prompts in production (was restricted to non-prod only)
- Surface Anthropic API error details in 502 responses (error body was previously swallowed)
- Fix whitespace-only follow-up input not disabling the send button

## Test plan

- [x] Java compiles clean (checkstyle + main + test)
- [x] Angular frontend builds
- [x] All 6 RegistryDashAiActionTest tests pass (including 2 new GET handler tests)
- [ ] CI (Cloud Build)
- [ ] Manual: toggle Advanced → verify default prompt loads → edit → send → verify custom prompt used → Reset to Default → verify revert
- [ ] Manual: trigger 502 → verify error detail shown in modal instead of generic message

🤖 Generated with [Claude Code](https://claude.com/claude-code)