### PR TITLE
docs: add AI tier 2-3 design notes and env config plan

### DIFF
--- a/docs/superpowers/plans/2026-04-25-env-specific-ai-config.md
+++ b/docs/superpowers/plans/2026-04-25-env-specific-ai-config.md
@@ -1,0 +1,60 @@
+# Plan: Add Environment-Specific AI Configuration
+
+## Context
+
+PR #114 (AI-powered analysis with Claude) is merged. The feature works on alpha-gke, but the environment-specific YAML configs in `nomulus-secrets` don't have an `ai:` section — they rely on null-safe fallbacks in `RegistryConfig.java` and defaults from `default-config.yaml`. We want explicit per-environment configuration for operational clarity, and production needs a tighter rate limit (60/hr vs 120/hr).
+
+## What Changes
+
+### nomulus repo: NO code changes needed
+
+The existing code is complete:
+- `default-config.yaml` (lines 642-651) — has `ai:` section with all defaults
+- `RegistryConfig.java` (lines 1452-1474) — null-safe fallbacks (`config.ai != null ? ...`)
+- `RegistryConfigSettings.java` (lines 261-267) — `Ai` POJO
+- `AnthropicModule.java` — Secret Manager lookup with env var fallback
+- `AnthropicClient.java` — model mapping, streaming
+
+Keep the null-safe fallbacks as defensive coding (protects unit tests, local dev, new envs).
+
+### nomulus-secrets repo: Add `ai:` section to 3 files
+
+Files at: `core/src/main/java/google/registry/config/files/`
+
+**`nomulus-config-alpha.yaml`** — append:
+```yaml
+ai:
+  apiBaseUrl: https://api.anthropic.com
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  defaultModel: sonnet
+  rateLimitPerHour: 120
+```
+
+**`nomulus-config-sandbox.yaml`** — append:
+```yaml
+ai:
+  apiBaseUrl: https://api.anthropic.com
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  defaultModel: sonnet
+  rateLimitPerHour: 120
+```
+
+**`nomulus-config-production.yaml`** — append:
+```yaml
+ai:
+  apiBaseUrl: https://api.anthropic.com
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  defaultModel: sonnet
+  rateLimitPerHour: 60
+```
+
+### Secret Manager: Create API key secret
+
+- Secret name: `ud_rsp_anthropic_api_key`
+- Create in each project: `ud-registry-alpha-gke`, `ud-registry-sandbox-gke`, `ud-registry-prod-gke`
+- Value: Anthropic API key from the team's API account
+
+## Status
+
+- **Not yet implemented.** This is a post-Tier 1 operational task.
+- The feature works on alpha using `default-config.yaml` defaults and the secret already exists in alpha.

--- a/docs/superpowers/specs/2026-04-24-registry-dash-ai-tiers-2-3-design.md
+++ b/docs/superpowers/specs/2026-04-24-registry-dash-ai-tiers-2-3-design.md
@@ -1,0 +1,34 @@
+# Registry Dashboard AI — Tier 2 & 3 Design Notes
+
+Captured 2026-04-24 during Tier 1 polish session. These are early design notes to inform future specs.
+
+## Tier Overview
+
+- **Tier 1** (complete, PR #114): Static snapshot analysis. Sparkle button → prompt menu → streaming modal with follow-ups. Claude gets a JSON dump of chart data. Three pages: Domain Activity, Revenue Billing, Forecasting.
+- **Tier 2**: Expanded pages + prompt refinement.
+- **Tier 3**: Agentic tool use — Claude can fetch additional data mid-conversation.
+
+## Tier 2 — Expanded Pages + Prompt Refinement
+
+- Add sparkle buttons to remaining pages (Overview, Portfolio, Pricing, Explore)
+- Refine system prompts based on Tier 1 usage patterns
+- Move finalized prompts from frontend constants to backend config (the "migration path" from the Tier 1 spec)
+- Add prompt versioning/A-B testing capability
+- Model preference persistence (already partially implemented via settings)
+
+## Tier 3 — Agentic Tool Use
+
+**Why:** Tier 1 gives Claude a static snapshot of chart data. Follow-up questions like "what domains transferred between which registrars?" fail because the detail isn't in the dataset. Tool use solves this.
+
+- Claude gets tools it can call to fetch additional data mid-conversation
+- Uses Anthropic tool_use API (function calling)
+- Backend defines available tools, Claude decides when to invoke them
+- Example tools:
+  - `query_transfers(tld, date_range)` → domain-level transfer details with registrar info
+  - `query_registrar_activity(registrar_id)` → per-registrar breakdown
+  - `query_domain_details(domain_name)` → full lifecycle for a specific domain
+  - `run_explore_query(query_descriptor)` → runs against the Explore engine (same as Data Exploration page)
+  - `get_pricing_rules(tld, registrar_id)` → current pricing configuration
+- SSE still sufficient (request-response with tool calls in between)
+- Backend orchestrates: receives user message → sends to Anthropic with tools → if tool_use response, executes tool, sends result back → continues until text response
+- Multi-turn tool use loop happens server-side, streamed text chunks sent to frontend as they arrive


### PR DESCRIPTION
## Summary

- Add Tier 2-3 design notes (expanded pages, prompt refinement, agentic tool use)
- Add environment-specific AI config plan for nomulus-secrets

These were previously scattered across memory files and Claude plans. Moving them into the repo so they're available to all worktrees and agents.

## Test plan

- [x] Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)