### PR TITLE
feat(registry-dash): AI Tier 2 — sparkle on Portfolio/Pricing, YAML prompts, /ai/prompts endpoint

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
@@ -9,12 +9,26 @@ Drives the canonical UI test plan for the Nomulus Registry Dashboard against a c
 
 ## Files in this skill
 
-- `test-plan.md` — the canonical 19-test plan. **Source of truth for what gets tested.**
+- `test-plan.md` — the canonical test plan. **Source of truth for what gets tested.**
 - `metadata.json` — `{ lastReviewedCommit, lastReviewedAt, lastReviewer }`. Updated only when a test-plan update is merged to master.
 - `paths.txt` — newline-separated git pathspecs to watch for drift.
 - `helpers/check-drift.sh` — prints commits and changed files since `lastReviewedCommit` for the watched paths.
+- `helpers/start-local-stack.sh` — idempotently starts test server + angular dev for `local-dev` runs. Fetches `ANTHROPIC_API_KEY` from Secret Manager.
+- `helpers/seed-test-data.sh` — seeds the testcontainers Postgres with extra rows (e.g. pricing rules) so dashboard pages have non-trivial data. Optional — most tests pass against the default Fixture.java data.
 
 ## Workflow
+
+### Phase 0 — Environment bring-up (local-dev only)
+
+If the user picks `local-dev` in Phase 2, the skill is responsible for the local stack — do **not** ask the user to run servers manually. Run `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh`. The script:
+
+- Reuses anything already listening on `:8080` / `:4200`.
+- Starts the Java test server (`./gradlew :core:runTestServer`) if needed; waits up to 180s for cold start.
+- Starts the Angular dev server (`npm start` from `console-webapp/`) if needed; waits up to 60s.
+- Pulls `ANTHROPIC_API_KEY` from Secret Manager (`AI_TRAFFIC_ANALYZER_ANTHROPIC_API_KEY` in `unstoppable-domains` GCP project) so the AI sparkle endpoints actually call Claude.
+- Pass `--restart` to kill stale gradle daemons / ng serve processes first; useful when a previous session left zombies.
+
+If Docker isn't running, the script exits with a clear message — surface it to the user; we cannot start testcontainers without Docker.
 
 ### Phase 1 — Drift detection (always first)
 
@@ -48,12 +62,18 @@ Show the user the drift summary, then offer three options:
 
 Ask the user to pick a test environment:
 
-- **local-dev** — `http://localhost:4200/console` (requires local Angular dev server + test server with `ANTHROPIC_API_KEY`)
+- **local-dev** — `http://localhost:4200/console`. The skill will bring up the stack itself in Phase 0 — the user does **not** need to start anything manually.
 - **alpha** — `https://console.dnex-alpha.com/console`
 - **sandbox** — `https://console.dnex-sandbox.com/console` (or whatever the actual URL is — verify before navigating)
 - **production** — **REJECT.** Production is never a valid test environment.
 
 Verify the chosen environment's URL with the user before proceeding.
+
+### Phase 2b — Test data (local-dev only, optional)
+
+The default test-server `Fixture.java` data covers tests 1-6, 15: 2 TLDs (`example`, `xn--q9jyb4c`), `TheRegistrar` + `NewRegistrar` (with domains), and OTE registrars with no domains. That's enough to verify sparkle visibility, prompt menus, the streaming AI flow, and the prompts endpoint.
+
+For tests that need richer data — Test 14 (Pricing analysis) needs at least one `RegistrarPricing` row, Test 7-8 are more meaningful with multi-TLD revenue history — run `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/seed-test-data.sh` after the test server is up. The script is idempotent. If a richer dataset is available locally (e.g. `local-test-data-setup.sql` from a prior session), prefer that.
 
 ### Phase 3 — Test execution
 

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/check-drift.sh
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/check-drift.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 The Nomulus Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Print commits + changed files since metadata.lastReviewedCommit for the paths in paths.txt.
 # Empty output = no drift. Non-empty output = drift detected.
 

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/seed-test-data.sh
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/seed-test-data.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Nomulus Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Seed minimum dashboard test data into the running testcontainers Postgres so
+# the registry-dash UI test plan exercises non-trivial data. Idempotent (uses
+# ON CONFLICT). Required only for tests 7-14 of test-plan.md; tests 1-6 and 15
+# pass against the default Fixture.java data without seeding.
+#
+# Prereqs:
+# - Test server is running (testcontainers Postgres listening on a host port).
+# - psql is installed.
+#
+# Usage:
+#   bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/seed-test-data.sh
+
+set -euo pipefail
+
+PG_PORT="$(docker ps --format '{{.Image}} {{.Ports}}' \
+  | awk '/postgres:17-alpine/ { match($0, /0\.0\.0\.0:[0-9]+->5432/); if (RSTART) { gsub(/0\.0\.0\.0:|->5432/, "", $0); print substr($0, RSTART, RLENGTH-12); exit } }')"
+
+if [[ -z "$PG_PORT" ]]; then
+  echo "[seed-test-data] ERROR: testcontainers Postgres not detected (is the test server running?)" >&2
+  exit 1
+fi
+
+echo "[seed-test-data] seeding into postgres on :$PG_PORT…"
+
+PGPASSWORD=test psql -h localhost -p "$PG_PORT" -U test -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+-- One pricing rule per existing TLD/registrar combo so the Pricing page has
+-- something to summarize. Adjust amounts/operations as needed.
+
+INSERT INTO "RegistrarPricing"
+  (id, registrar_id, tld, operation, price_amount, price_currency, effective_date, expiry_date, is_active, creation_time)
+VALUES
+  (gen_random_uuid(), 'TheRegistrar', 'example', 'CREATE', 12.50, 'USD', '2026-01-01', NULL, true, now()),
+  (gen_random_uuid(), 'TheRegistrar', 'example', 'RENEW',  10.00, 'USD', '2026-01-01', NULL, true, now()),
+  (gen_random_uuid(), 'NewRegistrar', 'example', 'CREATE',  9.50, 'USD', '2026-01-01', NULL, true, now()),
+  (gen_random_uuid(), 'NewRegistrar', 'tld',     'CREATE',  8.75, 'USD', '2026-01-01', NULL, true, now())
+ON CONFLICT DO NOTHING;
+SQL
+
+echo "[seed-test-data] done. RegistrarPricing rows:"
+PGPASSWORD=test psql -h localhost -p "$PG_PORT" -U test -d postgres -tAc \
+  'SELECT count(*) FROM "RegistrarPricing"'

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Nomulus Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Idempotently start the local Nomulus stack for the registry-dashboard test
+# plan: test server (Java + testcontainers Postgres) on :8080, Angular dev
+# server on :4200. Fetches ANTHROPIC_API_KEY from Secret Manager so the AI
+# sparkle endpoints work.
+#
+# Usage:
+#   bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh [--restart]
+#
+# --restart   Kill any existing test-server / angular-dev / gradle daemons
+#             before starting fresh. Default behavior reuses anything already
+#             listening on the expected ports.
+#
+# Output:
+#   Prints status lines as each layer comes up. Exits 0 once both ports
+#   respond, non-zero on any failure.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+LOG_DIR="${REPO_ROOT}/.context/test-registry-dash"
+mkdir -p "$LOG_DIR"
+TEST_SERVER_LOG="$LOG_DIR/test-server.log"
+ANGULAR_LOG="$LOG_DIR/angular-dev.log"
+
+RESTART=0
+for arg in "$@"; do
+  if [[ "$arg" == "--restart" ]]; then
+    RESTART=1
+  fi
+done
+
+port_is_open() {
+  curl -sf --max-time 2 -o /dev/null "http://localhost:$1/" \
+    || curl -sf --max-time 2 -o /dev/null "http://[::1]:$1/"
+}
+
+kill_stack() {
+  echo "[start-local-stack] killing existing test server, angular dev, gradle daemons…"
+  pkill -9 -f "RegistryTestServer" 2>/dev/null || true
+  pkill -9 -f "runTestServer" 2>/dev/null || true
+  pkill -9 -f "GradleWorker" 2>/dev/null || true
+  pkill -9 -f "gradle.*Daemon" 2>/dev/null || true
+  pkill -9 -f "ng serve" 2>/dev/null || true
+  pkill -9 -f "@angular/cli/bin/ng" 2>/dev/null || true
+  sleep 2
+}
+
+if [[ "$RESTART" == "1" ]]; then
+  kill_stack
+fi
+
+# 1. Docker daemon — required for testcontainers Postgres.
+if ! docker info >/dev/null 2>&1; then
+  echo "[start-local-stack] ERROR: Docker daemon not running. Start Docker Desktop and re-run." >&2
+  exit 1
+fi
+
+# 2. ANTHROPIC_API_KEY — fetch from Secret Manager if not set.
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "[start-local-stack] fetching ANTHROPIC_API_KEY from Secret Manager…"
+  ANTHROPIC_API_KEY="$(gcloud secrets versions access latest \
+    --secret=AI_TRAFFIC_ANALYZER_ANTHROPIC_API_KEY \
+    --project=unstoppable-domains 2>/dev/null || true)"
+  if [[ -z "$ANTHROPIC_API_KEY" ]]; then
+    echo "[start-local-stack] WARN: could not fetch ANTHROPIC_API_KEY. AI analyze calls will fail." >&2
+  else
+    export ANTHROPIC_API_KEY
+  fi
+fi
+
+# 3. Test server.
+if port_is_open 8080; then
+  echo "[start-local-stack] test server already up on :8080 — reusing."
+else
+  echo "[start-local-stack] starting test server (logs: $TEST_SERVER_LOG)…"
+  (
+    cd "$REPO_ROOT"
+    nohup ./gradlew :core:runTestServer > "$TEST_SERVER_LOG" 2>&1 &
+  )
+  echo "[start-local-stack] waiting for :8080 (cold start can take 2-3 min)…"
+  for i in $(seq 1 180); do
+    if port_is_open 8080; then break; fi
+    sleep 1
+  done
+  if ! port_is_open 8080; then
+    echo "[start-local-stack] ERROR: test server did not come up on :8080 within 180s. See $TEST_SERVER_LOG" >&2
+    exit 2
+  fi
+  echo "[start-local-stack] test server up."
+fi
+
+# 4. Angular dev server.
+if port_is_open 4200; then
+  echo "[start-local-stack] angular dev server already up on :4200 — reusing."
+else
+  echo "[start-local-stack] starting angular dev server (logs: $ANGULAR_LOG)…"
+  if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.nvm/nvm.sh"
+    nvm use 22.16.0 >/dev/null 2>&1 || nvm use --lts >/dev/null 2>&1 || true
+  fi
+  (
+    cd "$REPO_ROOT/console-webapp"
+    nohup npm start > "$ANGULAR_LOG" 2>&1 &
+  )
+  echo "[start-local-stack] waiting for :4200…"
+  for i in $(seq 1 60); do
+    if port_is_open 4200; then break; fi
+    sleep 1
+  done
+  if ! port_is_open 4200; then
+    echo "[start-local-stack] ERROR: angular dev server did not come up on :4200 within 60s. See $ANGULAR_LOG" >&2
+    exit 3
+  fi
+  echo "[start-local-stack] angular dev server up."
+fi
+
+echo "[start-local-stack] ready: open http://localhost:4200/console"

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastReviewedCommit": "513dea2c5",
+  "lastReviewedCommit": "0e786ebf24e0e0169a75c538df74807bc6b3153c",
   "lastReviewedAt": "2026-04-29",
   "lastReviewer": "torrey@unstoppabledomains.com",
-  "lastReviewerNote": "PR #114 (registry-dash AI feature) merged. Initial baseline."
+  "lastReviewerNote": "Tier 2: Portfolio + Pricing sparkle, AiPromptsService, GET /ai/prompts endpoint, YAML-driven prompts, promptVersion logging. Adds tests 13-17."
 }

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -11,7 +11,7 @@
 
 ## Test 1: Sparkle Button Visibility
 
-**Goal:** Verify sparkle buttons appear on all 5 pages with charts.
+**Goal:** Verify sparkle buttons appear on all 7 dashboard pages.
 
 ### Steps:
 1. Navigate to **Domain Activity** (`/#/registry-dash/domain-activity`).
@@ -27,11 +27,15 @@
 11. Before running a query, verify NO sparkle icon is visible (the button is conditional on chart data existing).
 12. Configure a query (Source: Domain Activity, Metric: Count, Group By: TLD) and click "Run Query".
 13. Verify a sparkle icon appears above the rendered chart.
+14. Navigate to **Portfolio** (`/#/registry-dash/portfolio`).
+15. Verify a single sparkle icon appears in the page header row, to the right of the "Registrar Portfolio" heading.
+16. Navigate to **Pricing** (`/#/registry-dash/pricing`).
+17. Verify a single sparkle icon appears in the page header row, between the "Registrar Custom Pricing Rules" heading and the "Add Rule" button.
 
 ### Expected:
-- Sparkle icons visible on all 5 pages (after query runs on Explore).
+- Sparkle icons visible on all 7 pages (after query runs on Explore).
 - Icons are subtle (slightly transparent, opacity ~0.6) and become fully opaque on hover.
-- Each chart also has an "open in new" explore button alongside the sparkle.
+- Charts also have an "open in new" explore button alongside the sparkle (Portfolio + Pricing have only the sparkle, no explore button).
 
 ---
 
@@ -53,6 +57,8 @@
    - `warning` Identify risks (NOT "Find anomalies")
    - `lightbulb` Suggest actions
 7. Navigate to **Overview**, click sparkle. Verify the same 3 generic options as Domain Activity.
+8. Navigate to **Portfolio**, click sparkle. Verify menu shows the same 3 generic options (`bar_chart` Summarize trends, `search` Find anomalies, `lightbulb` Suggest actions).
+9. Navigate to **Pricing**, click sparkle. Verify the same 3 generic options.
 
 ### Expected:
 - Each page has 3 prompt options.
@@ -275,3 +281,111 @@
 - Each page's analysis uses that page's chart data.
 - No stale data from previous pages appears in analysis.
 - Model preference persists across all navigations.
+
+---
+
+## Test 13: Portfolio Page Analysis
+
+**Goal:** Verify AI analysis works on registrar portfolio data (Tier 2).
+
+### Steps:
+1. Navigate to **Portfolio** (`/#/registry-dash/portfolio`).
+2. Confirm the registrar table renders with at least one row (state, domain count, allowed TLDs).
+3. Click the sparkle button → "Summarize trends".
+4. Verify modal title is "Summarize trends — Portfolio".
+5. Wait for the response. Verify it discusses portfolio composition (registrar concentration, top registrars, TLD spread, total registrar count).
+6. Close the modal. Click sparkle → "Find anomalies".
+7. Verify the response discusses outlier registrars or unusual TLD allocations.
+
+### Expected:
+- Analysis references concrete registrar names and domain counts visible in the table.
+- "Summarize trends" and "Find anomalies" produce different content (no recycled response).
+- Modal renders and streams identically to other pages.
+
+---
+
+## Test 14: Pricing Page Analysis
+
+**Goal:** Verify AI analysis works on pricing data (Tier 2).
+
+### Steps:
+1. Navigate to **Pricing** (`/#/registry-dash/pricing`).
+2. Confirm the pricing rules table renders with at least one row.
+3. Click the sparkle button → "Summarize trends".
+4. Verify modal title is "Summarize trends — Pricing".
+5. Wait for the response. Verify it discusses the pricing landscape (premium spread, registrar discount distribution, TLD comparisons).
+6. Close the modal. Click sparkle → "Suggest actions".
+7. Verify the response provides pricing recommendations referencing actual registrar/TLD data.
+
+### Expected:
+- Analysis references concrete pricing values, registrar IDs, or TLD names from the table.
+- The "Add Rule" button still works and is not obscured by the sparkle icon.
+
+---
+
+## Test 15: Prompts Endpoint API Smoke
+
+**Goal:** Verify the new `GET /console-api/registry-dash/ai/prompts` endpoint serves per-page menus from backend YAML config.
+
+### Steps:
+1. From any dashboard page, open DevTools → Console.
+2. For each page (`portfolio`, `pricing`, `overview`, `domain-activity`, `revenue-billing`, `forecasting`, `explore`), run:
+   ```js
+   await fetch('/console-api/registry-dash/ai/prompts?page=portfolio', { credentials: 'include' }).then(r => r.json())
+   ```
+   (substituting the page name)
+3. Verify each response has shape `{ version: "v1", menu: [{promptType, label, icon, userMessage}, ...] }`.
+4. Verify `menu` length is 3 for every page.
+5. Verify `menu` items match the labels rendered in the UI menu (Test 2).
+6. Run the request with an unknown page and confirm 400:
+   ```js
+   await fetch('/console-api/registry-dash/ai/prompts?page=domains', { credentials: 'include' }).then(r => r.status)
+   ```
+7. Run the request with no page param and confirm 400:
+   ```js
+   await fetch('/console-api/registry-dash/ai/prompts', { credentials: 'include' }).then(r => r.status)
+   ```
+
+### Expected:
+- All 7 pages return 200 with a 3-item menu and `version: "v1"`.
+- Unknown / missing page returns 400.
+- The `userMessage` strings in the response match what gets sent when the user clicks a menu item (cross-check by triggering an analysis and inspecting the network request payload's `conversationHistory[0].content`).
+
+---
+
+## Test 16: Config-Driven System Prompt (advanced, local-dev only)
+
+**Goal:** Verify the backend system prompt is built from `default-config.yaml` `ai.prompts` instead of hardcoded Java strings.
+
+### Steps:
+1. With the local test server running, edit `core/src/main/java/google/registry/config/files/default-config.yaml` and change `ai.prompts.basePreamble` to a sentinel value, e.g. `"PREAMBLE_SMOKE_TEST"`.
+2. Restart the test server (the YAML is read at startup).
+3. From the dashboard, fire any analysis (e.g. Portfolio → "Summarize trends").
+4. In the test server log, find the line `AI analysis request: user=…, page=portfolio, …, promptVersion=v1, …`.
+5. Optionally enable FINE logging on the action class to dump the system prompt and confirm it begins with `PREAMBLE_SMOKE_TEST`.
+6. Revert the YAML change and restart.
+
+### Expected:
+- The log line includes `promptVersion=v1` (or whatever version is in the YAML).
+- The change in basePreamble influences the generated system prompt without rebuilding any Java.
+- After revert + restart, behavior returns to default.
+
+> Skip this test on alpha/sandbox unless you have ops access to edit deployed config and restart pods.
+
+---
+
+## Test 17: Cross-Page Navigation (Tier 2 update)
+
+**Goal:** Verify Portfolio + Pricing slot into the existing cross-page nav flow without regressions.
+
+### Steps:
+1. Run analysis on Portfolio → close modal.
+2. Navigate to Pricing → run analysis → close modal.
+3. Navigate to Overview → run analysis.
+4. Navigate back to Portfolio → run a new analysis.
+5. Verify each analysis references that page's data (registrar table for Portfolio, pricing rules for Pricing) and the model preference set in Test 5 still applies.
+
+### Expected:
+- All 7 pages now participate in the cross-page flow established by Test 12.
+- No data bleed between pages.
+- Model preference and conversation history are scoped per-modal (closing the modal clears history).

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -13,7 +13,14 @@
 // limitations under the License.
 
 export interface AiAnalyzeRequest {
-  page: 'domain-activity' | 'revenue-billing' | 'forecasting' | 'explore' | 'overview';
+  page:
+    | 'domain-activity'
+    | 'revenue-billing'
+    | 'forecasting'
+    | 'explore'
+    | 'overview'
+    | 'portfolio'
+    | 'pricing';
   promptType: string;
   metadata: {
     dateRange: { start: string; end: string };

--- a/console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed } from '@angular/core/testing';
+import { AiPromptsService } from './ai-prompts.service';
+
+describe('AiPromptsService', () => {
+  let service: AiPromptsService;
+  let fetchSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AiPromptsService);
+    fetchSpy = spyOn(window, 'fetch');
+  });
+
+  it('fetches and returns the menu for a page', async () => {
+    fetchSpy.and.resolveTo(
+      new Response(
+        JSON.stringify({
+          version: 'v1',
+          menu: [
+            {
+              promptType: 'summarize_trends',
+              label: 'Summarize trends',
+              icon: 'bar_chart',
+              userMessage: '...',
+            },
+          ],
+        }),
+      ),
+    );
+    const result = await service.getMenu('portfolio');
+    expect(result.version).toBe('v1');
+    expect(result.menu.length).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/console-api/registry-dash/ai/prompts?page=portfolio',
+      jasmine.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('caches results so the second call does not refetch', async () => {
+    fetchSpy.and.resolveTo(new Response(JSON.stringify({ version: 'v1', menu: [] })));
+    await service.getMenu('portfolio');
+    await service.getMenu('portfolio');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to FALLBACK_MENU on fetch error', async () => {
+    fetchSpy.and.resolveTo(new Response('boom', { status: 500 }));
+    const result = await service.getMenu('portfolio');
+    expect(result.version).toBe('fallback');
+    expect(result.menu.length).toBeGreaterThan(0);
+  });
+});

--- a/console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Injectable } from '@angular/core';
+import { AiPromptOption } from './ai-analysis.models';
+import { FALLBACK_MENU } from './ai-prompts';
+
+export interface AiPromptsResponse {
+  version: string;
+  menu: AiPromptOption[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class AiPromptsService {
+  private cache = new Map<string, AiPromptsResponse>();
+
+  async getMenu(page: string): Promise<AiPromptsResponse> {
+    const cached = this.cache.get(page);
+    if (cached) return cached;
+
+    try {
+      const res = await fetch(
+        `/console-api/registry-dash/ai/prompts?page=${encodeURIComponent(page)}`,
+        { credentials: 'include' },
+      );
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = (await res.json()) as AiPromptsResponse;
+      this.cache.set(page, data);
+      return data;
+    } catch {
+      return { version: 'fallback', menu: FALLBACK_MENU[page] ?? [] };
+    }
+  }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-prompts.ts
@@ -130,10 +130,64 @@ export const OVERVIEW_PROMPTS: AiPromptOption[] = [
   },
 ];
 
-export const PROMPTS_BY_PAGE: Record<string, AiPromptOption[]> = {
+export const PORTFOLIO_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize the registrar portfolio — concentration, growth among top registrars, TLD spread.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage:
+      'Identify portfolio anomalies — sudden concentration shifts, registrars with unusual TLD mix.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Based on this portfolio data, suggest registrar outreach or partnership opportunities.',
+  },
+];
+
+export const PRICING_PROMPTS: AiPromptOption[] = [
+  {
+    icon: 'bar_chart',
+    label: 'Summarize trends',
+    promptType: 'summarize_trends',
+    userMessage:
+      'Summarize the pricing landscape — premium spread, registrar discount distribution, TLD comparisons.',
+  },
+  {
+    icon: 'search',
+    label: 'Find anomalies',
+    promptType: 'find_anomalies',
+    userMessage:
+      'Identify pricing anomalies — outlier registrar fees, unusual premium gaps, mispriced TLDs.',
+  },
+  {
+    icon: 'lightbulb',
+    label: 'Suggest actions',
+    promptType: 'suggest_actions',
+    userMessage:
+      'Based on this pricing data, suggest pricing adjustments or registrar negotiations.',
+  },
+];
+
+/**
+ * Fallback prompt menu used only when the backend /ai/prompts endpoint is unreachable.
+ * The authoritative source of truth is `default-config.yaml` ai.prompts.menus.
+ */
+export const FALLBACK_MENU: Record<string, AiPromptOption[]> = {
   'domain-activity': DOMAIN_ACTIVITY_PROMPTS,
   'revenue-billing': REVENUE_BILLING_PROMPTS,
   forecasting: FORECASTING_PROMPTS,
   explore: EXPLORE_PROMPTS,
   overview: OVERVIEW_PROMPTS,
+  portfolio: PORTFOLIO_PROMPTS,
+  pricing: PRICING_PROMPTS,
 };

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
@@ -83,6 +83,10 @@ export class AiSparkleButtonComponent {
         return 'Data Exploration';
       case 'overview':
         return 'Overview';
+      case 'portfolio':
+        return 'Portfolio';
+      case 'pricing':
+        return 'Pricing';
     }
   }
 }

--- a/console-webapp/src/app/registry-dash/portfolio/portfolio.component.html
+++ b/console-webapp/src/app/registry-dash/portfolio/portfolio.component.html
@@ -9,7 +9,14 @@
     <div class="error-banner">{{ dashService.error() }}</div>
   }
 
-  <h2 class="mat-headline-6">Registrar Portfolio</h2>
+  <div class="portfolio-header-row">
+    <h2 class="mat-headline-6">Registrar Portfolio</h2>
+    <app-ai-sparkle-button
+      page="portfolio"
+      [prompts]="aiPrompts"
+      [chartData]="dashService.filteredPortfolio()">
+    </app-ai-sparkle-button>
+  </div>
   <p class="subtitle">All registrars accredited to operate under this registry, their status, domain counts, and authorized TLDs.</p>
 
   @if (dashService.filteredPortfolio().length > 0) {

--- a/console-webapp/src/app/registry-dash/portfolio/portfolio.component.scss
+++ b/console-webapp/src/app/registry-dash/portfolio/portfolio.component.scss
@@ -5,6 +5,12 @@
     @include ud.error-banner;
   }
 
+  .portfolio-header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   table {
     width: 100%;
   }

--- a/console-webapp/src/app/registry-dash/portfolio/portfolio.component.ts
+++ b/console-webapp/src/app/registry-dash/portfolio/portfolio.component.ts
@@ -17,10 +17,17 @@ import { MaterialModule } from '../../material.module';
 import { CommonModule } from '@angular/common';
 import { RegistryDashService } from '../registry-dash.service';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { PORTFOLIO_PROMPTS } from '../ai/ai-prompts';
 
 @Component({
   selector: 'app-registry-dash-portfolio',
-  imports: [MaterialModule, CommonModule, FilterPanelComponent],
+  imports: [
+    MaterialModule,
+    CommonModule,
+    FilterPanelComponent,
+    AiSparkleButtonComponent,
+  ],
   templateUrl: './portfolio.component.html',
   styleUrls: ['./portfolio.component.scss'],
 })
@@ -32,6 +39,8 @@ export class PortfolioComponent {
     'domainCount',
     'allowedTlds',
   ];
+
+  readonly aiPrompts = PORTFOLIO_PROMPTS;
 
   constructor(protected dashService: RegistryDashService) {
     this.dashService.getPortfolio().subscribe();

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.html
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.html
@@ -12,9 +12,16 @@
   <div class="pricing-header">
     <div class="pricing-header-row">
       <h2 class="mat-headline-6">Registrar Custom Pricing Rules</h2>
-      <button mat-raised-button color="primary" (click)="openAddForm()">
-        <mat-icon>add</mat-icon> Add Rule
-      </button>
+      <div class="pricing-header-actions">
+        <app-ai-sparkle-button
+          page="pricing"
+          [prompts]="aiPrompts"
+          [chartData]="filteredRules()">
+        </app-ai-sparkle-button>
+        <button mat-raised-button color="primary" (click)="openAddForm()">
+          <mat-icon>add</mat-icon> Add Rule
+        </button>
+      </div>
     </div>
     <p class="pricing-description">Custom pricing overrides for specific registrars. These rules take precedence over the Nomulus TLD default price. When a registrar has a pricing rule for a given TLD and operation, the custom price is charged instead of the Nomulus default. Hover over column headers for details.</p>
   </div>

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.scss
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.scss
@@ -12,6 +12,12 @@
       align-items: center;
     }
 
+    .pricing-header-actions {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
     h2 {
       margin: 0;
     }

--- a/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
+++ b/console-webapp/src/app/registry-dash/pricing/pricing.component.ts
@@ -23,14 +23,27 @@ import { SnackBarModule } from '../../snackbar.module';
 import { PricingRule, RegistryDashService, SystemRegistrar } from '../registry-dash.service';
 import { UserDataService } from '../../shared/services/userData.service';
 import { FilterPanelComponent } from '../filter-panel/filter-panel.component';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+import { PRICING_PROMPTS } from '../ai/ai-prompts';
 
 @Component({
   selector: 'app-registry-dash-pricing',
-  imports: [MaterialModule, CommonModule, ReactiveFormsModule, SnackBarModule, MatSortModule, FilterPanelComponent],
+  imports: [
+    MaterialModule,
+    CommonModule,
+    ReactiveFormsModule,
+    SnackBarModule,
+    MatSortModule,
+    FilterPanelComponent,
+    AiSparkleButtonComponent,
+  ],
   templateUrl: './pricing.component.html',
   styleUrls: ['./pricing.component.scss'],
 })
 export class PricingComponent implements AfterViewInit {
+
+  readonly aiPrompts = PRICING_PROMPTS;
+
   private static readonly MONEY_COLUMN_KEYS: Record<string, string> = {
     priceAmount: 'pricing.priceAmount',
     defaultPrice: 'pricing.defaultPrice',

--- a/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
+++ b/core/src/main/java/google/registry/ai/AiAnalyzeRequest.java
@@ -14,12 +14,19 @@
 
 package google.registry.ai;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import java.util.List;
 
 /** Request payload for the AI analysis endpoint. */
 public class AiAnalyzeRequest {
+
+  /** Pages allowed to invoke AI analysis. Add new pages here AND in default-config.yaml menus. */
+  public static final ImmutableSet<String> VALID_PAGES =
+      ImmutableSet.of(
+          "domain-activity", "revenue-billing", "forecasting",
+          "explore", "overview", "portfolio", "pricing");
 
   public String page;
   public String promptType;
@@ -36,13 +43,6 @@ public class AiAnalyzeRequest {
   }
 
   public boolean isValid() {
-    return page != null
-        && promptType != null
-        && chartData != null
-        && (page.equals("domain-activity")
-            || page.equals("revenue-billing")
-            || page.equals("forecasting")
-            || page.equals("explore")
-            || page.equals("overview"));
+    return page != null && promptType != null && chartData != null && VALID_PAGES.contains(page);
   }
 }

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1473,6 +1473,23 @@ public final class RegistryConfig {
       return config.ai != null ? config.ai.rateLimitPerHour : 120;
     }
 
+    @Provides
+    @Config("anthropicPromptConfig")
+    public static RegistryConfigSettings.Prompts provideAnthropicPromptConfig(
+        RegistryConfigSettings config) {
+      if (config.ai != null && config.ai.prompts != null) {
+        return config.ai.prompts;
+      }
+      RegistryConfigSettings.Prompts empty = new RegistryConfigSettings.Prompts();
+      empty.version = "unset";
+      empty.basePreamble = "";
+      empty.responseGuidance = "";
+      empty.promptTypes = ImmutableMap.of();
+      empty.pageHints = ImmutableMap.of();
+      empty.menus = ImmutableMap.of();
+      return empty;
+    }
+
     private static String formatComments(String text) {
       return Splitter.on('\n').omitEmptyStrings().trimResults().splitToList(text).stream()
           .map(s -> "# " + s)

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -264,6 +264,25 @@ public class RegistryConfigSettings {
     public String apiKeySecretName;
     public String defaultModel;
     public int rateLimitPerHour;
+    public Prompts prompts;
+  }
+
+  /** AI prompt content, loaded from default-config.yaml. */
+  public static class Prompts {
+    public String version;
+    public String basePreamble;
+    public String responseGuidance;
+    public Map<String, String> promptTypes;
+    public Map<String, String> pageHints;
+    public Map<String, List<MenuItem>> menus;
+  }
+
+  /** A single entry in a per-page sparkle menu. */
+  public static class MenuItem {
+    public String promptType;
+    public String label;
+    public String icon;
+    public String userMessage;
   }
 
   /** Configuration for Mosapi. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -648,3 +648,114 @@ ai:
   defaultModel: sonnet
   # Rate limit: max requests per user per hour
   rateLimitPerHour: 120
+  # Prompt content for the AI sparkle feature. Edit here to tweak prompts without redeploying
+  # frontend code. The version field is logged on every request for observability.
+  prompts:
+    version: "v1"
+    basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
+    responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
+    promptTypes:
+      summarize_trends: "Summarize the key trends in this data. Identify growth or decline patterns, compare across TLDs, and highlight the most significant changes."
+      find_anomalies: "Identify anomalies, outliers, and unusual patterns in this data. Look for unexpected spikes, drops, or ratios that warrant investigation."
+      suggest_actions: "Based on this data, suggest specific actionable recommendations. Focus on opportunities for growth, risk mitigation, and operational improvements."
+      identify_risks: "Identify risks in this data. Look for expiration cliffs, declining registrars, and patterns that could lead to revenue loss."
+    pageHints:
+      domain-activity: "You are looking at domain lifecycle activity (creates, transfers, renewals, deletes) across TLDs."
+      revenue-billing: "You are looking at billing revenue across TLDs and operations."
+      forecasting: "You are looking at renewal-rate forecasts and expiration curves."
+      overview: "You are looking at top-level registry health metrics."
+      explore: "You are looking at an ad-hoc data exploration result."
+      portfolio: "You are looking at registrar portfolio composition and concentration."
+      pricing: "You are looking at TLD pricing configuration and effective fees."
+    menus:
+      domain-activity:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize the key trends in domain activity — lifecycle patterns, growth or decline across TLDs."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify anomalies in domain activity — unexpected spikes, unusual create/delete ratios, outlier TLDs."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on this domain activity data, suggest specific actions for retention and growth."
+      revenue-billing:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize revenue trends — key drivers, growth percentages, TLD performance comparison."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify revenue anomalies — unexpected spikes or drops, declining segments, unusual patterns."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on this revenue data, suggest pricing adjustments, registrar outreach, or growth opportunities."
+      forecasting:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize renewal health — overall rates, TLD comparison, trajectory."
+        - promptType: identify_risks
+          label: "Identify risks"
+          icon: "warning"
+          userMessage: "Identify risks — expiration cliffs, declining registrars, TLDs with dropping renewal rates."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Suggest retention strategies, pricing recommendations, and proactive outreach based on this forecast data."
+      overview:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize the key trends across the registry — activity patterns, renewal health, and overall performance."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify any anomalies or concerns in the overview metrics."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on these overview metrics, what should the registry team focus on?"
+      explore:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize the key trends visible in this data."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify any anomalies or unusual patterns in this data."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on this data, what actions would you recommend?"
+      portfolio:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize the registrar portfolio — concentration, growth among top registrars, TLD spread."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify portfolio anomalies — sudden concentration shifts, registrars with unusual TLD mix."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on this portfolio data, suggest registrar outreach or partnership opportunities."
+      pricing:
+        - promptType: summarize_trends
+          label: "Summarize trends"
+          icon: "bar_chart"
+          userMessage: "Summarize the pricing landscape — premium spread, registrar discount distribution, TLD comparisons."
+        - promptType: find_anomalies
+          label: "Find anomalies"
+          icon: "search"
+          userMessage: "Identify pricing anomalies — outlier registrar fees, unusual premium gaps, mispriced TLDs."
+        - promptType: suggest_actions
+          label: "Suggest actions"
+          icon: "lightbulb"
+          userMessage: "Based on this pricing data, suggest pricing adjustments or registrar negotiations."

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -132,6 +132,7 @@ import google.registry.ui.server.console.RegistrarsAction;
 import google.registry.ui.server.console.domains.ConsoleBulkDomainAction;
 import google.registry.ui.server.console.registrydash.RegistryDashAdminAction;
 import google.registry.ui.server.console.registrydash.RegistryDashAiAction;
+import google.registry.ui.server.console.registrydash.RegistryDashAiPromptsAction;
 import google.registry.ui.server.console.registrydash.RegistryDashExploreAction;
 import google.registry.ui.server.console.registrydash.RegistryDashCostBasisAction;
 import google.registry.ui.server.console.registrydash.RegistryDashDomainActivityAction;
@@ -352,6 +353,8 @@ interface RequestComponent {
   RegistryDashSettingsAction registryDashSettingsAction();
 
   RegistryDashAiAction registryDashAiAction();
+
+  RegistryDashAiPromptsAction registryDashAiPromptsAction();
 
   UDRegistryDashTldFeesAction udRegistryDashTldFeesAction();
 

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
@@ -461,4 +461,10 @@ public final class ConsoleModule {
       @OptionalJsonPayload Optional<JsonElement> payload) {
     return payload;
   }
+
+  @Provides
+  @Parameter("page")
+  static Optional<String> providePage(HttpServletRequest req) {
+    return extractOptionalParameter(req, "page");
+  }
 }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -24,6 +24,8 @@ import com.google.gson.JsonObject;
 import google.registry.ai.AiAnalyzeRequest;
 import google.registry.ai.AiRateLimiter;
 import google.registry.ai.AnthropicClient;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryConfigSettings;
 import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.GlobalRole;
 import google.registry.model.console.User;
@@ -56,18 +58,21 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   private final AnthropicClient anthropicClient;
   private final AiRateLimiter rateLimiter;
   private final Gson gson;
+  private final RegistryConfigSettings.Prompts promptConfig;
 
   @Inject
   public RegistryDashAiAction(
       ConsoleApiParams consoleApiParams,
       @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
       AnthropicClient anthropicClient,
-      AiRateLimiter rateLimiter) {
+      AiRateLimiter rateLimiter,
+      @Config("anthropicPromptConfig") RegistryConfigSettings.Prompts promptConfig) {
     super(consoleApiParams);
     this.payload = payload;
     this.anthropicClient = anthropicClient;
     this.rateLimiter = rateLimiter;
     this.gson = consoleApiParams.gson();
+    this.promptConfig = promptConfig;
   }
 
   @Override
@@ -102,8 +107,10 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     String resolvedModel = AnthropicClient.resolveModelId(model != null ? model : "sonnet");
 
     logger.atInfo().log(
-        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s, historySize=%d",
+        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s,"
+            + " promptVersion=%s, historySize=%d",
         userEmail, request.page, request.promptType, resolvedModel,
+        promptConfig.version,
         request.conversationHistory != null ? request.conversationHistory.size() : 0);
 
     try {
@@ -151,31 +158,17 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   private String getDefaultSystemPrompt(
       String page, String promptType, JsonElement chartData, JsonObject metadata) {
     StringBuilder sb = new StringBuilder();
-    sb.append("You are an expert domain registry analyst. ");
-    sb.append("You are analyzing data from the ").append(page)
-        .append(" page of a domain registry dashboard.\n\n");
+    sb.append(promptConfig.basePreamble).append("\n\n");
 
     sb.append("## Analysis Type\n");
-    switch (promptType) {
-      case "summarize_trends":
-        sb.append("Summarize the key trends in this data. Identify growth or decline patterns, ");
-        sb.append("compare across TLDs, and highlight the most significant changes.\n");
-        break;
-      case "find_anomalies":
-        sb.append("Identify anomalies, outliers, and unusual patterns in this data. ");
-        sb.append("Look for unexpected spikes, drops, or ratios that warrant investigation.\n");
-        break;
-      case "suggest_actions":
-        sb.append("Based on this data, suggest specific actionable recommendations. ");
-        sb.append("Focus on opportunities for growth, risk mitigation, and operational ");
-        sb.append("improvements.\n");
-        break;
-      case "identify_risks":
-        sb.append("Identify risks in this data. Look for expiration cliffs, declining ");
-        sb.append("registrars, and patterns that could lead to revenue loss.\n");
-        break;
-      default:
-        sb.append("Analyze this data and provide insights.\n");
+    sb.append(
+            promptConfig.promptTypes.getOrDefault(
+                promptType, "Analyze this data and provide insights."))
+        .append("\n");
+
+    String pageHint = promptConfig.pageHints.get(page);
+    if (pageHint != null && !pageHint.isEmpty()) {
+      sb.append("\n## Page\n").append(pageHint).append("\n");
     }
 
     sb.append("\n## Context\n");
@@ -188,9 +181,8 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       }
     }
 
-    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n");
-    sb.append("\nProvide your analysis in clear markdown. Use specific numbers from the data. ");
-    sb.append("Keep your response concise and actionable.");
+    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n\n");
+    sb.append(promptConfig.responseGuidance);
 
     return sb.toString();
   }

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java
@@ -1,0 +1,84 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import google.registry.ai.AiAnalyzeRequest;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryConfigSettings;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.User;
+import google.registry.request.Action;
+import google.registry.request.Action.Service;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.ui.server.console.ConsoleApiAction;
+import google.registry.ui.server.console.ConsoleApiParams;
+import jakarta.inject.Inject;
+import java.util.Optional;
+
+/** Returns the active AI sparkle menu for a dashboard page, plus the prompt-config version. */
+@Action(
+    service = Service.CONSOLE,
+    path = RegistryDashAiPromptsAction.PATH,
+    method = Action.Method.GET,
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class RegistryDashAiPromptsAction extends ConsoleApiAction {
+
+  static final String PATH = "/console-api/registry-dash/ai/prompts";
+
+  private static final Gson PLAIN_GSON = new Gson();
+
+  private final Optional<String> page;
+  private final RegistryConfigSettings.Prompts promptConfig;
+
+  @Inject
+  public RegistryDashAiPromptsAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("page") Optional<String> page,
+      @Config("anthropicPromptConfig") RegistryConfigSettings.Prompts promptConfig) {
+    super(consoleApiParams);
+    this.page = page;
+    this.promptConfig = promptConfig;
+  }
+
+  @Override
+  protected void getHandler(User user) {
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_DASHBOARD_OVERVIEW)) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+    String pageName = page.orElse(null);
+    if (pageName == null || !AiAnalyzeRequest.VALID_PAGES.contains(pageName)) {
+      setFailedResponse("Invalid or missing page parameter", SC_BAD_REQUEST);
+      return;
+    }
+    if (promptConfig.menus == null || !promptConfig.menus.containsKey(pageName)) {
+      setFailedResponse("No prompt menu configured for page: " + pageName, SC_NOT_FOUND);
+      return;
+    }
+    JsonObject body = new JsonObject();
+    body.addProperty("version", promptConfig.version);
+    body.add("menu", PLAIN_GSON.toJsonTree(promptConfig.menus.get(pageName)));
+    consoleApiParams.response().setStatus(SC_OK);
+    consoleApiParams.response().setPayload(PLAIN_GSON.toJson(body));
+  }
+}

--- a/core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java
+++ b/core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java
@@ -1,0 +1,61 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+class AiAnalyzeRequestTest {
+
+  private static AiAnalyzeRequest validRequestForPage(String page) {
+    AiAnalyzeRequest req = new AiAnalyzeRequest();
+    req.page = page;
+    req.promptType = "summarize_trends";
+    req.chartData = new JsonObject();
+    return req;
+  }
+
+  @Test
+  void validPages_includesAllTier1AndTier2() {
+    assertThat(AiAnalyzeRequest.VALID_PAGES)
+        .containsExactly(
+            "domain-activity", "revenue-billing", "forecasting",
+            "explore", "overview", "portfolio", "pricing");
+  }
+
+  @Test
+  void isValid_acceptsPortfolio() {
+    assertThat(validRequestForPage("portfolio").isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_acceptsPricing() {
+    assertThat(validRequestForPage("pricing").isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_rejectsUnknownPage() {
+    assertThat(validRequestForPage("domains").isValid()).isFalse();
+  }
+
+  @Test
+  void isValid_rejectsNullPage() {
+    AiAnalyzeRequest req = validRequestForPage("portfolio");
+    req.page = null;
+    assertThat(req.isValid()).isFalse();
+  }
+}

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -19,10 +19,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.TestLogHandler;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import google.registry.ai.AiRateLimiter;
 import google.registry.ai.AnthropicClient;
+import google.registry.config.RegistryConfigSettings;
 import google.registry.model.console.User;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.request.auth.AuthResult;
@@ -33,6 +36,7 @@ import google.registry.testing.FakeResponse;
 import google.registry.ui.server.console.ConsoleApiParams;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.logging.Logger;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,7 +88,7 @@ class RegistryDashAiActionTest {
     }).when(anthropicClient).streamMessage(any(), any(), any(), any());
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter);
+        params, Optional.of(json), anthropicClient, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -97,7 +101,7 @@ class RegistryDashAiActionTest {
   @Test
   void testBadRequest_missingPayload() {
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.empty(), anthropicClient, rateLimiter);
+        params, Optional.empty(), anthropicClient, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
@@ -110,10 +114,58 @@ class RegistryDashAiActionTest {
     JsonElement json = JsonParser.parseString(payload);
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter);
+        params, Optional.of(json), anthropicClient, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  void testSystemPrompt_drawnFromConfig() throws Exception {
+    RegistryConfigSettings.Prompts promptConfig = new RegistryConfigSettings.Prompts();
+    promptConfig.version = "test-v1";
+    promptConfig.basePreamble = "PREAMBLE_FROM_TEST";
+    promptConfig.responseGuidance = "GUIDANCE_FROM_TEST";
+    promptConfig.promptTypes = ImmutableMap.of("summarize_trends", "BODY_FROM_TEST");
+    promptConfig.pageHints = ImmutableMap.of("portfolio", "HINT_FROM_TEST");
+    promptConfig.menus = ImmutableMap.of();
+
+    String captured = capturedSystemPrompt(promptConfig, "portfolio", "summarize_trends");
+
+    assertThat(captured).contains("PREAMBLE_FROM_TEST");
+    assertThat(captured).contains("BODY_FROM_TEST");
+    assertThat(captured).contains("HINT_FROM_TEST");
+    assertThat(captured).contains("GUIDANCE_FROM_TEST");
+  }
+
+  @Test
+  void testRequest_logsPromptVersion() throws Exception {
+    RegistryConfigSettings.Prompts p = defaultPromptConfig();
+    p.version = "logged-version-xyz";
+
+    TestLogHandler handler = new TestLogHandler();
+    Logger logger = Logger.getLogger(RegistryDashAiAction.class.getName());
+    logger.addHandler(handler);
+    try {
+      capturedSystemPrompt(p, "domain-activity", "summarize_trends");
+      boolean found =
+          handler.getStoredLogRecords().stream()
+              .anyMatch(
+                  r -> {
+                    if (r.getParameters() != null) {
+                      for (Object param : r.getParameters()) {
+                        if ("logged-version-xyz".equals(String.valueOf(param))) {
+                          return true;
+                        }
+                      }
+                    }
+                    return r.getMessage() != null
+                        && r.getMessage().contains("logged-version-xyz");
+                  });
+      assertThat(found).isTrue();
+    } finally {
+      logger.removeHandler(handler);
+    }
   }
 
   @Test
@@ -126,9 +178,46 @@ class RegistryDashAiActionTest {
     JsonElement json = JsonParser.parseString(payload);
 
     RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, strictLimiter);
+        params, Optional.of(json), anthropicClient, strictLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(429);
+  }
+
+  private RegistryConfigSettings.Prompts defaultPromptConfig() {
+    RegistryConfigSettings.Prompts p = new RegistryConfigSettings.Prompts();
+    p.version = "test-v1";
+    p.basePreamble = "You are an expert domain registry analyst.";
+    p.responseGuidance = "Be concise.";
+    p.promptTypes = ImmutableMap.of(
+        "summarize_trends", "Summarize trends.",
+        "find_anomalies", "Find anomalies.",
+        "suggest_actions", "Suggest actions.",
+        "identify_risks", "Identify risks.");
+    p.pageHints = ImmutableMap.of();
+    p.menus = ImmutableMap.of();
+    return p;
+  }
+
+  private String capturedSystemPrompt(
+      RegistryConfigSettings.Prompts promptConfig, String page, String promptType)
+      throws Exception {
+    String payload = String.format(
+        "{\"page\":\"%s\",\"promptType\":\"%s\",\"chartData\":{},\"conversationHistory\":[]}",
+        page, promptType);
+    JsonElement json = JsonParser.parseString(payload);
+
+    String[] capturedPrompt = new String[1];
+    doAnswer(invocation -> {
+      capturedPrompt[0] = invocation.getArgument(0);
+      Consumer<String> onChunk = invocation.getArgument(3);
+      onChunk.accept("ok");
+      return null;
+    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter, promptConfig);
+    action.run();
+    return capturedPrompt[0];
   }
 }

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java
@@ -1,0 +1,138 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import google.registry.config.RegistryConfigSettings;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.request.auth.AuthResult;
+import google.registry.testing.ConsoleApiParamsUtils;
+import google.registry.testing.DatabaseHelper;
+import google.registry.testing.FakeClock;
+import google.registry.testing.FakeResponse;
+import google.registry.ui.server.console.ConsoleApiParams;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/** Tests for {@link RegistryDashAiPromptsAction}. */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RegistryDashAiPromptsActionTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private ConsoleApiParams params;
+  private FakeResponse response;
+  private RegistryConfigSettings.Prompts promptConfig;
+
+  @BeforeEach
+  void setUp() {
+    User user = DatabaseHelper.createAdminUser("fte@test.com");
+    AuthResult authResult = AuthResult.createUser(user);
+    params = ConsoleApiParamsUtils.createFake(authResult);
+    response = (FakeResponse) params.response();
+    when(params.request().getMethod()).thenReturn("GET");
+
+    RegistryConfigSettings.MenuItem item = new RegistryConfigSettings.MenuItem();
+    item.promptType = "summarize_trends";
+    item.label = "Summarize trends";
+    item.icon = "bar_chart";
+    item.userMessage = "Summarize trends.";
+
+    promptConfig = new RegistryConfigSettings.Prompts();
+    promptConfig.version = "v1";
+    promptConfig.menus = ImmutableMap.of("portfolio", ImmutableList.of(item));
+    promptConfig.promptTypes = ImmutableMap.of();
+    promptConfig.pageHints = ImmutableMap.of();
+    promptConfig.basePreamble = "";
+    promptConfig.responseGuidance = "";
+  }
+
+  @Test
+  void testSuccess_returnsMenuForPage() {
+    new RegistryDashAiPromptsAction(params, Optional.of("portfolio"), promptConfig).run();
+
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    JsonObject body = JsonParser.parseString(response.getPayload()).getAsJsonObject();
+    assertThat(body.get("version").getAsString()).isEqualTo("v1");
+    assertThat(body.getAsJsonArray("menu")).hasSize(1);
+    assertThat(body.getAsJsonArray("menu").get(0).getAsJsonObject().get("label").getAsString())
+        .isEqualTo("Summarize trends");
+  }
+
+  @Test
+  void testFailure_unknownPage_returns400() {
+    new RegistryDashAiPromptsAction(params, Optional.of("domains"), promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void testFailure_missingPage_returns400() {
+    new RegistryDashAiPromptsAction(params, Optional.empty(), promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void testFailure_pageNotInMenu_returns404() {
+    new RegistryDashAiPromptsAction(params, Optional.of("pricing"), promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_NOT_FOUND);
+  }
+
+  @Test
+  void testFailure_noPermission_returns403() {
+    User noPermUser =
+        tm().transact(
+                () -> {
+                  User u =
+                      new User.Builder()
+                          .setEmailAddress("noperm@test.com")
+                          .setUserRoles(
+                              new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+                          .build();
+                  tm().put(u);
+                  return u;
+                });
+    ConsoleApiParams nopermParams =
+        ConsoleApiParamsUtils.createFake(AuthResult.createUser(noPermUser));
+    when(nopermParams.request().getMethod()).thenReturn("GET");
+    new RegistryDashAiPromptsAction(nopermParams, Optional.of("portfolio"), promptConfig).run();
+    assertThat(((FakeResponse) nopermParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
+  }
+}

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -82,6 +82,7 @@ CONSOLE  /console-api/registrar                             ConsoleUpdateRegistr
 CONSOLE  /console-api/registrars                            RegistrarsAction                               GET,POST            n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/admin                   RegistryDashAdminAction                        GET,POST            n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/ai/analyze              RegistryDashAiAction                           POST                n  USER PUBLIC
+CONSOLE  /console-api/registry-dash/ai/prompts              RegistryDashAiPromptsAction                    GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/cost-basis              RegistryDashCostBasisAction                    GET,POST,PUT        n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/domain-activity         RegistryDashDomainActivityAction               GET                 n  USER PUBLIC
 CONSOLE  /console-api/registry-dash/effective-fees          UDRegistryDashEffectiveFeesAction              GET                 n  USER PUBLIC

--- a/docs/superpowers/plans/2026-04-29-registry-dash-ai-tier2.md
+++ b/docs/superpowers/plans/2026-04-29-registry-dash-ai-tier2.md
@@ -1,0 +1,1234 @@
+# Registry Dashboard AI — Tier 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the AI sparkle button on Portfolio and Pricing pages, externalize prompt content from Java/TS into `default-config.yaml`, expose a new `GET /ai/prompts` endpoint backing the frontend menu, and log the active prompt version per request.
+
+**Architecture:** Extend the existing `ai:` config block with a `prompts:` subsection (system-prompt fragments + per-page menus). Refactor `RegistryDashAiAction.getDefaultSystemPrompt` to consume injected config. Add a sibling `RegistryDashAiPromptsAction` for `GET /ai/prompts`. Frontend gains an `AiPromptsService` that fetches and caches the menu per page; `ai-prompts.ts` becomes a fallback-only export.
+
+**Tech Stack:** Java 21, Dagger 2, Jakarta Servlets, Angular 17+ (signals, standalone components), Angular Material, JUnit 5 + Mockito + Truth.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-registry-dash-ai-tier2-design.md`
+
+---
+
+## File Map
+
+### Backend — New Files
+| File | Responsibility |
+|------|---------------|
+| `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java` | GET action returning `{version, menu}` for a page |
+| `core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java` | Unit tests for `VALID_PAGES` allowlist |
+| `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java` | Unit tests for the new action |
+
+### Backend — Modified Files
+| File | Change |
+|------|--------|
+| `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java` | Extract `VALID_PAGES` constant; add `portfolio`, `pricing` |
+| `core/src/main/java/google/registry/config/RegistryConfigSettings.java` | Add nested `Prompts`, `MenuItem` classes on `Ai` |
+| `core/src/main/java/google/registry/config/files/default-config.yaml` | Extend `ai:` with `prompts:` block |
+| `core/src/main/java/google/registry/config/RegistryConfig.java` | Add `@Config("anthropicPromptConfig")` provider |
+| `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java` | Refactor `getDefaultSystemPrompt`; inject `Prompts`; log `promptVersion` |
+| `core/src/main/java/google/registry/module/RequestComponent.java` | Bind `RegistryDashAiPromptsAction` route |
+| `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java` | Cover config-driven prompts; cover `portfolio`, `pricing` |
+| `core/src/test/resources/google/registry/module/routing.txt` | Regenerate (auto, after action added) |
+
+### Frontend — New Files
+| File | Responsibility |
+|------|---------------|
+| `console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts` | Fetch + cache prompts menu per page |
+| `console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts` | Service tests |
+
+### Frontend — Modified Files
+| File | Change |
+|------|--------|
+| `console-webapp/src/app/registry-dash/ai/ai-prompts.ts` | Convert exports into `FALLBACK_MENU` map only |
+| `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts` | Replace `PROMPTS_BY_PAGE[page]` with `aiPromptsService.getMenu(page)` |
+| `console-webapp/src/app/registry-dash/portfolio/portfolio.component.html` | Add `<app-ai-sparkle-button page="portfolio">` |
+| `console-webapp/src/app/registry-dash/pricing/pricing.component.html` | Add `<app-ai-sparkle-button page="pricing">` |
+
+---
+
+## Task 1: Extend the page allowlist
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java:38-47`
+- Test: `core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java`:
+
+```java
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+package google.registry.ai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+class AiAnalyzeRequestTest {
+
+  private static AiAnalyzeRequest validRequestForPage(String page) {
+    AiAnalyzeRequest req = new AiAnalyzeRequest();
+    req.page = page;
+    req.promptType = "summarize_trends";
+    req.chartData = new JsonObject();
+    return req;
+  }
+
+  @Test
+  void validPages_includesAllTier1AndTier2() {
+    assertThat(AiAnalyzeRequest.VALID_PAGES)
+        .containsExactly(
+            "domain-activity", "revenue-billing", "forecasting",
+            "explore", "overview", "portfolio", "pricing");
+  }
+
+  @Test
+  void isValid_acceptsPortfolio() {
+    assertThat(validRequestForPage("portfolio").isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_acceptsPricing() {
+    assertThat(validRequestForPage("pricing").isValid()).isTrue();
+  }
+
+  @Test
+  void isValid_rejectsUnknownPage() {
+    assertThat(validRequestForPage("domains").isValid()).isFalse();
+  }
+
+  @Test
+  void isValid_rejectsNullPage() {
+    AiAnalyzeRequest req = validRequestForPage("portfolio");
+    req.page = null;
+    assertThat(req.isValid()).isFalse();
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+./nom_build :core:test --tests google.registry.ai.AiAnalyzeRequestTest
+```
+
+Expected: FAIL — `AiAnalyzeRequest.VALID_PAGES` does not exist.
+
+- [ ] **Step 3: Edit `AiAnalyzeRequest.java` to introduce `VALID_PAGES`**
+
+Replace the body of `AiAnalyzeRequest.java` (lines 17-48) so the file reads:
+
+```java
+package google.registry.ai;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.List;
+
+/** Request payload for the AI analysis endpoint. */
+public class AiAnalyzeRequest {
+
+  /** Pages allowed to invoke AI analysis. Add new pages here AND in default-config.yaml menus. */
+  public static final ImmutableSet<String> VALID_PAGES =
+      ImmutableSet.of(
+          "domain-activity", "revenue-billing", "forecasting",
+          "explore", "overview", "portfolio", "pricing");
+
+  public String page;
+  public String promptType;
+  public JsonObject metadata;
+  public JsonElement chartData;
+  public String model;
+  public String systemPrompt;
+  public List<ConversationMessage> conversationHistory;
+
+  /** A single message in the conversation history. */
+  public static class ConversationMessage {
+    public String role;
+    public String content;
+  }
+
+  public boolean isValid() {
+    return page != null && promptType != null && chartData != null && VALID_PAGES.contains(page);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+./nom_build :core:test --tests google.registry.ai.AiAnalyzeRequestTest
+```
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ai/AiAnalyzeRequest.java \
+        core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java
+git commit -m "feat(registry-dash): allow portfolio and pricing pages for AI analyze"
+```
+
+---
+
+## Task 2: Sparkle button on Portfolio
+
+**Files:**
+- Modify: `console-webapp/src/app/registry-dash/portfolio/portfolio.component.html`
+- Modify: `console-webapp/src/app/registry-dash/portfolio/portfolio.component.ts` (imports if needed)
+
+- [ ] **Step 1: Open the reference template**
+
+Read `console-webapp/src/app/registry-dash/overview/overview.component.html`. Locate the `<app-ai-sparkle-button>` element and the surrounding header markup. Note its `page` attribute and any container/styling.
+
+- [ ] **Step 2: Add sparkle to portfolio template**
+
+Open `console-webapp/src/app/registry-dash/portfolio/portfolio.component.html`. Find the page header row (the heading element near the top). Add `<app-ai-sparkle-button page="portfolio"></app-ai-sparkle-button>` adjacent to the heading, mirroring the placement style used in `overview.component.html`.
+
+- [ ] **Step 3: Wire imports if standalone**
+
+Open `portfolio.component.ts`. If it is standalone, add `AiSparkleButtonComponent` to the `imports` array. Confirm the import statement: `import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';`.
+
+If `portfolio.component.ts` is not standalone, locate the parent module and add the component to its `imports` array.
+
+- [ ] **Step 4: Build the frontend**
+
+```
+cd console-webapp && npm run build
+```
+
+Expected: build succeeds, no Angular template errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/portfolio/
+git commit -m "feat(registry-dash): add AI sparkle button to Portfolio page"
+```
+
+---
+
+## Task 3: Sparkle button on Pricing
+
+**Files:**
+- Modify: `console-webapp/src/app/registry-dash/pricing/pricing.component.html`
+- Modify: `console-webapp/src/app/registry-dash/pricing/pricing.component.ts` (imports if needed)
+
+- [ ] **Step 1: Add sparkle to pricing template**
+
+Open `console-webapp/src/app/registry-dash/pricing/pricing.component.html`. Add `<app-ai-sparkle-button page="pricing"></app-ai-sparkle-button>` in the header row, mirroring the Portfolio placement from Task 2.
+
+- [ ] **Step 2: Wire imports**
+
+Open `pricing.component.ts`. Add `AiSparkleButtonComponent` to the `imports` array (or to the parent module's `imports`).
+
+- [ ] **Step 3: Build the frontend**
+
+```
+cd console-webapp && npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/pricing/
+git commit -m "feat(registry-dash): add AI sparkle button to Pricing page"
+```
+
+---
+
+## Task 4: Audit existing Overview + Explore wiring
+
+**Files (read-only verification):**
+- `console-webapp/src/app/registry-dash/overview/overview.component.html`
+- `console-webapp/src/app/registry-dash/explore/explore.component.html`
+
+- [ ] **Step 1: Confirm `[page]` values match `PROMPTS_BY_PAGE` keys**
+
+Open each file. Note the value of the `page` attribute on `<app-ai-sparkle-button>`. Open `console-webapp/src/app/registry-dash/ai/ai-prompts.ts` and confirm each value is a key in `PROMPTS_BY_PAGE`.
+
+Expected: Overview uses `page="overview"`, Explore uses `page="explore"`. Both keys exist in `PROMPTS_BY_PAGE`.
+
+If any mismatch is found, file-level fix it inline (rename the page literal or add a missing menu) before continuing.
+
+- [ ] **Step 2: Verify in local dev**
+
+Start the local test server (see `MEMORY.md → reference_local_dev_setup.md`). Log in, navigate to Overview and Explore. Click each sparkle button and confirm a 3-item menu (`Summarize trends`, `Find anomalies`, `Suggest actions`) opens.
+
+- [ ] **Step 3: Commit (if any fix was needed)**
+
+```bash
+git commit -m "fix(registry-dash): align Overview/Explore sparkle page identifiers"
+```
+
+If no fix was needed, no commit; just record the audit result.
+
+---
+
+## Task 5: `RegistryConfigSettings.Ai.Prompts` POJO
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/config/RegistryConfigSettings.java:262-267`
+
+- [ ] **Step 1: Add the nested `Prompts` and `MenuItem` classes**
+
+In `RegistryConfigSettings.java`, replace the existing `Ai` class (line 262) with:
+
+```java
+  /** Configuration for AI (Anthropic) integration. */
+  public static class Ai {
+    public String apiBaseUrl;
+    public String apiKeySecretName;
+    public String defaultModel;
+    public int rateLimitPerHour;
+    public Prompts prompts;
+  }
+
+  /** AI prompt content, loaded from default-config.yaml. */
+  public static class Prompts {
+    public String version;
+    public String basePreamble;
+    public String responseGuidance;
+    public Map<String, String> promptTypes;
+    public Map<String, String> pageHints;
+    public Map<String, List<MenuItem>> menus;
+  }
+
+  /** A single entry in a per-page sparkle menu. */
+  public static class MenuItem {
+    public String promptType;
+    public String label;
+    public String icon;
+    public String userMessage;
+  }
+```
+
+Add imports if missing: `import java.util.List;`, `import java.util.Map;`.
+
+- [ ] **Step 2: Build the project**
+
+```
+./nom_build :core:compileJava
+```
+
+Expected: compiles cleanly. The new classes are unused at this point — that's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/src/main/java/google/registry/config/RegistryConfigSettings.java
+git commit -m "feat(registry-dash): add Prompts/MenuItem config POJO for AI"
+```
+
+---
+
+## Task 6: `prompts:` block in `default-config.yaml`
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/config/files/default-config.yaml:642-651`
+
+- [ ] **Step 1: Append `prompts:` after the existing `ai:` fields**
+
+Below the existing `rateLimitPerHour: 120` line, add:
+
+```yaml
+  prompts:
+    version: "v1"
+    basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
+    responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
+    promptTypes:
+      summarize_trends: "Summarize the key trends in this data. Identify growth or decline patterns, compare across TLDs, and highlight the most significant changes."
+      find_anomalies: "Identify anomalies, outliers, and unusual patterns in this data. Look for unexpected spikes, drops, or ratios that warrant investigation."
+      suggest_actions: "Based on this data, suggest specific actionable recommendations. Focus on opportunities for growth, risk mitigation, and operational improvements."
+      identify_risks: "Identify risks in this data. Look for expiration cliffs, declining registrars, and patterns that could lead to revenue loss."
+    pageHints:
+      domain-activity: "You are looking at domain lifecycle activity (creates, transfers, renewals, deletes) across TLDs."
+      revenue-billing: "You are looking at billing revenue across TLDs and operations."
+      forecasting: "You are looking at renewal-rate forecasts and expiration curves."
+      overview: "You are looking at top-level registry health metrics."
+      explore: "You are looking at an ad-hoc data exploration result."
+      portfolio: "You are looking at registrar portfolio composition and concentration."
+      pricing: "You are looking at TLD pricing configuration and effective fees."
+    menus:
+      domain-activity:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize the key trends in domain activity — lifecycle patterns, growth or decline across TLDs." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify anomalies in domain activity — unexpected spikes, unusual create/delete ratios, outlier TLDs." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on this domain activity data, suggest specific actions for retention and growth." }
+      revenue-billing:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize revenue trends — key drivers, growth percentages, TLD performance comparison." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify revenue anomalies — unexpected spikes or drops, declining segments, unusual patterns." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on this revenue data, suggest pricing adjustments, registrar outreach, or growth opportunities." }
+      forecasting:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize renewal health — overall rates, TLD comparison, trajectory." }
+        - { promptType: identify_risks, label: "Identify risks", icon: "warning",
+            userMessage: "Identify risks — expiration cliffs, declining registrars, TLDs with dropping renewal rates." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Suggest retention strategies, pricing recommendations, and proactive outreach based on this forecast data." }
+      overview:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize the key trends across the registry — activity patterns, renewal health, and overall performance." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify any anomalies or concerns in the overview metrics." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on these overview metrics, what should the registry team focus on?" }
+      explore:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize the key trends visible in this data." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify any anomalies or unusual patterns in this data." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on this data, what actions would you recommend?" }
+      portfolio:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize the registrar portfolio — concentration, growth among top registrars, TLD spread." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify portfolio anomalies — sudden concentration shifts, registrars with unusual TLD mix." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on this portfolio data, suggest registrar outreach or partnership opportunities." }
+      pricing:
+        - { promptType: summarize_trends, label: "Summarize trends", icon: "bar_chart",
+            userMessage: "Summarize the pricing landscape — premium spread, registrar discount distribution, TLD comparisons." }
+        - { promptType: find_anomalies, label: "Find anomalies", icon: "search",
+            userMessage: "Identify pricing anomalies — outlier registrar fees, unusual premium gaps, mispriced TLDs." }
+        - { promptType: suggest_actions, label: "Suggest actions", icon: "lightbulb",
+            userMessage: "Based on this pricing data, suggest pricing adjustments or registrar negotiations." }
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+```
+./nom_build :core:compileJava :core:processResources
+```
+
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/src/main/java/google/registry/config/files/default-config.yaml
+git commit -m "feat(registry-dash): externalize AI prompt content to default-config.yaml"
+```
+
+---
+
+## Task 7: `@Config("anthropicPromptConfig")` provider
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/config/RegistryConfig.java`
+
+- [ ] **Step 1: Locate the existing AI providers**
+
+Open `RegistryConfig.java`. Find the existing `@Config("anthropicApiBaseUrl")` provider (around line 1452 per the env-config plan). Note the pattern — `@Provides @Config(...) static <Type> name(RegistryConfigSettings cfg)`.
+
+- [ ] **Step 2: Add the prompts provider**
+
+Add immediately after the last AI-related provider:
+
+```java
+    @Provides
+    @Config("anthropicPromptConfig")
+    static RegistryConfigSettings.Prompts provideAnthropicPromptConfig(
+        RegistryConfigSettings config) {
+      // Defensive: tests and minimal configs may omit the prompts block.
+      if (config.ai != null && config.ai.prompts != null) {
+        return config.ai.prompts;
+      }
+      RegistryConfigSettings.Prompts empty = new RegistryConfigSettings.Prompts();
+      empty.version = "unset";
+      empty.basePreamble = "";
+      empty.responseGuidance = "";
+      empty.promptTypes = ImmutableMap.of();
+      empty.pageHints = ImmutableMap.of();
+      empty.menus = ImmutableMap.of();
+      return empty;
+    }
+```
+
+Add `import com.google.common.collect.ImmutableMap;` if not present.
+
+- [ ] **Step 3: Build**
+
+```
+./nom_build :core:compileJava
+```
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/src/main/java/google/registry/config/RegistryConfig.java
+git commit -m "feat(registry-dash): add @Config provider for AI prompt config"
+```
+
+---
+
+## Task 8: Refactor `getDefaultSystemPrompt` to use config (TDD)
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java`
+- Modify: `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+In `RegistryDashAiActionTest.java`, add (within the existing test class):
+
+```java
+  @Test
+  void testSystemPrompt_drawnFromConfig() throws Exception {
+    RegistryConfigSettings.Prompts promptConfig = new RegistryConfigSettings.Prompts();
+    promptConfig.version = "test-v1";
+    promptConfig.basePreamble = "PREAMBLE_FROM_TEST";
+    promptConfig.responseGuidance = "GUIDANCE_FROM_TEST";
+    promptConfig.promptTypes = ImmutableMap.of("summarize_trends", "BODY_FROM_TEST");
+    promptConfig.pageHints = ImmutableMap.of("portfolio", "HINT_FROM_TEST");
+    promptConfig.menus = ImmutableMap.of();
+
+    String captured = capturedSystemPrompt(promptConfig, "portfolio", "summarize_trends");
+
+    assertThat(captured).contains("PREAMBLE_FROM_TEST");
+    assertThat(captured).contains("BODY_FROM_TEST");
+    assertThat(captured).contains("HINT_FROM_TEST");
+    assertThat(captured).contains("GUIDANCE_FROM_TEST");
+  }
+```
+
+Add a helper at the bottom of the test class:
+
+```java
+  private String capturedSystemPrompt(
+      RegistryConfigSettings.Prompts promptConfig, String page, String promptType)
+      throws Exception {
+    String payload = String.format(
+        "{\"page\":\"%s\",\"promptType\":\"%s\",\"chartData\":{},\"conversationHistory\":[]}",
+        page, promptType);
+    JsonElement json = JsonParser.parseString(payload);
+
+    String[] capturedPrompt = new String[1];
+    doAnswer(invocation -> {
+      capturedPrompt[0] = invocation.getArgument(0);
+      Consumer<String> onChunk = invocation.getArgument(3);
+      onChunk.accept("ok");
+      return null;
+    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+
+    RegistryDashAiAction action = new RegistryDashAiAction(
+        params, Optional.of(json), anthropicClient, rateLimiter, promptConfig);
+    action.run();
+    return capturedPrompt[0];
+  }
+```
+
+Add imports as needed: `com.google.common.collect.ImmutableMap`, `google.registry.config.RegistryConfigSettings`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiActionTest.testSystemPrompt_drawnFromConfig
+```
+
+Expected: FAIL — constructor signature does not yet take `Prompts`, and prompt is built from hardcoded strings.
+
+- [ ] **Step 3: Refactor `RegistryDashAiAction`**
+
+Change the constructor and field set in `RegistryDashAiAction.java`:
+
+```java
+  private final Optional<JsonElement> payload;
+  private final AnthropicClient anthropicClient;
+  private final AiRateLimiter rateLimiter;
+  private final Gson gson;
+  private final RegistryConfigSettings.Prompts promptConfig;
+
+  @Inject
+  public RegistryDashAiAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
+      AnthropicClient anthropicClient,
+      AiRateLimiter rateLimiter,
+      @Config("anthropicPromptConfig") RegistryConfigSettings.Prompts promptConfig) {
+    super(consoleApiParams);
+    this.payload = payload;
+    this.anthropicClient = anthropicClient;
+    this.rateLimiter = rateLimiter;
+    this.gson = consoleApiParams.gson();
+    this.promptConfig = promptConfig;
+  }
+```
+
+Replace the body of `getDefaultSystemPrompt(...)` (lines 151-196) with:
+
+```java
+  private String getDefaultSystemPrompt(
+      String page, String promptType, JsonElement chartData, JsonObject metadata) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(promptConfig.basePreamble).append("\n\n");
+
+    sb.append("## Analysis Type\n");
+    sb.append(
+        promptConfig.promptTypes.getOrDefault(
+            promptType, "Analyze this data and provide insights."))
+        .append("\n");
+
+    String pageHint = promptConfig.pageHints.get(page);
+    if (pageHint != null && !pageHint.isEmpty()) {
+      sb.append("\n## Page\n").append(pageHint).append("\n");
+    }
+
+    sb.append("\n## Context\n");
+    if (metadata != null) {
+      if (metadata.has("dateRange")) {
+        sb.append("Date range: ").append(metadata.get("dateRange")).append("\n");
+      }
+      if (metadata.has("filteredTlds") && metadata.getAsJsonArray("filteredTlds").size() > 0) {
+        sb.append("Filtered to TLDs: ").append(metadata.get("filteredTlds")).append("\n");
+      }
+    }
+
+    sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n\n");
+    sb.append(promptConfig.responseGuidance);
+
+    return sb.toString();
+  }
+```
+
+Add imports: `import google.registry.config.RegistryConfig.Config;`, `import google.registry.config.RegistryConfigSettings;`.
+
+- [ ] **Step 4: Update existing test setUp**
+
+In `RegistryDashAiActionTest.setUp()`, build a default `Prompts` instance and pass it through the constructor anywhere `new RegistryDashAiAction(...)` is invoked. Pattern:
+
+```java
+  private RegistryConfigSettings.Prompts defaultPromptConfig() {
+    RegistryConfigSettings.Prompts p = new RegistryConfigSettings.Prompts();
+    p.version = "test-v1";
+    p.basePreamble = "You are an expert domain registry analyst.";
+    p.responseGuidance = "Be concise.";
+    p.promptTypes = ImmutableMap.of(
+        "summarize_trends", "Summarize trends.",
+        "find_anomalies", "Find anomalies.",
+        "suggest_actions", "Suggest actions.",
+        "identify_risks", "Identify risks.");
+    p.pageHints = ImmutableMap.of();
+    p.menus = ImmutableMap.of();
+    return p;
+  }
+```
+
+Update each existing constructor invocation to pass `defaultPromptConfig()` as the 5th argument.
+
+- [ ] **Step 5: Run all `RegistryDashAiActionTest`s**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiActionTest
+```
+
+Expected: all PASS, including the new `testSystemPrompt_drawnFromConfig`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java \
+        core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+git commit -m "refactor(registry-dash): build AI system prompt from injected config"
+```
+
+---
+
+## Task 9: Log `promptVersion` per request (TDD)
+
+**Files:**
+- Modify: `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java:104-107`
+- Modify: `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `RegistryDashAiActionTest`:
+
+```java
+  @Test
+  void testRequest_logsPromptVersion() throws Exception {
+    RegistryConfigSettings.Prompts p = defaultPromptConfig();
+    p.version = "logged-version-xyz";
+
+    TestLogHandler handler = new TestLogHandler();
+    Logger logger = Logger.getLogger(RegistryDashAiAction.class.getName());
+    logger.addHandler(handler);
+
+    capturedSystemPrompt(p, "domain-activity", "summarize_trends");
+
+    assertThat(
+        handler.getStoredLogRecords().stream()
+            .map(LogRecord::getMessage)
+            .anyMatch(m -> m.contains("promptVersion=logged-version-xyz")))
+        .isTrue();
+  }
+```
+
+Add imports: `com.google.common.testing.TestLogHandler`, `java.util.logging.LogRecord`, `java.util.logging.Logger`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiActionTest.testRequest_logsPromptVersion
+```
+
+Expected: FAIL — log line does not include `promptVersion=`.
+
+- [ ] **Step 3: Update the log call**
+
+In `RegistryDashAiAction.java` around line 104, replace:
+
+```java
+    logger.atInfo().log(
+        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s, historySize=%d",
+        userEmail, request.page, request.promptType, resolvedModel,
+        request.conversationHistory != null ? request.conversationHistory.size() : 0);
+```
+
+with:
+
+```java
+    logger.atInfo().log(
+        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s,"
+            + " promptVersion=%s, historySize=%d",
+        userEmail, request.page, request.promptType, resolvedModel,
+        promptConfig.version,
+        request.conversationHistory != null ? request.conversationHistory.size() : 0);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiActionTest
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java \
+        core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+git commit -m "feat(registry-dash): log promptVersion on AI analysis requests"
+```
+
+---
+
+## Task 10: New `RegistryDashAiPromptsAction` (TDD)
+
+**Files:**
+- Create: `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java`
+- Create: `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `RegistryDashAiPromptsActionTest.java`:
+
+```java
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+package google.registry.ui.server.console.registrydash;
+
+import static com.google.common.truth.Truth.assertThat;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import google.registry.config.RegistryConfigSettings;
+import google.registry.model.console.User;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.request.auth.AuthResult;
+import google.registry.testing.ConsoleApiParamsUtils;
+import google.registry.testing.DatabaseHelper;
+import google.registry.testing.FakeClock;
+import google.registry.testing.FakeResponse;
+import google.registry.ui.server.console.ConsoleApiParams;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RegistryDashAiPromptsActionTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-01-01T00:00:00Z"));
+
+  @org.junit.jupiter.api.extension.RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private ConsoleApiParams params;
+  private FakeResponse response;
+  private RegistryConfigSettings.Prompts promptConfig;
+
+  @BeforeEach
+  void setUp() {
+    User user = DatabaseHelper.createAdminUser("fte@test.com");
+    AuthResult authResult = AuthResult.createUser(user);
+    params = ConsoleApiParamsUtils.createFake(authResult);
+    response = (FakeResponse) params.response();
+    when(params.request().getMethod()).thenReturn("GET");
+
+    RegistryConfigSettings.MenuItem item = new RegistryConfigSettings.MenuItem();
+    item.promptType = "summarize_trends";
+    item.label = "Summarize trends";
+    item.icon = "bar_chart";
+    item.userMessage = "Summarize trends.";
+
+    promptConfig = new RegistryConfigSettings.Prompts();
+    promptConfig.version = "v1";
+    promptConfig.menus = ImmutableMap.of("portfolio", ImmutableList.of(item));
+    promptConfig.promptTypes = ImmutableMap.of();
+    promptConfig.pageHints = ImmutableMap.of();
+    promptConfig.basePreamble = "";
+    promptConfig.responseGuidance = "";
+  }
+
+  @Test
+  void testSuccess_returnsMenuForPage() {
+    new RegistryDashAiPromptsAction(params, "portfolio", promptConfig).run();
+
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    JsonObject body = JsonParser.parseString(response.getPayload()).getAsJsonObject();
+    assertThat(body.get("version").getAsString()).isEqualTo("v1");
+    assertThat(body.getAsJsonArray("menu")).hasSize(1);
+    assertThat(body.getAsJsonArray("menu").get(0).getAsJsonObject().get("label").getAsString())
+        .isEqualTo("Summarize trends");
+  }
+
+  @Test
+  void testFailure_unknownPage_returns400() {
+    new RegistryDashAiPromptsAction(params, "domains", promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void testFailure_missingPage_returns400() {
+    new RegistryDashAiPromptsAction(params, null, promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+  }
+
+  @Test
+  void testFailure_pageNotInMenu_returns404() {
+    new RegistryDashAiPromptsAction(params, "pricing", promptConfig).run();
+    assertThat(response.getStatus()).isEqualTo(SC_NOT_FOUND);
+  }
+
+  @Test
+  void testFailure_noPermission_returns403() {
+    User noPermUser = DatabaseHelper.createUser("noperm@test.com");
+    params = ConsoleApiParamsUtils.createFake(AuthResult.createUser(noPermUser));
+    when(params.request().getMethod()).thenReturn("GET");
+    new RegistryDashAiPromptsAction(params, "portfolio", promptConfig).run();
+    assertThat(((FakeResponse) params.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiPromptsActionTest
+```
+
+Expected: FAIL — `RegistryDashAiPromptsAction` does not exist.
+
+- [ ] **Step 3: Implement the action**
+
+Create `RegistryDashAiPromptsAction.java`:
+
+```java
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+package google.registry.ui.server.console.registrydash;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import google.registry.ai.AiAnalyzeRequest;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryConfigSettings;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.User;
+import google.registry.request.Action;
+import google.registry.request.Action.Service;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.ui.server.console.ConsoleApiAction;
+import google.registry.ui.server.console.ConsoleApiParams;
+import jakarta.inject.Inject;
+
+@Action(
+    service = Service.CONSOLE,
+    path = RegistryDashAiPromptsAction.PATH,
+    method = Action.Method.GET,
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class RegistryDashAiPromptsAction extends ConsoleApiAction {
+
+  static final String PATH = "/console-api/registry-dash/ai/prompts";
+
+  private static final Gson PLAIN_GSON = new Gson();
+
+  private final String page;
+  private final RegistryConfigSettings.Prompts promptConfig;
+
+  @Inject
+  public RegistryDashAiPromptsAction(
+      ConsoleApiParams consoleApiParams,
+      @Parameter("page") String page,
+      @Config("anthropicPromptConfig") RegistryConfigSettings.Prompts promptConfig) {
+    super(consoleApiParams);
+    this.page = page;
+    this.promptConfig = promptConfig;
+  }
+
+  @Override
+  protected void getHandler(User user) {
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_DASHBOARD_OVERVIEW)) {
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
+      return;
+    }
+    if (page == null || !AiAnalyzeRequest.VALID_PAGES.contains(page)) {
+      setFailedResponse("Invalid or missing page parameter", SC_BAD_REQUEST);
+      return;
+    }
+    if (promptConfig.menus == null || !promptConfig.menus.containsKey(page)) {
+      setFailedResponse("No prompt menu configured for page: " + page, SC_NOT_FOUND);
+      return;
+    }
+    JsonObject body = new JsonObject();
+    body.addProperty("version", promptConfig.version);
+    body.add("menu", PLAIN_GSON.toJsonTree(promptConfig.menus.get(page)));
+    consoleApiParams.response().setStatus(SC_OK);
+    consoleApiParams.response().setPayload(PLAIN_GSON.toJson(body));
+  }
+}
+```
+
+Remove the unused `ImmutableMap` import if your IDE flags it. Gson serializes `List<MenuItem>` via reflection, producing the array of `{promptType, label, icon, userMessage}` objects expected by the frontend.
+
+- [ ] **Step 4: Wire route in `RequestComponent`**
+
+Open `core/src/main/java/google/registry/module/RequestComponent.java`. Find where other registry-dash actions are bound (look for `RegistryDashAiAction`). Add a binding for `RegistryDashAiPromptsAction` next to it.
+
+- [ ] **Step 5: Add `@Parameter("page")` provider**
+
+Open `core/src/main/java/google/registry/ui/server/console/ConsoleModule.java`. Add a provider that extracts `page` from the request query string:
+
+```java
+    @Provides
+    @Parameter("page")
+    @Nullable
+    static String providePage(HttpServletRequest req) {
+      return req.getParameter("page");
+    }
+```
+
+(Skip this step if such a provider already exists — search before adding.)
+
+- [ ] **Step 6: Run all action tests**
+
+```
+./nom_build :core:test --tests google.registry.ui.server.console.registrydash.RegistryDashAiPromptsActionTest
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 7: Regenerate routing.txt**
+
+```
+./gradlew nomulus
+cd core && java -jar build/libs/nomulus.jar -e localhost get_routing_map -c google.registry.module.RequestComponent > src/test/resources/google/registry/module/routing.txt
+```
+
+Strip any jline warning lines from the top of the file.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java \
+        core/src/main/java/google/registry/module/RequestComponent.java \
+        core/src/main/java/google/registry/ui/server/console/ConsoleModule.java \
+        core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java \
+        core/src/test/resources/google/registry/module/routing.txt
+git commit -m "feat(registry-dash): add GET /ai/prompts endpoint"
+```
+
+---
+
+## Task 11: Frontend `AiPromptsService` (TDD)
+
+**Files:**
+- Create: `console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts`
+- Create: `console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ai-prompts.service.spec.ts`:
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { AiPromptsService } from './ai-prompts.service';
+
+describe('AiPromptsService', () => {
+  let service: AiPromptsService;
+  let fetchSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AiPromptsService);
+    fetchSpy = spyOn(window, 'fetch');
+  });
+
+  it('fetches and returns the menu for a page', async () => {
+    fetchSpy.and.resolveTo(new Response(JSON.stringify({
+      version: 'v1',
+      menu: [{ promptType: 'summarize_trends', label: 'Summarize trends',
+               icon: 'bar_chart', userMessage: '...' }],
+    })));
+    const result = await service.getMenu('portfolio');
+    expect(result.version).toBe('v1');
+    expect(result.menu.length).toBe(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/console-api/registry-dash/ai/prompts?page=portfolio',
+      jasmine.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('caches results so the second call does not refetch', async () => {
+    fetchSpy.and.resolveTo(new Response(JSON.stringify({ version: 'v1', menu: [] })));
+    await service.getMenu('portfolio');
+    await service.getMenu('portfolio');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to FALLBACK_MENU on fetch error', async () => {
+    fetchSpy.and.resolveTo(new Response('boom', { status: 500 }));
+    const result = await service.getMenu('portfolio');
+    expect(result.version).toBe('fallback');
+    expect(result.menu.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test (it fails — service doesn't exist)**
+
+```
+cd console-webapp && npm run test -- --include='**/ai-prompts.service.spec.ts' --watch=false
+```
+
+Expected: FAIL — cannot resolve `./ai-prompts.service`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `ai-prompts.service.ts`:
+
+```typescript
+import { Injectable } from '@angular/core';
+import { AiPromptOption } from './ai-analysis.models';
+import { FALLBACK_MENU } from './ai-prompts';
+
+export interface AiPromptsResponse {
+  version: string;
+  menu: AiPromptOption[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class AiPromptsService {
+  private cache = new Map<string, AiPromptsResponse>();
+
+  async getMenu(page: string): Promise<AiPromptsResponse> {
+    const cached = this.cache.get(page);
+    if (cached) return cached;
+
+    try {
+      const res = await fetch(
+        `/console-api/registry-dash/ai/prompts?page=${encodeURIComponent(page)}`,
+        { credentials: 'include' },
+      );
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = (await res.json()) as AiPromptsResponse;
+      this.cache.set(page, data);
+      return data;
+    } catch {
+      return { version: 'fallback', menu: FALLBACK_MENU[page] ?? [] };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```
+cd console-webapp && npm run test -- --include='**/ai-prompts.service.spec.ts' --watch=false
+```
+
+Expected: 3 specs PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts \
+        console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts
+git commit -m "feat(registry-dash): AiPromptsService fetches and caches AI menu per page"
+```
+
+---
+
+## Task 12: Convert `ai-prompts.ts` to fallback-only
+
+**Files:**
+- Modify: `console-webapp/src/app/registry-dash/ai/ai-prompts.ts`
+
+- [ ] **Step 1: Replace `PROMPTS_BY_PAGE` with `FALLBACK_MENU`**
+
+In `ai-prompts.ts`, change the final export to:
+
+```typescript
+/**
+ * Fallback prompt menu used only when the backend /ai/prompts endpoint is unreachable.
+ * The authoritative source of truth is `default-config.yaml` ai.prompts.menus.
+ */
+export const FALLBACK_MENU: Record<string, AiPromptOption[]> = {
+  'domain-activity': DOMAIN_ACTIVITY_PROMPTS,
+  'revenue-billing': REVENUE_BILLING_PROMPTS,
+  forecasting: FORECASTING_PROMPTS,
+  explore: EXPLORE_PROMPTS,
+  overview: OVERVIEW_PROMPTS,
+};
+```
+
+Delete the existing `PROMPTS_BY_PAGE` export. Keep the per-page constant exports for now (consumed only via `FALLBACK_MENU`).
+
+- [ ] **Step 2: Build to surface any other importers**
+
+```
+cd console-webapp && npm run build
+```
+
+Expected: build fails on the next file that imports `PROMPTS_BY_PAGE` — that's `ai-sparkle-button.component.ts` and is fixed in Task 13. If any other file imports `PROMPTS_BY_PAGE`, fix the import inline (replace with `FALLBACK_MENU` only as a temporary bridge — Task 13 removes it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-prompts.ts
+git commit -m "refactor(registry-dash): rename PROMPTS_BY_PAGE to FALLBACK_MENU"
+```
+
+---
+
+## Task 13: Wire `AiPromptsService` into `ai-sparkle-button`
+
+**Files:**
+- Modify: `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts`
+
+- [ ] **Step 1: Inject the service and load menu lazily**
+
+Replace the existing `PROMPTS_BY_PAGE[page]` lookup with a call to `aiPromptsService.getMenu(page)`. The component currently reads `PROMPTS_BY_PAGE[this.page]` on init; switch to `effect(() => { this.aiPromptsService.getMenu(this.page).then(r => this.menuItems.set(r.menu)); });` (or equivalent based on how the component manages state — preserve existing pattern).
+
+Update imports: remove `import { PROMPTS_BY_PAGE } from './ai-prompts';`, add `import { AiPromptsService } from './ai-prompts.service';`. Inject in the constructor: `constructor(private aiPromptsService: AiPromptsService, ...) {}`.
+
+- [ ] **Step 2: Run the existing component tests**
+
+```
+cd console-webapp && npm run test -- --include='**/ai-sparkle-button*' --watch=false
+```
+
+Fix any failures by updating mocks to provide the service instead of relying on the constants module.
+
+- [ ] **Step 3: Build the frontend**
+
+```
+cd console-webapp && npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+git commit -m "feat(registry-dash): sparkle button fetches menu from backend prompts endpoint"
+```
+
+---
+
+## Task 14: Local end-to-end verification
+
+**No file changes — verification only.**
+
+- [ ] **Step 1: Start the local test server**
+
+Follow `MEMORY.md → reference_local_dev_setup.md`. Run `local-test-data-setup.sql` and `local-create-domains.sql` once the server is up.
+
+- [ ] **Step 2: Smoke each page**
+
+Log in as a dashboard-permitted user. For each of the seven pages (Overview, Domain Activity, Revenue Billing, Forecasting, Explore, Portfolio, Pricing):
+
+1. Navigate to the page.
+2. Click the sparkle button.
+3. Confirm the 3-item menu renders (icons + labels match the YAML).
+4. Click "Summarize trends" and confirm a streaming response renders in the modal.
+5. Type a follow-up question and confirm it streams.
+
+- [ ] **Step 3: Verify config-driven prompts**
+
+Edit `default-config.yaml` `ai.prompts.basePreamble` to a sentinel value (`"PREAMBLE_E2E_TEST"`). Restart the test server. Fire any analysis. Confirm the server log line at INFO level includes the sentinel and `promptVersion=v1`. Revert the file.
+
+- [ ] **Step 4: Verify allowlist regression**
+
+```
+curl -i -X POST -b "cookie-from-browser" \
+  -H "Content-Type: application/json" \
+  -d '{"page":"domains","promptType":"summarize_trends","chartData":{}}' \
+  http://localhost:8080/console-api/registry-dash/ai/analyze
+```
+
+Expected: HTTP 400.
+
+- [ ] **Step 5: Verify prompts endpoint directly**
+
+```
+curl -i -b "cookie-from-browser" \
+  http://localhost:8080/console-api/registry-dash/ai/prompts?page=portfolio
+```
+
+Expected: 200 with JSON body `{"version": "v1", "menu": [...]}`.
+
+- [ ] **Step 6: Commit nothing (verification only)**
+
+If all steps pass, proceed to `gh pr create --base master`.
+
+---
+
+## Self-Review Checklist (run before handoff)
+
+- [ ] Every spec section has at least one task that implements it (sparkle wiring, YAML migration, prompts endpoint, version log, audit, tests, e2e).
+- [ ] No "TODO" / "implement later" / "fill in details" placeholders.
+- [ ] `Prompts` POJO field names match between `RegistryConfigSettings.java`, the YAML, the `@Config` provider, and `RegistryDashAiAction`.
+- [ ] `VALID_PAGES` membership matches the YAML `menus:` keys (both lists contain the same 7 pages).
+- [ ] Each task ends with a commit step.
+- [ ] Frontend tasks build (`npm run build`); backend tasks compile and pass tests (`./nom_build :core:test --tests …`).

--- a/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier2-design.md
+++ b/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier2-design.md
@@ -1,0 +1,276 @@
+# Registry Dashboard AI Analysis — Tier 2 Design Spec
+
+## Context
+
+Tier 1 (PR #114) shipped AI-powered analysis on three dashboard pages: Domain Activity, Revenue Billing, Forecasting. The system prompt is built in `RegistryDashAiAction.getDefaultSystemPrompt()` from hardcoded Java strings, and the user-facing prompt menu (canned "Summarize trends" entries) lives in the frontend constant file `ai-prompts.ts`.
+
+After Tier 1 went live, the team observed:
+
+- Two more pages already had sparkle buttons added (Overview, Explore) without a corresponding spec/plan, leaving inconsistent coverage.
+- Two pages still need them (Portfolio, Pricing).
+- Iterating on prompt wording requires a deploy because both the Java strings and the TS constants are baked into the build.
+- There is no record of which prompt revision was active when an analysis ran, blocking quality measurement.
+
+Tier 2 closes those gaps. Tier 3 (agentic tool use) is a separate spec.
+
+## Scope
+
+**In scope:**
+1. Sparkle buttons on Portfolio and Pricing.
+2. Re-audit existing wiring on Overview and Explore — confirm `[page]` matches a registered prompt set and the menu renders.
+3. Migrate the system prompt building blocks **and** the user-message menus from hardcoded Java/TS into `default-config.yaml` under the existing `ai:` block.
+4. Expose a new `GET /console-api/registry-dash/ai/prompts?page=<page>` endpoint that serves the active menu + prompt version. Frontend fetches at first sparkle-button open per page.
+5. Log the active `promptVersion` on every analysis request for observability.
+
+**Out of scope (deferred):**
+- Anthropic tool_use / function calling (Tier 3).
+- FTE-only prompt-version override beyond what Tier 1 already supports (the existing `systemPrompt` override in `AiAnalyzeRequest` is unchanged).
+- Hash-based variant assignment / live A/B experiments.
+- Per-environment prompt overrides — the env-specific YAML rollout is tracked separately in `docs/superpowers/plans/2026-04-25-env-specific-ai-config.md`.
+- Refining prompt wording itself — that is a content task done after the structural migration lands. Existing prompt strings carry over verbatim into YAML.
+
+## Architecture
+
+### Java → YAML migration
+
+```
+default-config.yaml                       RegistryConfigSettings.Ai.Prompts
+─────────────────────                     ────────────────────────────────
+ai:                                        public static class Prompts {
+  prompts:                                   public String version;
+    version: "v1"                            public String basePreamble;
+    basePreamble: "You are an…"              public Map<String,String> promptTypes;
+    promptTypes:                             public Map<String,String> pageHints;
+      summarize_trends: "…"                  public Map<String,List<MenuItem>> menus;
+    pageHints:                             }
+      domain-activity: "…"
+    menus:
+      portfolio:
+        - { promptType, label, icon, userMessage }
+                                          │
+                                          ▼
+                                          @Config("anthropicPromptConfig") Prompts
+                                          │
+                                          ▼
+                       ┌──────────────────┴──────────────────┐
+                       ▼                                     ▼
+       RegistryDashAiAction                    RegistryDashAiPromptsAction
+       (build system prompt from               (GET /ai/prompts?page=<page>
+        injected config; log version)           returns { version, menu })
+```
+
+The frontend stops importing `ai-prompts.ts` constants and instead asks the backend for the menu when a user opens the sparkle button on a page.
+
+### Why YAML, not a database?
+
+`default-config.yaml` is the existing pattern for tunable Nomulus configuration (`ai:` block at line 642 already exists for API base URL, secret name, default model, rate limit). YAML is hot-reloaded only on deploy, but iterating on prompt wording is a once-a-week cadence — fast enough. A DB-backed solution can come later if the cadence picks up. YAGNI.
+
+### Why a separate prompts endpoint, not embedding in `/ai/analyze`?
+
+- The frontend renders the menu before the user picks a prompt, so it needs the menu before any analysis call.
+- A separate endpoint is cacheable per-session (one fetch per page-open) and keeps the analyze endpoint focused.
+- Same auth gate (`VIEW_DASHBOARD_OVERVIEW`); negligible additional surface.
+
+## Frontend Design
+
+### Portfolio + Pricing sparkle wiring
+
+- `<app-ai-sparkle-button page="portfolio">` placed in the page-header row of `portfolio.component.html`, matching the placement in `overview.component.html`.
+- Same pattern for Pricing in `pricing.component.html`.
+- Sparkle button component already exists; only the host templates change.
+
+### Audit task for Overview + Explore
+
+- Open `overview.component.html` and `explore.component.html`; confirm `[page]` literal matches the YAML menu key.
+- Click each in local dev; confirm the menu renders the expected items (`summarize_trends`, `find_anomalies`, `suggest_actions` for both).
+- No code change expected — this is a verification step that gates the Phase B migration.
+
+### Prompts service
+
+New service (or extension of `ai-analysis.service.ts`):
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class AiPromptsService {
+  private cache = new Map<string, { version: string; menu: AiPromptOption[] }>();
+
+  async getMenu(page: string): Promise<{ version: string; menu: AiPromptOption[] }> {
+    if (this.cache.has(page)) return this.cache.get(page)!;
+    const res = await fetch(`/console-api/registry-dash/ai/prompts?page=${page}`, { credentials: 'include' });
+    if (!res.ok) return { version: 'fallback', menu: FALLBACK_MENU[page] ?? [] };
+    const data = await res.json();
+    this.cache.set(page, data);
+    return data;
+  }
+}
+```
+
+`ai-sparkle-button.component.ts` calls `getMenu(this.page)` on first open per page, populates `MatMenu` from the result. The existing `ai-prompts.ts` constants are kept as `FALLBACK_MENU` only — they're no longer the source of truth in production, but they keep the UI useful if the backend fetch fails.
+
+### Frontend types
+
+`AiPromptOption` already exists; the response shape adds `version` at the top level.
+
+```typescript
+interface AiPromptsResponse {
+  version: string;
+  menu: AiPromptOption[];
+}
+```
+
+## Backend Design
+
+### Refactored `getDefaultSystemPrompt`
+
+Replace the hardcoded `switch` over `promptType` (currently lines 159-179 of `RegistryDashAiAction.java`) with lookups against the injected prompt config:
+
+```java
+private String getDefaultSystemPrompt(
+    String page, String promptType, JsonElement chartData, JsonObject metadata) {
+  StringBuilder sb = new StringBuilder();
+  sb.append(promptConfig.basePreamble).append("\n\n");
+  sb.append("## Analysis Type\n");
+  sb.append(promptConfig.promptTypes.getOrDefault(
+      promptType, "Analyze this data and provide insights.")).append("\n");
+  String pageHint = promptConfig.pageHints.get(page);
+  if (pageHint != null) {
+    sb.append("\n## Page\n").append(pageHint).append("\n");
+  }
+  sb.append("\n## Context\n");
+  // ...metadata block unchanged...
+  sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n");
+  sb.append(promptConfig.responseGuidance);  // closing instructions, also config-driven
+  return sb.toString();
+}
+```
+
+Method signature unchanged; only the body. The constructor gets a new injected `Prompts promptConfig` parameter.
+
+### New action: `RegistryDashAiPromptsAction`
+
+- **Path:** `GET /console-api/registry-dash/ai/prompts`
+- **Query param:** `page` — required, validated against the same allowlist as `AiAnalyzeRequest`.
+- **Auth:** `Auth.AUTH_PUBLIC_LOGGED_IN`, same as `RegistryDashAiAction`.
+- **Permission:** `VIEW_DASHBOARD_OVERVIEW`.
+- **Response body:** `{"version": "v1", "menu": [{"promptType": "summarize_trends", "label": "...", "icon": "...", "userMessage": "..."}, ...]}`.
+- **Errors:**
+  - `400` if `page` missing or not in allowlist.
+  - `403` if permission missing.
+  - `404` if the YAML has no menu for the requested page (treated as misconfiguration).
+- **Location:** `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java`.
+
+### Page allowlist refactor
+
+`AiAnalyzeRequest.isValid()` currently has a hardcoded set. To stay DRY between the analyze endpoint and the new prompts endpoint, extract:
+
+```java
+public static final ImmutableSet<String> VALID_PAGES = ImmutableSet.of(
+    "domain-activity", "revenue-billing", "forecasting", "explore", "overview",
+    "portfolio", "pricing");
+```
+
+Both actions reference `AiAnalyzeRequest.VALID_PAGES`.
+
+### Prompt-version observability
+
+Extend the existing `logger.atInfo()` call at `RegistryDashAiAction.java:104`:
+
+```java
+logger.atInfo().log(
+    "AI analysis request: user=%s, page=%s, promptType=%s, model=%s, "
+    + "promptVersion=%s, historySize=%d",
+    userEmail, request.page, request.promptType, resolvedModel,
+    promptConfig.version, ...);
+```
+
+Cheap, structured, log-based-metric ready. No SSE protocol change.
+
+## Data Payloads
+
+### `GET /ai/prompts?page=<page>` response
+
+```json
+{
+  "version": "v1",
+  "menu": [
+    { "promptType": "summarize_trends", "label": "Summarize trends",
+      "icon": "bar_chart", "userMessage": "Summarize the key trends…" },
+    { "promptType": "find_anomalies", "label": "Find anomalies",
+      "icon": "search", "userMessage": "Identify anomalies…" },
+    { "promptType": "suggest_actions", "label": "Suggest actions",
+      "icon": "lightbulb", "userMessage": "Based on this data…" }
+  ]
+}
+```
+
+### `default-config.yaml` schema
+
+```yaml
+ai:
+  apiBaseUrl: https://api.anthropic.com
+  apiKeySecretName: ud_rsp_anthropic_api_key
+  defaultModel: sonnet
+  rateLimitPerHour: 120
+  prompts:
+    version: "v1"
+    basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
+    responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
+    promptTypes:
+      summarize_trends: "Summarize the key trends in this data..."
+      find_anomalies: "Identify anomalies, outliers, and unusual patterns..."
+      suggest_actions: "Based on this data, suggest specific actionable recommendations..."
+      identify_risks: "Identify risks in this data..."
+    pageHints:
+      domain-activity: "(optional per-page guidance)"
+      revenue-billing: "..."
+      forecasting: "..."
+      overview: "..."
+      explore: "..."
+      portfolio: "..."
+      pricing: "..."
+    menus:
+      domain-activity: [ {promptType, label, icon, userMessage}, ... ]
+      revenue-billing: [ ... ]
+      forecasting: [ ... ]
+      overview: [ ... ]
+      explore: [ ... ]
+      portfolio: [ ... ]
+      pricing: [ ... ]
+```
+
+## New Files
+
+### Backend (Java)
+- `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsAction.java`
+- `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiPromptsActionTest.java`
+
+### Modified
+- `core/src/main/java/google/registry/config/files/default-config.yaml` — extend `ai:` block with `prompts:`
+- `core/src/main/java/google/registry/config/RegistryConfigSettings.java` — add `Prompts` nested class on `Ai`
+- `core/src/main/java/google/registry/config/RegistryConfig.java` — add `@Config("anthropicPromptConfig")` provider
+- `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java` — refactor `getDefaultSystemPrompt`, log promptVersion
+- `core/src/main/java/google/registry/ai/AiAnalyzeRequest.java` — extract `VALID_PAGES` constant; add `portfolio`, `pricing`
+- `core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java` — extend to cover config-driven prompts and new pages
+- `core/src/test/java/google/registry/ai/AiAnalyzeRequestTest.java` — assert `portfolio` and `pricing` accepted
+
+### Frontend (Angular)
+- `console-webapp/src/app/registry-dash/ai/ai-prompts.service.ts` (new)
+- `console-webapp/src/app/registry-dash/ai/ai-prompts.service.spec.ts` (new)
+- `console-webapp/src/app/registry-dash/ai/ai-prompts.ts` — convert from primary source to `FALLBACK_MENU`-only export
+- `console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts` — fetch menu via service instead of importing constant
+- `console-webapp/src/app/registry-dash/portfolio/portfolio.component.html` — add sparkle button
+- `console-webapp/src/app/registry-dash/pricing/pricing.component.html` — add sparkle button
+
+## Verification
+
+1. **Backend unit tests** for `Prompts` config loading and `getDefaultSystemPrompt` driven by a fixture YAML.
+2. **`RegistryDashAiPromptsActionTest`** covers: 200 with menu for each valid page, 400 for missing/invalid `page`, 403 for missing permission, 404 for misconfigured page.
+3. **`AiAnalyzeRequestTest`** asserts `portfolio` and `pricing` accepted, unknown pages rejected.
+4. **Frontend `AiPromptsService` spec** covers: cached on second call, falls back to `FALLBACK_MENU` on fetch error, surfaces `version` in response.
+5. **Local end-to-end:**
+   - Start local test server, log in, navigate to Portfolio → click sparkle → menu renders → "Summarize trends" → streaming response.
+   - Repeat for Pricing.
+   - Re-verify Overview and Explore still work after the migration.
+   - Edit `default-config.yaml` `ai.prompts.basePreamble`, restart, fire an analysis, confirm new preamble appears in server log line at INFO.
+6. **Allowlist regression:** `POST /ai/analyze` with `page: "domains"` still returns 400; `page: "portfolio"` returns 200.
+7. **Log-line check:** confirm `promptVersion=v1` appears in the `AI analysis request` log line on each request.


### PR DESCRIPTION
## Summary

Implements Tier 2 of the registry-dashboard AI analysis feature ([spec](https://github.com/unstoppabledomains/nomulus/blob/UDtorrey/ai-tier-2-plan/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier2-design.md), [plan](https://github.com/unstoppabledomains/nomulus/blob/UDtorrey/ai-tier-2-plan/docs/superpowers/plans/2026-04-29-registry-dash-ai-tier2.md)) on top of Tier 1 (#114).

- Adds the AI sparkle button to **Portfolio** and **Pricing** pages, completing dashboard coverage. Confirmed Overview and Explore already had it (no change there).
- Externalizes the AI **system prompt** and the **per-page menu** into `default-config.yaml` under `ai.prompts.{basePreamble, responseGuidance, promptTypes, pageHints, menus}`. `RegistryDashAiAction.getDefaultSystemPrompt` now reads from injected `RegistryConfigSettings.Prompts` instead of hardcoded Java strings — prompts can be tuned without rebuilding the JAR.
- New `GET /console-api/registry-dash/ai/prompts?page=<page>` endpoint serves `{ version, menu }` for the requested page, gated by `VIEW_DASHBOARD_OVERVIEW`. Frontend `AiPromptsService` fetches and caches per page; `ai-prompts.ts` constants now serve only as a fallback when the endpoint is unreachable.
- Logs `promptVersion=v1` on every analyze request for observability — first primitive toward later A/B work.
- Updates the canonical `test-registry-dash` test plan (tests 13–17 added) and gives the skill helpers to bring up the local stack itself (`helpers/start-local-stack.sh`) and seed minimum pricing data (`helpers/seed-test-data.sh`), so future runs don't require the user to start servers manually.

## Files changed (highlights)

- Backend: `RegistryConfigSettings.Ai.Prompts` POJO; `default-config.yaml` `ai.prompts:` block; `RegistryConfig.@Config("anthropicPromptConfig")` provider; `RegistryDashAiAction` constructor + body refactor; new `RegistryDashAiPromptsAction` + 5-test class; `AiAnalyzeRequest.VALID_PAGES` extracted (adds `portfolio`, `pricing`); `routing.txt` regenerated.
- Frontend: `PORTFOLIO_PROMPTS` / `PRICING_PROMPTS`; `FALLBACK_MENU` (replaces `PROMPTS_BY_PAGE`); new `ai-prompts.service.ts` + spec; sparkle wiring on Portfolio + Pricing components.
- Plugin: `test-plan.md` extended; `helpers/start-local-stack.sh` and `helpers/seed-test-data.sh` added; `metadata.json` advanced.
- Docs: dated spec + plan in `docs/superpowers/`.

## Test plan

- [x] `./gradlew :core:compileJava :core:compileTestJava` — clean
- [x] `./gradlew :core:test --tests *AiAnalyzeRequestTest` — 5/5
- [x] `./gradlew :core:test --tests *RegistryDashAiActionTest` — 6/6 (incl. new `testSystemPrompt_drawnFromConfig`, `testRequest_logsPromptVersion`)
- [x] `./gradlew :core:test --tests *RegistryDashAiPromptsActionTest` — 5/5
- [x] `cd console-webapp && npm run build` — clean (Node 22.16)
- [x] **Local E2E with real Claude** — Portfolio sparkle → Sonnet → streaming markdown response with data-aware analysis citing actual registrar shares; `GET /ai/prompts` returns 200 for all 7 pages; unknown/missing → 400; server log line includes `promptVersion=v1`.
- [ ] Stage on alpha-gke and confirm sparkle on Portfolio/Pricing for an FTE user.
- [ ] (Follow-up, separate PR) Wire env-specific prompt config in `nomulus-secrets` per `docs/superpowers/plans/2026-04-25-env-specific-ai-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)