### PR TITLE
feat(registry-dash): AI Tier 3 — agentic tool use

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -389,3 +389,55 @@
 - All 7 pages now participate in the cross-page flow established by Test 12.
 - No data bleed between pages.
 - Model preference and conversation history are scoped per-modal (closing the modal clears history).
+
+---
+
+## Test 18: Tier 3 Tool Use — Indicator UX
+
+**Goal:** Verify the analysis modal shows transient tool indicators when Claude calls a tool.
+
+### Steps:
+1. Navigate to **Domain Activity** (or any page with sparkle).
+2. Click sparkle → open the analysis modal.
+3. Wait for the initial analysis to finish.
+4. In the follow-up box, type: `What specific domains transferred in the last 30 days for the example tld?` (substitute a TLD with seeded transfer data).
+5. Watch for an inline indicator below the streaming text: `🔍 Searching transfers…` (italic, slight pulse animation).
+6. The indicator should appear when the tool is in flight and disappear once the tool result arrives.
+7. The final assistant text should reference specific domain names that came from the tool.
+
+### Expected:
+- Indicator appears mid-stream and is replaced by the next text chunk.
+- Final answer contains specific domain names, not just chart-level summaries.
+- Modal does not crash or hang.
+
+---
+
+## Test 19: Tier 3 Tool Use — Server Log
+
+**Goal:** Confirm the server-side log line records `toolsUsed=` for tool-firing requests.
+
+### Steps:
+1. Tail the test server log (or Cloud Logging in alpha-gke) for `RegistryDashAiAction`.
+2. Run Test 18.
+3. Locate the corresponding `AI analysis request:` log line.
+
+### Expected:
+- The log line includes `toolsUsed=[query_transfers]` (or the relevant tool list).
+- For analyses that don't trigger any tool, `toolsUsed=[]`.
+
+---
+
+## Test 20: Tier 3 Tool Use — Permission Scope
+
+**Goal:** Tools must respect per-user TLD scope.
+
+### Steps:
+1. Log in as a non-FTE user mapped to a single registry/TLD set.
+2. Open the modal on Domain Activity.
+3. Ask `What domains transferred for tld <some-tld-the-user-cannot-see>?`.
+4. The tool should refuse (Claude will get an `is_error: true` tool_result; the assistant will say it doesn't have access).
+
+### Expected:
+- No data from a TLD outside the user's access scope ever appears in the modal.
+- Final text is a clear "I don't have access" rather than a stack trace.
+

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -43,6 +43,9 @@
       <mat-icon class="message-icon">auto_awesome</mat-icon>
       <div class="message-content markdown-body">
         <div [innerHTML]="streamedText() | markdown"></div>
+        <div *ngFor="let t of toolsInFlight()" class="tool-indicator">
+          {{ t.label }}<span class="tool-indicator-dots">…</span>
+        </div>
         <mat-progress-bar mode="indeterminate" class="stream-progress"></mat-progress-bar>
       </div>
     </div>

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
@@ -128,3 +128,25 @@ mat-dialog-actions {
     }
   }
 }
+
+.tool-indicator {
+  margin: 8px 0;
+  padding: 6px 10px;
+  background: var(--ud-surface-2, #f5f5f5);
+  border-left: 3px solid var(--ud-accent);
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--ud-text-muted, #666);
+  font-style: italic;
+}
+
+.tool-indicator-dots {
+  display: inline-block;
+  margin-left: 2px;
+  animation: tool-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes tool-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -62,6 +62,7 @@ export class AiAnalysisModalComponent implements OnInit {
   streaming = computed(() => this.aiService.streaming());
   streamedText = computed(() => this.aiService.streamedText());
   error = computed(() => this.aiService.error());
+  toolsInFlight = computed(() => this.aiService.toolsInFlight());
 
   constructor(
     public dialogRef: MatDialogRef<AiAnalysisModalComponent>,

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -48,3 +48,21 @@ export interface AiPromptOption {
 }
 
 export type AiModelChoice = 'haiku' | 'sonnet' | 'opus';
+
+export type AiStreamFrame =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; tool: string; args: Record<string, unknown> }
+  | { type: 'tool_result'; tool: string; ok: boolean }
+  | { type: 'done' };
+
+export interface ToolInFlight {
+  tool: string;
+  label: string;
+}
+
+export const TOOL_LABELS: Record<string, string> = {
+  query_transfers: '🔍 Searching transfers',
+  get_pricing_rules: '💰 Looking up pricing',
+  query_registrar_activity: '📊 Checking registrar activity',
+  query_domain_details: '🔎 Looking up domain',
+};

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -13,25 +13,29 @@
 // limitations under the License.
 
 import { Injectable, signal } from '@angular/core';
-import { AiAnalyzeRequest } from './ai-analysis.models';
+import {
+  AiAnalyzeRequest,
+  AiStreamFrame,
+  TOOL_LABELS,
+  ToolInFlight,
+} from './ai-analysis.models';
 
 @Injectable({ providedIn: 'root' })
 export class AiAnalysisService {
   streaming = signal(false);
   streamedText = signal('');
   error = signal<string | null>(null);
+  toolsInFlight = signal<ToolInFlight[]>([]);
+  toolsUsed = signal<string[]>([]);
 
   async analyze(request: AiAnalyzeRequest): Promise<void> {
     this.streaming.set(true);
     this.streamedText.set('');
     this.error.set(null);
+    this.toolsInFlight.set([]);
+    this.toolsUsed.set([]);
 
     try {
-      const xsrfCookie = document.cookie
-        .split('; ')
-        .find(c => c.startsWith('X-CSRF-Token='));
-      const xsrfToken = xsrfCookie?.split('=')[1] ?? '';
-
       const response = await fetch('/console-api/registry-dash/ai/analyze', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -81,11 +85,29 @@ export class AiAnalysisService {
           const data = line.substring(6).trim();
           if (data === '[DONE]') break;
           try {
-            const parsed = JSON.parse(data);
-            if (parsed.text) {
-              accumulated += parsed.text;
+            const frame = JSON.parse(data) as AiStreamFrame | { text?: string };
+
+            // Tier 1 (legacy) frames had only {text: "..."} — handle gracefully.
+            if (!('type' in frame) && 'text' in frame && frame.text) {
+              accumulated += frame.text;
               this.streamedText.set(accumulated);
+              continue;
             }
+
+            const typed = frame as AiStreamFrame;
+            if (typed.type === 'text') {
+              accumulated += typed.text;
+              this.streamedText.set(accumulated);
+            } else if (typed.type === 'tool_use') {
+              const label = TOOL_LABELS[typed.tool] ?? `🔧 Running ${typed.tool}`;
+              this.toolsInFlight.update(list => [...list, { tool: typed.tool, label }]);
+              this.toolsUsed.update(list => [...list, typed.tool]);
+            } else if (typed.type === 'tool_result') {
+              this.toolsInFlight.update(list =>
+                removeFirst(list, t => t.tool === typed.tool),
+              );
+            }
+            // 'done' is informational; the [DONE] sentinel still terminates the loop.
           } catch {
             // skip malformed chunks
           }
@@ -95,6 +117,15 @@ export class AiAnalysisService {
       this.error.set('Response interrupted. Try again?');
     } finally {
       this.streaming.set(false);
+      this.toolsInFlight.set([]);
     }
   }
+}
+
+function removeFirst<T>(list: T[], pred: (item: T) => boolean): T[] {
+  const idx = list.findIndex(pred);
+  if (idx < 0) return list;
+  const out = list.slice();
+  out.splice(idx, 1);
+  return out;
 }

--- a/core/src/main/java/google/registry/ai/AiOrchestrator.java
+++ b/core/src/main/java/google/registry/ai/AiOrchestrator.java
@@ -1,0 +1,170 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool;
+import google.registry.ai.tools.AiToolRegistry;
+import google.registry.model.console.User;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Multi-turn loop that lets Claude call backend {@link AiTool}s mid-conversation.
+ *
+ * <p>Per turn: send conversation + tool definitions to Anthropic; for each {@code tool_use} block
+ * that comes back, execute the matching tool and append a {@code tool_result} message to the
+ * conversation; resend. Stop when Anthropic emits {@code stop_reason = end_turn} or when the turn
+ * cap is hit.
+ *
+ * <p>Streams text deltas and tool-use signals to the caller via the supplied {@link Consumer}.
+ */
+@Singleton
+public class AiOrchestrator {
+
+  private static final int MAX_TURNS = 5;
+  private static final Gson GSON = new Gson();
+
+  private final AnthropicClient anthropicClient;
+  private final AiToolRegistry registry;
+
+  @Inject
+  public AiOrchestrator(AnthropicClient anthropicClient, AiToolRegistry registry) {
+    this.anthropicClient = anthropicClient;
+    this.registry = registry;
+  }
+
+  /**
+   * Runs a multi-turn conversation and returns the ordered list of tool names that were invoked.
+   * Caller's {@link Consumer} sees every {@link OrchestratorEvent} in order.
+   */
+  public ImmutableList<String> run(
+      String systemPrompt,
+      List<AiAnalyzeRequest.ConversationMessage> initialHistory,
+      String modelOverride,
+      User user,
+      Consumer<OrchestratorEvent> sink)
+      throws IOException {
+
+    JsonArray messages = new JsonArray();
+    if (initialHistory != null) {
+      for (AiAnalyzeRequest.ConversationMessage msg : initialHistory) {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("role", msg.role);
+        obj.addProperty("content", msg.content);
+        messages.add(obj);
+      }
+    }
+
+    JsonArray tools = registry.anthropicToolDefinitions();
+    List<String> toolsUsed = new ArrayList<>();
+
+    for (int turn = 0; turn < MAX_TURNS; turn++) {
+      List<PendingToolCall> pending = new ArrayList<>();
+      AnthropicClient.StreamResult result =
+          anthropicClient.streamMessageWithTools(
+              systemPrompt,
+              messages,
+              modelOverride,
+              tools,
+              event -> {
+                if (event instanceof AnthropicClient.TextDelta td) {
+                  sink.accept(new TextEvent(td.text()));
+                } else if (event instanceof AnthropicClient.ToolUseBlock tu) {
+                  JsonObject argsObj =
+                      tu.input() instanceof JsonObject jo ? jo : new JsonObject();
+                  sink.accept(new ToolUseEvent(tu.name(), argsObj));
+                  pending.add(new PendingToolCall(tu.toolUseId(), tu.name(), argsObj));
+                }
+              });
+
+      if (pending.isEmpty()) {
+        // No tool calls this turn — Claude is done.
+        sink.accept(new DoneEvent());
+        return ImmutableList.copyOf(toolsUsed);
+      }
+
+      // Append the assistant turn (containing the tool_use blocks) to the conversation.
+      JsonObject assistantMsg = new JsonObject();
+      assistantMsg.addProperty("role", "assistant");
+      assistantMsg.add("content", result.assistantContent());
+      messages.add(assistantMsg);
+
+      // Execute each tool and append a single user message containing all tool_results.
+      JsonArray toolResultsContent = new JsonArray();
+      for (PendingToolCall p : pending) {
+        toolsUsed.add(p.name);
+        JsonObject resultBlock = new JsonObject();
+        resultBlock.addProperty("type", "tool_result");
+        resultBlock.addProperty("tool_use_id", p.toolUseId);
+        Optional<AiTool> maybeTool = registry.get(p.name);
+        if (maybeTool.isEmpty()) {
+          resultBlock.addProperty("is_error", true);
+          resultBlock.addProperty("content", "Unknown tool: " + p.name);
+          sink.accept(new ToolResultEvent(p.name, false));
+        } else {
+          try {
+            JsonElement out = maybeTool.get().execute(p.args, user);
+            resultBlock.addProperty("content", GSON.toJson(out));
+            sink.accept(new ToolResultEvent(p.name, true));
+          } catch (AiTool.AiToolException e) {
+            resultBlock.addProperty("is_error", true);
+            resultBlock.addProperty("content", e.getMessage());
+            sink.accept(new ToolResultEvent(p.name, false));
+          } catch (RuntimeException e) {
+            resultBlock.addProperty("is_error", true);
+            resultBlock.addProperty(
+                "content", "Tool execution error: " + e.getClass().getSimpleName());
+            sink.accept(new ToolResultEvent(p.name, false));
+          }
+        }
+        toolResultsContent.add(resultBlock);
+      }
+
+      JsonObject userMsg = new JsonObject();
+      userMsg.addProperty("role", "user");
+      userMsg.add("content", toolResultsContent);
+      messages.add(userMsg);
+    }
+
+    // Hit the turn cap. Surface as done.
+    sink.accept(new DoneEvent());
+    return ImmutableList.copyOf(toolsUsed);
+  }
+
+  // -- Events -------------------------------------------------------------------------------
+
+  public sealed interface OrchestratorEvent
+      permits TextEvent, ToolUseEvent, ToolResultEvent, DoneEvent {}
+
+  public record TextEvent(String text) implements OrchestratorEvent {}
+
+  public record ToolUseEvent(String tool, JsonObject args) implements OrchestratorEvent {}
+
+  public record ToolResultEvent(String tool, boolean ok) implements OrchestratorEvent {}
+
+  public record DoneEvent() implements OrchestratorEvent {}
+
+  private record PendingToolCall(String toolUseId, String name, JsonObject args) {}
+}

--- a/core/src/main/java/google/registry/ai/AnthropicClient.java
+++ b/core/src/main/java/google/registry/ai/AnthropicClient.java
@@ -184,7 +184,7 @@ public class AnthropicClient {
             String type = event.has("type") ? event.get("type").getAsString() : "";
             switch (type) {
               case "content_block_start" -> {
-                int index = event.get("index").getAsInt();
+                int index = event.has("index") ? event.get("index").getAsInt() : 0;
                 JsonObject block = event.getAsJsonObject("content_block");
                 String blockType = block.get("type").getAsString();
                 BlockBuilder bb = new BlockBuilder(blockType);
@@ -195,7 +195,7 @@ public class AnthropicClient {
                 blocks.put(index, bb);
               }
               case "content_block_delta" -> {
-                int index = event.get("index").getAsInt();
+                int index = event.has("index") ? event.get("index").getAsInt() : 0;
                 JsonObject delta = event.getAsJsonObject("delta");
                 String dType = delta.get("type").getAsString();
                 BlockBuilder bb =
@@ -213,7 +213,7 @@ public class AnthropicClient {
                 }
               }
               case "content_block_stop" -> {
-                int index = event.get("index").getAsInt();
+                int index = event.has("index") ? event.get("index").getAsInt() : 0;
                 BlockBuilder bb = blocks.get(index);
                 if (bb != null && "tool_use".equals(bb.blockType)) {
                   JsonObject input;

--- a/core/src/main/java/google/registry/ai/AnthropicClient.java
+++ b/core/src/main/java/google/registry/ai/AnthropicClient.java
@@ -16,32 +16,48 @@ package google.registry.ai;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Singleton;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+/**
+ * Hand-rolled OkHttp client for Anthropic's Messages API with streaming + tool-use support.
+ *
+ * <p>Two streaming modes:
+ *
+ * <ul>
+ *   <li>{@link #streamMessage(String, List, String, Consumer)} — text-only, used by
+ *       single-turn analysis without tools.
+ *   <li>{@link #streamMessageWithTools} — tool-use aware. Yields {@link StreamEvent} values for
+ *       text deltas, tool-use blocks, and message-stop signals; the caller (the orchestrator)
+ *       decides whether to execute tools and recurse.
+ * </ul>
+ */
 @Singleton
 public class AnthropicClient {
 
   private static final String ANTHROPIC_VERSION = "2023-06-01";
   private static final int MAX_TOKENS = 4096;
-  private static final Map<String, String> MODEL_MAP = Map.of(
-      "haiku", "claude-haiku-4-5-20251001",
-      "sonnet", "claude-sonnet-4-5-20250929",
-      "opus", "claude-opus-4-6");
+  private static final Map<String, String> MODEL_MAP =
+      Map.of(
+          "haiku", "claude-haiku-4-5-20251001",
+          "sonnet", "claude-sonnet-4-5-20250929",
+          "opus", "claude-opus-4-6");
   private static final Gson GSON = new Gson();
 
   private final OkHttpClient httpClient;
@@ -61,20 +77,16 @@ public class AnthropicClient {
     this.defaultModel = defaultModel;
   }
 
+  /**
+   * Streams plain text deltas (no tools). Equivalent to {@link #streamMessageWithTools} called
+   * with an empty tool list and a callback that only consumes {@link TextDelta}.
+   */
   public void streamMessage(
       String systemPrompt,
       List<AiAnalyzeRequest.ConversationMessage> conversationHistory,
       String modelOverride,
-      Consumer<String> onChunk) throws IOException {
-
-    String model = resolveModelId(modelOverride != null ? modelOverride : defaultModel);
-
-    JsonObject body = new JsonObject();
-    body.addProperty("model", model);
-    body.addProperty("max_tokens", MAX_TOKENS);
-    body.addProperty("stream", true);
-    body.addProperty("system", systemPrompt);
-
+      Consumer<String> onChunk)
+      throws IOException {
     JsonArray messages = new JsonArray();
     if (conversationHistory != null) {
       for (AiAnalyzeRequest.ConversationMessage msg : conversationHistory) {
@@ -84,18 +96,63 @@ public class AnthropicClient {
         messages.add(msgObj);
       }
     }
+    streamMessageInternal(
+        systemPrompt,
+        messages,
+        modelOverride,
+        new JsonArray(),
+        event -> {
+          if (event instanceof TextDelta td) {
+            onChunk.accept(td.text());
+          }
+        });
+  }
+
+  /**
+   * Tool-use-aware streaming. Caller supplies the full conversation as a {@link JsonArray} of
+   * Anthropic message objects (so the orchestrator can append assistant tool_use blocks and user
+   * tool_result blocks across turns).
+   */
+  public StreamResult streamMessageWithTools(
+      String systemPrompt,
+      JsonArray messages,
+      String modelOverride,
+      JsonArray tools,
+      Consumer<StreamEvent> sink)
+      throws IOException {
+    return streamMessageInternal(systemPrompt, messages, modelOverride, tools, sink);
+  }
+
+  private StreamResult streamMessageInternal(
+      String systemPrompt,
+      JsonArray messages,
+      String modelOverride,
+      JsonArray tools,
+      Consumer<StreamEvent> sink)
+      throws IOException {
+    String model = resolveModelId(modelOverride != null ? modelOverride : defaultModel);
+
+    JsonObject body = new JsonObject();
+    body.addProperty("model", model);
+    body.addProperty("max_tokens", MAX_TOKENS);
+    body.addProperty("stream", true);
+    body.addProperty("system", systemPrompt);
     body.add("messages", messages);
+    if (tools != null && tools.size() > 0) {
+      body.add("tools", tools);
+    }
 
-    RequestBody requestBody = RequestBody.create(
-        GSON.toJson(body), MediaType.parse("application/json"));
+    RequestBody requestBody =
+        RequestBody.create(GSON.toJson(body), MediaType.parse("application/json"));
 
-    Request request = new Request.Builder()
-        .url(baseUrl + "/v1/messages")
-        .post(requestBody)
-        .addHeader("x-api-key", apiKey)
-        .addHeader("anthropic-version", ANTHROPIC_VERSION)
-        .addHeader("Content-Type", "application/json")
-        .build();
+    Request request =
+        new Request.Builder()
+            .url(baseUrl + "/v1/messages")
+            .post(requestBody)
+            .addHeader("x-api-key", apiKey)
+            .addHeader("anthropic-version", ANTHROPIC_VERSION)
+            .addHeader("Content-Type", "application/json")
+            .build();
 
     try (Response response = httpClient.newCall(request).execute()) {
       if (response.code() == 429) {
@@ -105,33 +162,158 @@ public class AnthropicClient {
         throw new IOException("Anthropic API error: " + response.code());
       }
 
-      try (BufferedReader reader = new BufferedReader(
-          new InputStreamReader(response.body().byteStream(), StandardCharsets.UTF_8))) {
+      // Per-turn state: track open content blocks so we can assemble tool_use blocks (which
+      // arrive as input_json_delta accumulations).
+      Map<Integer, BlockBuilder> blocks = new HashMap<>();
+      String stopReason = null;
+
+      try (BufferedReader reader =
+          new BufferedReader(
+              new InputStreamReader(response.body().byteStream(), StandardCharsets.UTF_8))) {
         String line;
         while ((line = reader.readLine()) != null) {
-          if (!line.startsWith("data: ")) continue;
+          if (!line.startsWith("data: ")) {
+            continue;
+          }
           String data = line.substring(6).trim();
-          if (data.equals("[DONE]")) break;
-
+          if (data.equals("[DONE]")) {
+            break;
+          }
           try {
             JsonObject event = GSON.fromJson(data, JsonObject.class);
-            if (event.has("type")
-                && event.get("type").getAsString().equals("content_block_delta")) {
-              JsonObject delta = event.getAsJsonObject("delta");
-              if (delta.has("text")) {
-                onChunk.accept(delta.get("text").getAsString());
+            String type = event.has("type") ? event.get("type").getAsString() : "";
+            switch (type) {
+              case "content_block_start" -> {
+                int index = event.get("index").getAsInt();
+                JsonObject block = event.getAsJsonObject("content_block");
+                String blockType = block.get("type").getAsString();
+                BlockBuilder bb = new BlockBuilder(blockType);
+                if ("tool_use".equals(blockType)) {
+                  bb.toolUseId = block.get("id").getAsString();
+                  bb.toolName = block.get("name").getAsString();
+                }
+                blocks.put(index, bb);
+              }
+              case "content_block_delta" -> {
+                int index = event.get("index").getAsInt();
+                JsonObject delta = event.getAsJsonObject("delta");
+                String dType = delta.get("type").getAsString();
+                BlockBuilder bb =
+                    blocks.computeIfAbsent(
+                        index,
+                        i ->
+                            new BlockBuilder(
+                                "input_json_delta".equals(dType) ? "tool_use" : "text"));
+                if ("text_delta".equals(dType) && delta.has("text")) {
+                  String text = delta.get("text").getAsString();
+                  bb.text.append(text);
+                  sink.accept(new TextDelta(text));
+                } else if ("input_json_delta".equals(dType) && delta.has("partial_json")) {
+                  bb.partialJson.append(delta.get("partial_json").getAsString());
+                }
+              }
+              case "content_block_stop" -> {
+                int index = event.get("index").getAsInt();
+                BlockBuilder bb = blocks.get(index);
+                if (bb != null && "tool_use".equals(bb.blockType)) {
+                  JsonObject input;
+                  try {
+                    input =
+                        bb.partialJson.length() == 0
+                            ? new JsonObject()
+                            : GSON.fromJson(bb.partialJson.toString(), JsonObject.class);
+                  } catch (Exception e) {
+                    input = new JsonObject();
+                  }
+                  sink.accept(new ToolUseBlock(bb.toolUseId, bb.toolName, input));
+                }
+              }
+              case "message_delta" -> {
+                if (event.has("delta")) {
+                  JsonObject d = event.getAsJsonObject("delta");
+                  if (d.has("stop_reason") && !d.get("stop_reason").isJsonNull()) {
+                    stopReason = d.get("stop_reason").getAsString();
+                  }
+                }
+              }
+              case "message_stop" -> sink.accept(new MessageStop(stopReason));
+              default -> {
+                // ignore (ping, message_start, etc.)
               }
             }
           } catch (Exception e) {
-            // Skip non-JSON or non-delta lines
+            // Skip malformed events; don't kill the stream.
           }
         }
       }
+      return new StreamResult(stopReason, blocks);
     }
   }
 
   public static String resolveModelId(String shortName) {
     return MODEL_MAP.getOrDefault(shortName, MODEL_MAP.get("sonnet"));
+  }
+
+  // -- Stream events (tagged union) -------------------------------------------------------------
+
+  public sealed interface StreamEvent permits TextDelta, ToolUseBlock, MessageStop {}
+
+  public record TextDelta(String text) implements StreamEvent {}
+
+  public record ToolUseBlock(String toolUseId, String name, JsonElement input)
+      implements StreamEvent {}
+
+  public record MessageStop(String stopReason) implements StreamEvent {}
+
+  /** Result handed back from a single Anthropic call. */
+  public record StreamResult(String stopReason, Map<Integer, BlockBuilder> blocks) {
+
+    /**
+     * Reconstructs the assistant turn's content blocks for appending to the conversation history
+     * before the next call (so Anthropic sees its prior tool_use when we send the tool_result).
+     */
+    public JsonArray assistantContent() {
+      JsonArray content = new JsonArray();
+      // Iterate by index order to preserve block ordering.
+      blocks.entrySet().stream()
+          .sorted(Map.Entry.comparingByKey())
+          .forEach(
+              e -> {
+                BlockBuilder bb = e.getValue();
+                JsonObject obj = new JsonObject();
+                obj.addProperty("type", bb.blockType);
+                if ("text".equals(bb.blockType)) {
+                  obj.addProperty("text", bb.text.toString());
+                } else if ("tool_use".equals(bb.blockType)) {
+                  obj.addProperty("id", bb.toolUseId);
+                  obj.addProperty("name", bb.toolName);
+                  try {
+                    obj.add(
+                        "input",
+                        bb.partialJson.length() == 0
+                            ? new JsonObject()
+                            : GSON.fromJson(bb.partialJson.toString(), JsonObject.class));
+                  } catch (Exception ex) {
+                    obj.add("input", new JsonObject());
+                  }
+                }
+                content.add(obj);
+              });
+      return content;
+    }
+  }
+
+  /** Per-block accumulator (text for text blocks, partial JSON for tool_use). */
+  public static final class BlockBuilder {
+    final String blockType;
+    final StringBuilder text = new StringBuilder();
+    final StringBuilder partialJson = new StringBuilder();
+    String toolUseId;
+    String toolName;
+
+    BlockBuilder(String blockType) {
+      this.blockType = blockType;
+    }
   }
 
   /** Thrown when Anthropic returns 429. */

--- a/core/src/main/java/google/registry/ai/tools/AiTool.java
+++ b/core/src/main/java/google/registry/ai/tools/AiTool.java
@@ -1,0 +1,56 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+
+/**
+ * A tool Claude can invoke during an AI analysis conversation to fetch additional registry data.
+ *
+ * <p>Tools are registered in {@link AiToolRegistry} and surfaced to Anthropic's tool-use API. The
+ * orchestrator dispatches {@code tool_use} blocks back to the matching {@link AiTool#execute}
+ * implementation.
+ */
+public interface AiTool {
+
+  /** Stable tool name (matches what Claude will use in {@code tool_use} blocks). */
+  String name();
+
+  /** Short human description (used by Anthropic's tool selection logic). */
+  String description();
+
+  /** JSON-Schema input shape, conforming to Anthropic's tool input_schema requirements. */
+  JsonObject inputSchema();
+
+  /**
+   * Run the tool. Implementations are responsible for permission checks against {@code user} and
+   * for capping/truncating large result sets. Throw {@link AiToolException} for user-visible
+   * errors; the orchestrator will surface the message to Claude as an error tool_result.
+   */
+  JsonElement execute(JsonObject args, User user) throws AiToolException;
+
+  /** User-visible failure during tool execution (bad args, permission denied, etc.). */
+  class AiToolException extends Exception {
+    public AiToolException(String message) {
+      super(message);
+    }
+
+    public AiToolException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
+++ b/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
@@ -1,0 +1,74 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+
+/** Registry of {@link AiTool}s the AI orchestrator can dispatch to. */
+@Singleton
+public class AiToolRegistry {
+
+  private final ImmutableMap<String, AiTool> toolsByName;
+
+  @Inject
+  public AiToolRegistry(
+      QueryTransfersTool queryTransfers,
+      GetPricingRulesTool getPricingRules,
+      QueryRegistrarActivityTool queryRegistrarActivity,
+      QueryDomainDetailsTool queryDomainDetails) {
+    this(
+        ImmutableList.of(
+            queryTransfers, getPricingRules, queryRegistrarActivity, queryDomainDetails));
+  }
+
+  /** Test-friendly constructor. */
+  public AiToolRegistry(Iterable<AiTool> tools) {
+    ImmutableMap.Builder<String, AiTool> b = ImmutableMap.builder();
+    for (AiTool tool : tools) {
+      b.put(tool.name(), tool);
+    }
+    this.toolsByName = b.buildOrThrow();
+  }
+
+  public Optional<AiTool> get(String name) {
+    return Optional.ofNullable(toolsByName.get(name));
+  }
+
+  public ImmutableList<AiTool> all() {
+    return ImmutableList.copyOf(toolsByName.values());
+  }
+
+  /**
+   * The {@code tools} array Anthropic's Messages API expects: each entry has {@code name},
+   * {@code description}, and {@code input_schema} fields.
+   */
+  public JsonArray anthropicToolDefinitions() {
+    JsonArray arr = new JsonArray();
+    for (AiTool tool : toolsByName.values()) {
+      JsonObject def = new JsonObject();
+      def.addProperty("name", tool.name());
+      def.addProperty("description", tool.description());
+      def.add("input_schema", tool.inputSchema());
+      arr.add(def);
+    }
+    return arr;
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/GetPricingRulesTool.java
+++ b/core/src/main/java/google/registry/ai/tools/GetPricingRulesTool.java
@@ -1,0 +1,111 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+
+/**
+ * AI tool: returns active pricing rules for a TLD, optionally narrowed by registrar.
+ *
+ * <p>Wraps {@link ExploreDataSource#PRICING_RULES}.
+ */
+@Singleton
+public class GetPricingRulesTool implements AiTool {
+
+  private static final int MAX_ROWS = 200;
+
+  private static final List<String> COLUMNS =
+      List.of("registrar", "tld", "operation", "price_amount_sum", "currency");
+
+  @Inject
+  public GetPricingRulesTool() {}
+
+  @Override
+  public String name() {
+    return "get_pricing_rules";
+  }
+
+  @Override
+  public String description() {
+    return "Returns the current pricing rules (per-tld, per-registrar, per-operation prices). Use"
+        + " when the user asks about pricing, fees, or rate cards.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to query");
+    props.add("tld", tld);
+
+    JsonObject registrar = new JsonObject();
+    registrar.addProperty("type", "string");
+    registrar.addProperty(
+        "description", "Optional registrar id to narrow results to a single registrar");
+    props.add("registrar_id", registrar);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("tld");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String tld =
+        args.has("tld") && !args.get("tld").isJsonNull()
+            ? args.get("tld").getAsString()
+            : null;
+    if (tld == null || tld.isEmpty()) {
+      throw new AiToolException("Missing required arg: tld");
+    }
+    String registrarId =
+        args.has("registrar_id") && !args.get("registrar_id").isJsonNull()
+            ? args.get("registrar_id").getAsString()
+            : null;
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.PRICING_RULES.name(),
+            List.of("registrar", "tld", "operation"),
+            List.of("priceAmount"),
+            List.of(tld),
+            registrarId == null ? List.of() : List.of(registrarId),
+            List.of(),
+            List.of(),
+            null,
+            null);
+
+    return ToolJpaHelper.runExplore(
+        ExploreDataSource.PRICING_RULES, desc, effectiveTlds, COLUMNS, MAX_ROWS);
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryDomainDetailsTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryDomainDetailsTool.java
@@ -1,0 +1,168 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.ForeignKeyUtils;
+import google.registry.model.console.User;
+import google.registry.model.domain.Domain;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.persistence.Query;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * AI tool: returns full lifecycle details for a single domain — current registrar, status flags,
+ * creation/expiration timestamps, and recent history events.
+ */
+@Singleton
+public class QueryDomainDetailsTool implements AiTool {
+
+  private static final int MAX_HISTORY_EVENTS = 50;
+
+  private static final String HISTORY_QUERY =
+      """
+      SELECT dh.history_modification_time, dh.history_type, dh.history_registrar_id
+      FROM "DomainHistory" dh
+      WHERE dh.domain_repo_id = :repoId
+      ORDER BY dh.history_modification_time DESC
+      LIMIT :maxRows
+      """;
+
+  @Inject
+  public QueryDomainDetailsTool() {}
+
+  @Override
+  public String name() {
+    return "query_domain_details";
+  }
+
+  @Override
+  public String description() {
+    return "Returns full lifecycle details for a single domain: current registrar, status flags,"
+        + " creation/expiration timestamps, and recent history events. Use when the user asks"
+        + " about a specific domain by name.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject domainName = new JsonObject();
+    domainName.addProperty("type", "string");
+    domainName.addProperty("description", "Fully-qualified domain name (e.g. 'foo.example')");
+    props.add("domain_name", domainName);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("domain_name");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    if (!args.has("domain_name") || args.get("domain_name").isJsonNull()) {
+      throw new AiToolException("Missing required arg: domain_name");
+    }
+    String domainName = args.get("domain_name").getAsString();
+
+    return tm().transact(
+        () -> {
+          Optional<Domain> maybe =
+              ForeignKeyUtils.loadResourceByCacheIfEnabled(
+                  Domain.class, domainName, tm().getTransactionTime());
+          if (maybe.isEmpty()) {
+            JsonObject err = new JsonObject();
+            err.addProperty("error", "Domain not found: " + domainName);
+            return err;
+          }
+          Domain domain = maybe.get();
+
+          try {
+            ToolJpaHelper.assertTldAccess(user, domain.getTld());
+          } catch (AiToolException e) {
+            JsonObject err = new JsonObject();
+            err.addProperty("error", e.getMessage());
+            return err;
+          }
+
+          JsonObject out = new JsonObject();
+          out.addProperty("domain_name", domain.getDomainName());
+          out.addProperty("tld", domain.getTld());
+          out.addProperty("current_registrar", domain.getCurrentSponsorRegistrarId());
+          out.addProperty(
+              "creation_time",
+              domain.getCreationTime() == null ? null : domain.getCreationTime().toString());
+          out.addProperty(
+              "expiration_time",
+              domain.getRegistrationExpirationTime() == null
+                  ? null
+                  : domain.getRegistrationExpirationTime().toString());
+
+          JsonArray statusFlags = new JsonArray();
+          if (domain.getStatusValues() != null) {
+            for (Object s : domain.getStatusValues()) {
+              statusFlags.add(s.toString());
+            }
+          }
+          out.add("status_flags", statusFlags);
+
+          JsonArray history = new JsonArray();
+          Query q =
+              tm().getEntityManager()
+                  .createNativeQuery(HISTORY_QUERY)
+                  .setParameter("repoId", domain.getRepoId())
+                  .setParameter("maxRows", MAX_HISTORY_EVENTS);
+          @SuppressWarnings("unchecked")
+          List<Object[]> rows = q.getResultList();
+          for (Object[] row : rows) {
+            JsonObject ev = new JsonObject();
+            ev.addProperty(
+                "time",
+                row[0] == null ? null : normalizeTimestamp(row[0]));
+            ev.addProperty("type", row[1] == null ? null : row[1].toString());
+            ev.addProperty(
+                "registrar", row[2] == null ? null : row[2].toString());
+            history.add(ev);
+          }
+          out.add("history", history);
+          out.addProperty("historyCount", history.size());
+          out.addProperty("historyTruncated", history.size() >= MAX_HISTORY_EVENTS);
+          return out;
+        });
+  }
+
+  private static String normalizeTimestamp(Object val) {
+    if (val instanceof java.sql.Timestamp ts) {
+      return ts.toInstant().toString();
+    }
+    if (val instanceof java.time.OffsetDateTime odt) {
+      return odt.toInstant().toString();
+    }
+    if (val instanceof Instant inst) {
+      return inst.toString();
+    }
+    return val.toString();
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryRegistrarActivityTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryRegistrarActivityTool.java
@@ -1,0 +1,155 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AI tool: returns lifecycle activity (creates, renews, transfers, deletes) attributed to a
+ * specific registrar, optionally narrowed by TLD and date range.
+ *
+ * <p>Wraps {@link ExploreDataSource#DOMAIN_ACTIVITY}.
+ */
+@Singleton
+public class QueryRegistrarActivityTool implements AiTool {
+
+  private static final int MAX_ROWS = 500;
+
+  private static final List<String> COLUMNS =
+      List.of("period", "tld", "activity_type", "registrar", "count_value");
+
+  @Inject
+  public QueryRegistrarActivityTool() {}
+
+  @Override
+  public String name() {
+    return "query_registrar_activity";
+  }
+
+  @Override
+  public String description() {
+    return "Returns domain lifecycle activity (creates, renews, transfers, deletes) for a specific"
+        + " registrar, optionally filtered by TLD and date range. Use when the user asks about"
+        + " what a particular registrar has been doing.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject registrar = new JsonObject();
+    registrar.addProperty("type", "string");
+    registrar.addProperty("description", "Registrar id");
+    props.add("registrar_id", registrar);
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "Optional TLD to narrow results");
+    props.add("tld", tld);
+
+    JsonObject startDate = new JsonObject();
+    startDate.addProperty("type", "string");
+    startDate.addProperty("description", "Optional ISO date for range start");
+    props.add("start_date", startDate);
+
+    JsonObject endDate = new JsonObject();
+    endDate.addProperty("type", "string");
+    endDate.addProperty("description", "Optional ISO date for range end");
+    props.add("end_date", endDate);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("registrar_id");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String registrarId = stringArg(args, "registrar_id");
+    String tld = optionalString(args, "tld");
+    String startDate = optionalString(args, "start_date");
+    String endDate = optionalString(args, "end_date");
+
+    if (tld != null) {
+      ToolJpaHelper.assertTldAccess(user, tld);
+    }
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    List<String> dimensions = new ArrayList<>();
+    dimensions.add("period");
+    dimensions.add("tld");
+    dimensions.add("activity_type");
+    dimensions.add("registrar");
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.DOMAIN_ACTIVITY.name(),
+            dimensions,
+            List.of(),
+            tld == null ? List.of() : List.of(tld),
+            List.of(registrarId),
+            List.of(),
+            List.of(),
+            startDate,
+            endDate);
+
+    JsonObject result =
+        ToolJpaHelper.runExplore(
+            ExploreDataSource.DOMAIN_ACTIVITY, desc, effectiveTlds, COLUMNS, MAX_ROWS);
+
+    // Post-filter rows that don't match the registrar (DOMAIN_ACTIVITY doesn't natively filter
+    // by registrar in WHERE; the dimension is the current_sponsor_registrar_id).
+    JsonArray filtered = new JsonArray();
+    for (JsonElement row : result.getAsJsonArray("rows")) {
+      JsonObject obj = row.getAsJsonObject();
+      if (obj.has("registrar")
+          && !obj.get("registrar").isJsonNull()
+          && obj.get("registrar").getAsString().equals(registrarId)) {
+        filtered.add(obj);
+      }
+    }
+    result.add("rows", filtered);
+    result.addProperty("rowCount", filtered.size());
+    return result;
+  }
+
+  private static String stringArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return args.get(key).getAsString();
+  }
+
+  private static String optionalString(JsonObject args, String key) {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      return null;
+    }
+    String s = args.get(key).getAsString();
+    return s.isEmpty() ? null : s;
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryTransfersTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryTransfersTool.java
@@ -1,0 +1,124 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+
+/**
+ * AI tool: returns domain-level transfer activity for a TLD over a date range.
+ *
+ * <p>Wraps {@link ExploreDataSource#TRANSACTIONS} filtered to TRANSFER operations.
+ */
+@Singleton
+public class QueryTransfersTool implements AiTool {
+
+  private static final int MAX_ROWS = 100;
+
+  private static final List<String> COLUMNS =
+      List.of(
+          "timestamp",
+          "domain_name",
+          "tld",
+          "registrar",
+          "operation",
+          "amount",
+          "net_amount_to_registry",
+          "currency");
+
+  @Inject
+  public QueryTransfersTool() {}
+
+  @Override
+  public String name() {
+    return "query_transfers";
+  }
+
+  @Override
+  public String description() {
+    return "Returns the list of domain transfers for a TLD within a date range. Includes the"
+        + " timestamp, domain name, gaining registrar, and amount. Use when the user asks for"
+        + " specific domains that transferred or which registrars are involved in transfers.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to query (e.g. 'example')");
+    props.add("tld", tld);
+
+    JsonObject startDate = new JsonObject();
+    startDate.addProperty("type", "string");
+    startDate.addProperty("description", "ISO date or datetime, inclusive (e.g. '2026-04-01')");
+    props.add("start_date", startDate);
+
+    JsonObject endDate = new JsonObject();
+    endDate.addProperty("type", "string");
+    endDate.addProperty("description", "ISO date or datetime, inclusive (e.g. '2026-04-29')");
+    props.add("end_date", endDate);
+
+    schema.add("properties", props);
+    com.google.gson.JsonArray required = new com.google.gson.JsonArray();
+    required.add("tld");
+    required.add("start_date");
+    required.add("end_date");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String tld = stringArg(args, "tld");
+    String startDate = stringArg(args, "start_date");
+    String endDate = stringArg(args, "end_date");
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.TRANSACTIONS.name(),
+            List.of(),
+            List.of("amount"),
+            List.of(tld),
+            List.of(),
+            List.of("TRANSFER"),
+            List.of(),
+            startDate,
+            endDate);
+
+    return ToolJpaHelper.runExplore(
+        ExploreDataSource.TRANSACTIONS, desc, effectiveTlds, COLUMNS, MAX_ROWS);
+  }
+
+  private static String stringArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return args.get(key).getAsString();
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
+++ b/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
@@ -1,0 +1,237 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryBuilder;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import google.registry.ui.server.console.registrydash.RegistryDashAccessUtil;
+import jakarta.persistence.Query;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Shared helpers for AI tools that wrap the Explore query infrastructure. */
+final class ToolJpaHelper {
+
+  private ToolJpaHelper() {}
+
+  /** Resolves the user's TLD access scope, intersecting with a single requested TLD if given. */
+  static ImmutableSet<String> effectiveTlds(User user, String requestedTld) {
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+    ImmutableSet<String> accessTlds =
+        isAdmin
+            ? ImmutableSet.of()
+            : RegistryDashAccessUtil.getMappedTlds(user.getEmailAddress());
+    ImmutableSet<String> requested =
+        requestedTld == null || requestedTld.isEmpty()
+            ? ImmutableSet.of()
+            : ImmutableSet.of(requestedTld);
+    return RegistryDashAccessUtil.applyFilter(accessTlds, requested, isAdmin);
+  }
+
+  /** Asserts the requested TLD is in the user's access scope (admins bypass). */
+  static void assertTldAccess(User user, String tld) throws AiToolException {
+    if (tld == null || tld.isEmpty()) {
+      return;
+    }
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+    if (isAdmin) {
+      return;
+    }
+    ImmutableSet<String> accessTlds =
+        RegistryDashAccessUtil.getMappedTlds(user.getEmailAddress());
+    if (!accessTlds.contains(tld)) {
+      throw new AiToolException("Permission denied for tld: " + tld);
+    }
+  }
+
+  /**
+   * Runs an Explore-engine query and returns the rows as a JSON array of {@code {column: value}}
+   * objects.
+   */
+  static JsonObject runExplore(
+      ExploreDataSource source,
+      ExploreQueryDescriptor desc,
+      ImmutableSet<String> effectiveTlds,
+      List<String> columns,
+      int maxRows)
+      throws AiToolException {
+    source.validate(desc);
+    String sql = ExploreQueryBuilder.build(source, desc, effectiveTlds);
+
+    ExploreQueryDescriptor.ExploreFilters filters = desc.getFilters();
+    Instant startDate = null;
+    Instant endDate = null;
+    if (filters.getDateRange() != null) {
+      try {
+        startDate = parseDateTime(filters.getDateRange().getStart(), false);
+        endDate = parseDateTime(filters.getDateRange().getEnd(), true);
+      } catch (Exception e) {
+        throw new AiToolException("Invalid date_range: " + e.getMessage());
+      }
+    }
+    final Instant fStart = startDate;
+    final Instant fEnd = endDate;
+
+    return tm().transact(
+        () -> {
+          Query query = tm().getEntityManager().createNativeQuery(sql);
+          query.setParameter("maxRows", maxRows);
+          if (!effectiveTlds.isEmpty()) {
+            query.setParameter("tlds", effectiveTlds);
+          }
+          if (fStart != null) {
+            query.setParameter("startDate", fStart);
+          }
+          if (fEnd != null) {
+            query.setParameter("endDate", fEnd);
+          }
+          if (!filters.getOperations().isEmpty()) {
+            query.setParameter("operations", filters.getOperations());
+          }
+          if (!filters.getRegistrarIds().isEmpty()) {
+            query.setParameter("registrarIds", filters.getRegistrarIds());
+          }
+          if (!filters.getActivityTypes().isEmpty()) {
+            query.setParameter("activityTypes", filters.getActivityTypes());
+          }
+
+          @SuppressWarnings("unchecked")
+          List<Object> raw = query.getResultList();
+
+          JsonArray rows = new JsonArray();
+          for (Object r : raw) {
+            JsonObject rowObj = new JsonObject();
+            if (r instanceof Object[] arr) {
+              for (int i = 0; i < arr.length && i < columns.size(); i++) {
+                addNormalized(rowObj, columns.get(i), arr[i]);
+              }
+            } else if (!columns.isEmpty()) {
+              addNormalized(rowObj, columns.get(0), r);
+            }
+            rows.add(rowObj);
+          }
+
+          JsonObject out = new JsonObject();
+          out.add("rows", rows);
+          out.addProperty("rowCount", rows.size());
+          out.addProperty("truncated", rows.size() >= maxRows);
+          return out;
+        });
+  }
+
+  private static void addNormalized(JsonObject obj, String key, Object val) {
+    if (val == null) {
+      obj.add(key, com.google.gson.JsonNull.INSTANCE);
+      return;
+    }
+    String stringified = normalize(val);
+    if (val instanceof Number n) {
+      obj.addProperty(key, n);
+    } else if (val instanceof Boolean b) {
+      obj.addProperty(key, b);
+    } else {
+      obj.addProperty(key, stringified);
+    }
+  }
+
+  private static String normalize(Object val) {
+    if (val instanceof java.sql.Timestamp ts) {
+      return ts.toInstant().toString();
+    }
+    if (val instanceof java.time.OffsetDateTime odt) {
+      return odt.toInstant().toString();
+    }
+    if (val instanceof Instant inst) {
+      return inst.toString();
+    }
+    return val.toString();
+  }
+
+  static Instant parseDateTime(String value, boolean isEndDate) {
+    try {
+      return LocalDateTime.parse(value).toInstant(ZoneOffset.UTC);
+    } catch (DateTimeParseException e) {
+      LocalDate date = LocalDate.parse(value);
+      if (isEndDate) {
+        return date.plusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC);
+      }
+      return date.atStartOfDay().toInstant(ZoneOffset.UTC);
+    }
+  }
+
+  /**
+   * Builds an {@link ExploreQueryDescriptor} programmatically by serializing args to JSON and
+   * deserializing into the descriptor (whose fields are otherwise private with no setters).
+   */
+  static ExploreQueryDescriptor descriptor(
+      String dataSource,
+      List<String> dimensions,
+      List<String> metrics,
+      List<String> tlds,
+      List<String> registrarIds,
+      List<String> operations,
+      List<String> activityTypes,
+      String startDate,
+      String endDate) {
+    Map<String, Object> raw = new HashMap<>();
+    raw.put("dataSource", dataSource);
+    raw.put("dimensions", dimensions);
+    if (metrics != null && !metrics.isEmpty()) {
+      java.util.List<Map<String, String>> metricSpecs = new java.util.ArrayList<>();
+      for (String m : metrics) {
+        metricSpecs.add(Map.of("field", m, "aggregation", "sum"));
+      }
+      raw.put("metrics", metricSpecs);
+    }
+
+    Map<String, Object> filters = new HashMap<>();
+    if (tlds != null && !tlds.isEmpty()) {
+      filters.put("tlds", tlds);
+    }
+    if (registrarIds != null && !registrarIds.isEmpty()) {
+      filters.put("registrarIds", registrarIds);
+    }
+    if (operations != null && !operations.isEmpty()) {
+      filters.put("operations", operations);
+    }
+    if (activityTypes != null && !activityTypes.isEmpty()) {
+      filters.put("activityTypes", activityTypes);
+    }
+    if (startDate != null && endDate != null) {
+      filters.put("dateRange", Map.of("start", startDate, "end", endDate));
+    }
+    if (!filters.isEmpty()) {
+      raw.put("filters", filters);
+    }
+
+    com.google.gson.Gson gson = new com.google.gson.Gson();
+    return gson.fromJson(gson.toJsonTree(raw), ExploreQueryDescriptor.class);
+  }
+}

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1484,6 +1484,7 @@ public final class RegistryConfig {
       empty.version = "unset";
       empty.basePreamble = "";
       empty.responseGuidance = "";
+      empty.toolsHeader = "";
       empty.promptTypes = ImmutableMap.of();
       empty.pageHints = ImmutableMap.of();
       empty.menus = ImmutableMap.of();

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -272,6 +272,7 @@ public class RegistryConfigSettings {
     public String version;
     public String basePreamble;
     public String responseGuidance;
+    public String toolsHeader;
     public Map<String, String> promptTypes;
     public Map<String, String> pageHints;
     public Map<String, List<MenuItem>> menus;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -654,6 +654,9 @@ ai:
     version: "v1"
     basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
     responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
+    toolsHeader: |
+      ## Tools available
+      You have tools to fetch additional registry data when the user's question needs detail beyond the snapshot above. Use a tool when you need specific domains, registrar-level data, or pricing rules. Prefer specific tools over generic ones, and always cite the data the tool returned in your response.
     promptTypes:
       summarize_trends: "Summarize the key trends in this data. Identify growth or decline patterns, compare across TLDs, and highlight the most significant changes."
       find_anomalies: "Identify anomalies, outliers, and unusual patterns in this data. Look for unexpected spikes, drops, or ratios that warrant investigation."

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -17,11 +17,13 @@ package google.registry.ui.server.console.registrydash;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import google.registry.ai.AiAnalyzeRequest;
+import google.registry.ai.AiOrchestrator;
 import google.registry.ai.AiRateLimiter;
 import google.registry.ai.AnthropicClient;
 import google.registry.config.RegistryConfig.Config;
@@ -55,7 +57,7 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   private static final Gson PLAIN_GSON = new Gson();
 
   private final Optional<JsonElement> payload;
-  private final AnthropicClient anthropicClient;
+  private final AiOrchestrator orchestrator;
   private final AiRateLimiter rateLimiter;
   private final Gson gson;
   private final RegistryConfigSettings.Prompts promptConfig;
@@ -64,12 +66,12 @@ public class RegistryDashAiAction extends ConsoleApiAction {
   public RegistryDashAiAction(
       ConsoleApiParams consoleApiParams,
       @Parameter("aiAnalyzePayload") Optional<JsonElement> payload,
-      AnthropicClient anthropicClient,
+      AiOrchestrator orchestrator,
       AiRateLimiter rateLimiter,
       @Config("anthropicPromptConfig") RegistryConfigSettings.Prompts promptConfig) {
     super(consoleApiParams);
     this.payload = payload;
-    this.anthropicClient = anthropicClient;
+    this.orchestrator = orchestrator;
     this.rateLimiter = rateLimiter;
     this.gson = consoleApiParams.gson();
     this.promptConfig = promptConfig;
@@ -96,8 +98,9 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     String userEmail = user.getEmailAddress();
     if (!rateLimiter.tryAcquire(userEmail)) {
       consoleApiParams.response().setStatus(SC_TOO_MANY_REQUESTS);
-      consoleApiParams.response().setHeader(
-          "Retry-After", String.valueOf(rateLimiter.getRetryAfterSeconds(userEmail)));
+      consoleApiParams
+          .response()
+          .setHeader("Retry-After", String.valueOf(rateLimiter.getRetryAfterSeconds(userEmail)));
       setFailedResponse("Rate limit exceeded", SC_TOO_MANY_REQUESTS);
       return;
     }
@@ -106,13 +109,6 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     String model = request.model;
     String resolvedModel = AnthropicClient.resolveModelId(model != null ? model : "sonnet");
 
-    logger.atInfo().log(
-        "AI analysis request: user=%s, page=%s, promptType=%s, model=%s,"
-            + " promptVersion=%s, historySize=%d",
-        userEmail, request.page, request.promptType, resolvedModel,
-        promptConfig.version,
-        request.conversationHistory != null ? request.conversationHistory.size() : 0);
-
     try {
       PrintWriter writer = consoleApiParams.response().getWriter();
       consoleApiParams.response().setHeader("Content-Type", "text/event-stream");
@@ -120,17 +116,45 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       consoleApiParams.response().setHeader("Connection", "keep-alive");
       consoleApiParams.response().setStatus(200);
 
-      anthropicClient.streamMessage(
-          systemPrompt,
-          request.conversationHistory,
-          model,
-          chunk -> {
-            writer.write("data: " + PLAIN_GSON.toJson(new TextChunk(chunk)) + "\n\n");
-            writer.flush();
-          });
+      ImmutableList<String> toolsUsed =
+          orchestrator.run(
+              systemPrompt,
+              request.conversationHistory,
+              model,
+              user,
+              event -> {
+                JsonObject frame = new JsonObject();
+                if (event instanceof AiOrchestrator.TextEvent te) {
+                  frame.addProperty("type", "text");
+                  frame.addProperty("text", te.text());
+                } else if (event instanceof AiOrchestrator.ToolUseEvent tu) {
+                  frame.addProperty("type", "tool_use");
+                  frame.addProperty("tool", tu.tool());
+                  frame.add("args", tu.args());
+                } else if (event instanceof AiOrchestrator.ToolResultEvent tr) {
+                  frame.addProperty("type", "tool_result");
+                  frame.addProperty("tool", tr.tool());
+                  frame.addProperty("ok", tr.ok());
+                } else if (event instanceof AiOrchestrator.DoneEvent) {
+                  frame.addProperty("type", "done");
+                }
+                writer.write("data: " + PLAIN_GSON.toJson(frame) + "\n\n");
+                writer.flush();
+              });
 
       writer.write("data: [DONE]\n\n");
       writer.flush();
+
+      logger.atInfo().log(
+          "AI analysis request: user=%s, page=%s, promptType=%s, model=%s,"
+              + " promptVersion=%s, historySize=%d, toolsUsed=%s",
+          userEmail,
+          request.page,
+          request.promptType,
+          resolvedModel,
+          promptConfig.version,
+          request.conversationHistory != null ? request.conversationHistory.size() : 0,
+          toolsUsed);
 
     } catch (AnthropicClient.AnthropicRateLimitException e) {
       logger.atWarning().withCause(e).log("Anthropic rate limit hit");
@@ -146,13 +170,15 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     boolean isProduction = RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION;
     boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
 
-    if (!isProduction && isAdmin
-        && request.systemPrompt != null && !request.systemPrompt.isEmpty()) {
+    if (!isProduction
+        && isAdmin
+        && request.systemPrompt != null
+        && !request.systemPrompt.isEmpty()) {
       return request.systemPrompt;
     }
 
-    return getDefaultSystemPrompt(request.page, request.promptType, request.chartData,
-        request.metadata);
+    return getDefaultSystemPrompt(
+        request.page, request.promptType, request.chartData, request.metadata);
   }
 
   private String getDefaultSystemPrompt(
@@ -184,8 +210,10 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     sb.append("\n## Data\n```json\n").append(gson.toJson(chartData)).append("\n```\n\n");
     sb.append(promptConfig.responseGuidance);
 
+    if (promptConfig.toolsHeader != null && !promptConfig.toolsHeader.isEmpty()) {
+      sb.append("\n\n").append(promptConfig.toolsHeader);
+    }
+
     return sb.toString();
   }
-
-  private record TextChunk(String text) {}
 }

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -19,12 +19,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.TestLogHandler;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import google.registry.ai.AiOrchestrator;
 import google.registry.ai.AiRateLimiter;
-import google.registry.ai.AnthropicClient;
 import google.registry.config.RegistryConfigSettings;
 import google.registry.model.console.User;
 import google.registry.persistence.transaction.JpaTestExtensions;
@@ -57,7 +58,7 @@ class RegistryDashAiActionTest {
   final JpaTestExtensions.JpaIntegrationTestExtension jpa =
       new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
 
-  @Mock private AnthropicClient anthropicClient;
+  @Mock private AiOrchestrator orchestrator;
   private AiRateLimiter rateLimiter;
   private ConsoleApiParams params;
   private FakeResponse response;
@@ -74,21 +75,27 @@ class RegistryDashAiActionTest {
 
   @Test
   void testSuccess_streamsResponse() throws Exception {
-    String payload = "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
-        + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
-        + "{\"role\":\"user\",\"content\":\"Summarize trends\"}"
-        + "]}";
+    String payload =
+        "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+            + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
+            + "{\"role\":\"user\",\"content\":\"Summarize trends\"}"
+            + "]}";
     JsonElement json = JsonParser.parseString(payload);
 
-    doAnswer(invocation -> {
-      Consumer<String> onChunk = invocation.getArgument(3);
-      onChunk.accept("Hello ");
-      onChunk.accept("world");
-      return null;
-    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+    doAnswer(
+            invocation -> {
+              Consumer<AiOrchestrator.OrchestratorEvent> sink = invocation.getArgument(4);
+              sink.accept(new AiOrchestrator.TextEvent("Hello "));
+              sink.accept(new AiOrchestrator.TextEvent("world"));
+              sink.accept(new AiOrchestrator.DoneEvent());
+              return ImmutableList.of();
+            })
+        .when(orchestrator)
+        .run(any(), any(), any(), any(), any());
 
-    RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter, defaultPromptConfig());
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(200);
@@ -99,9 +106,43 @@ class RegistryDashAiActionTest {
   }
 
   @Test
+  void testToolUse_emitsToolFrames() throws Exception {
+    String payload =
+        "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+            + "\"chartData\":{},\"conversationHistory\":[]}";
+    JsonElement json = JsonParser.parseString(payload);
+
+    doAnswer(
+            invocation -> {
+              Consumer<AiOrchestrator.OrchestratorEvent> sink = invocation.getArgument(4);
+              com.google.gson.JsonObject args = new com.google.gson.JsonObject();
+              args.addProperty("tld", "example");
+              sink.accept(new AiOrchestrator.ToolUseEvent("query_transfers", args));
+              sink.accept(new AiOrchestrator.ToolResultEvent("query_transfers", true));
+              sink.accept(new AiOrchestrator.TextEvent("done"));
+              sink.accept(new AiOrchestrator.DoneEvent());
+              return ImmutableList.of("query_transfers");
+            })
+        .when(orchestrator)
+        .run(any(), any(), any(), any(), any());
+
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, rateLimiter, defaultPromptConfig());
+    action.run();
+
+    String written = response.getStringWriter().toString();
+    assertThat(written).contains("\"type\":\"tool_use\"");
+    assertThat(written).contains("\"tool\":\"query_transfers\"");
+    assertThat(written).contains("\"type\":\"tool_result\"");
+    assertThat(written).contains("\"ok\":true");
+  }
+
+  @Test
   void testBadRequest_missingPayload() {
-    RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.empty(), anthropicClient, rateLimiter, defaultPromptConfig());
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.empty(), orchestrator, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
@@ -109,12 +150,14 @@ class RegistryDashAiActionTest {
 
   @Test
   void testBadRequest_invalidPage() {
-    String payload = "{\"page\":\"invalid\",\"promptType\":\"summarize_trends\","
-        + "\"chartData\":{},\"conversationHistory\":[]}";
+    String payload =
+        "{\"page\":\"invalid\",\"promptType\":\"summarize_trends\","
+            + "\"chartData\":{},\"conversationHistory\":[]}";
     JsonElement json = JsonParser.parseString(payload);
 
-    RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter, defaultPromptConfig());
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, rateLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(400);
@@ -126,6 +169,7 @@ class RegistryDashAiActionTest {
     promptConfig.version = "test-v1";
     promptConfig.basePreamble = "PREAMBLE_FROM_TEST";
     promptConfig.responseGuidance = "GUIDANCE_FROM_TEST";
+    promptConfig.toolsHeader = "";
     promptConfig.promptTypes = ImmutableMap.of("summarize_trends", "BODY_FROM_TEST");
     promptConfig.pageHints = ImmutableMap.of("portfolio", "HINT_FROM_TEST");
     promptConfig.menus = ImmutableMap.of();
@@ -171,14 +215,16 @@ class RegistryDashAiActionTest {
   @Test
   void testRateLimitExceeded() {
     AiRateLimiter strictLimiter = new AiRateLimiter(clock, 0);
-    String payload = "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
-        + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
-        + "{\"role\":\"user\",\"content\":\"test\"}"
-        + "]}";
+    String payload =
+        "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+            + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
+            + "{\"role\":\"user\",\"content\":\"test\"}"
+            + "]}";
     JsonElement json = JsonParser.parseString(payload);
 
-    RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, strictLimiter, defaultPromptConfig());
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, strictLimiter, defaultPromptConfig());
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(429);
@@ -189,11 +235,13 @@ class RegistryDashAiActionTest {
     p.version = "test-v1";
     p.basePreamble = "You are an expert domain registry analyst.";
     p.responseGuidance = "Be concise.";
-    p.promptTypes = ImmutableMap.of(
-        "summarize_trends", "Summarize trends.",
-        "find_anomalies", "Find anomalies.",
-        "suggest_actions", "Suggest actions.",
-        "identify_risks", "Identify risks.");
+    p.toolsHeader = "";
+    p.promptTypes =
+        ImmutableMap.of(
+            "summarize_trends", "Summarize trends.",
+            "find_anomalies", "Find anomalies.",
+            "suggest_actions", "Suggest actions.",
+            "identify_risks", "Identify risks.");
     p.pageHints = ImmutableMap.of();
     p.menus = ImmutableMap.of();
     return p;
@@ -202,21 +250,27 @@ class RegistryDashAiActionTest {
   private String capturedSystemPrompt(
       RegistryConfigSettings.Prompts promptConfig, String page, String promptType)
       throws Exception {
-    String payload = String.format(
-        "{\"page\":\"%s\",\"promptType\":\"%s\",\"chartData\":{},\"conversationHistory\":[]}",
-        page, promptType);
+    String payload =
+        String.format(
+            "{\"page\":\"%s\",\"promptType\":\"%s\",\"chartData\":{},\"conversationHistory\":[]}",
+            page, promptType);
     JsonElement json = JsonParser.parseString(payload);
 
     String[] capturedPrompt = new String[1];
-    doAnswer(invocation -> {
-      capturedPrompt[0] = invocation.getArgument(0);
-      Consumer<String> onChunk = invocation.getArgument(3);
-      onChunk.accept("ok");
-      return null;
-    }).when(anthropicClient).streamMessage(any(), any(), any(), any());
+    doAnswer(
+            invocation -> {
+              capturedPrompt[0] = invocation.getArgument(0);
+              Consumer<AiOrchestrator.OrchestratorEvent> sink = invocation.getArgument(4);
+              sink.accept(new AiOrchestrator.TextEvent("ok"));
+              sink.accept(new AiOrchestrator.DoneEvent());
+              return ImmutableList.of();
+            })
+        .when(orchestrator)
+        .run(any(), any(), any(), any(), any());
 
-    RegistryDashAiAction action = new RegistryDashAiAction(
-        params, Optional.of(json), anthropicClient, rateLimiter, promptConfig);
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, rateLimiter, promptConfig);
     action.run();
     return capturedPrompt[0];
   }

--- a/docs/superpowers/plans/2026-04-29-registry-dash-ai-tier3.md
+++ b/docs/superpowers/plans/2026-04-29-registry-dash-ai-tier3.md
@@ -1,0 +1,80 @@
+# Registry Dashboard AI Tier 3 — Implementation Plan
+
+**Spec:** [`2026-04-29-registry-dash-ai-tier3-design.md`](../specs/2026-04-29-registry-dash-ai-tier3-design.md)
+
+## Step-by-step
+
+Each step is a logical commit. Tests are written alongside code (not strict RED-GREEN); compile-clean each step.
+
+### 1. AiTool interface + AiToolRegistry
+
+- **New** `core/src/main/java/google/registry/ai/tools/AiTool.java` — interface (`name`, `description`, `inputSchema`, `execute`).
+- **New** `core/src/main/java/google/registry/ai/tools/AiToolRegistry.java` — wraps `Map<String, AiTool>`, provides `get(name)`, `all()`, `anthropicToolDefinitions()` (returns the JSON array Anthropic wants).
+- **New** `AiToolRegistryTest.java` — register/lookup/missing.
+
+### 2. Tool implementations
+
+For each: implement `AiTool`, write a unit test that exercises the happy path + permission denial.
+
+- `QueryTransfersTool` — wraps `ExploreQueryBuilder` + `ExploreDataSource.TRANSACTIONS` filtered by `operation IN ('TRANSFER')`. Caps at 100 rows.
+- `GetPricingRulesTool` — wraps `ExploreQueryBuilder` + `ExploreDataSource.PRICING_RULES`.
+- `QueryRegistrarActivityTool` — wraps `ExploreQueryBuilder` + `ExploreDataSource.DOMAIN_ACTIVITY`, registrar-required filter.
+- `QueryDomainDetailsTool` — direct JPA: `ForeignKeyUtils.loadResourceByCacheIfEnabled(Domain.class, name, time)` + native query for `DomainHistory`. Caps at 50 history events.
+
+All four reuse `RegistryDashAccessUtil.applyFilter` for TLD scoping.
+
+### 3. Extend AnthropicClient
+
+- Add `streamMessage` overload accepting `List<JsonObject> tools` and a `Consumer<StreamEvent>` callback.
+- `StreamEvent` is a tagged union: `TextDelta`, `ToolUseBlock`, `MessageStop`.
+- The existing 4-arg overload forwards to the new one with `tools=List.of()`.
+- Test: feed canned SSE responses (text-only, tool-use, mixed) and assert callback invocations.
+
+### 4. AiOrchestrator
+
+- **New** `core/src/main/java/google/registry/ai/AiOrchestrator.java` — `run(systemPrompt, history, model, tools, registry, user, sink)`.
+- 5-turn cap. On `tool_use`, call `registry.get(name).execute(args, user)`, append `tool_result` block, recurse.
+- Test: orchestrator with stubbed `AnthropicClient` returning canned tool-use → text sequences.
+
+### 5. Wire into RegistryDashAiAction
+
+- Inject `AiOrchestrator` + `AiToolRegistry`.
+- Replace direct `streamMessage` call with `orchestrator.run(...)`.
+- Extend log line with `toolsUsed=%s` (tracked via the orchestrator's recorded tool list).
+- New SSE event types written to `PrintWriter`: `text`, `tool_use`, `tool_result`, `done`.
+
+### 6. Guice wiring
+
+- `AnthropicModule.provideAiToolRegistry(...)` registers all 4 tools.
+- `AnthropicModule.provideAiOrchestrator(client, registry)`.
+
+### 7. Config
+
+- `RegistryConfigSettings.Prompts.toolsHeader` (String).
+- `default-config.yaml ai.prompts.toolsHeader: "..."`.
+- `buildSystemPrompt` appends `toolsHeader` after `responseGuidance` when non-empty.
+
+### 8. Frontend
+
+- `ai-analysis.models.ts` — add `StreamEvent` discriminated union.
+- `ai-analysis.service.ts` — parse new SSE event types, emit through observable.
+- `ai-analysis-modal.component.ts/.html/.scss` — render in-flight tool indicator.
+
+### 9. Skill update
+
+- `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` — add Tier 3 test cases.
+
+### 10. Verify + PR
+
+- `./gradlew :core:compileJava :core:compileTestJava`
+- `./gradlew :core:test --tests "google.registry.ai.*"`
+- `cd console-webapp && nvm use 22.16.0 && npm run build`
+- Local E2E if helpers run cleanly.
+- Open PR against `master` referencing #114 and #121.
+
+## Out of scope
+
+- `run_explore_query` — see `.context/tier3-additional-tools-prompt.md` for follow-up.
+- Per-tool rate limiting — folded into existing analyze budget.
+- BigQuery audit export — log-line only for v1.
+- Mutation tools (would need separate confirmation UX).

--- a/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md
+++ b/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md
@@ -1,0 +1,243 @@
+# Registry Dashboard AI — Tier 3 Design (Agentic Tool Use)
+
+**Date:** 2026-04-29
+**Author:** torrey@unstoppabledomains.com
+**Status:** Implemented in PR — Tier 3 v1
+**Predecessors:** Tier 1 (PR #114), Tier 2 (PR #121)
+**Source design notes:** `docs/superpowers/specs/2026-04-24-registry-dash-ai-tiers-2-3-design.md`
+
+## Context
+
+Tier 1 sends Claude a static snapshot of the visible chart data and asks for analysis. Follow-up questions like "what specific domains transferred between which registrars?" fail because the detail isn't in the snapshot. Tier 3 lets Claude **call backend tools mid-conversation** to fetch the data it actually needs, using the Anthropic Messages API's tool-use feature.
+
+The backend defines tools, Claude decides when to invoke them, the backend executes and feeds results back. The multi-turn loop runs server-side; text deltas and tool-use signals are streamed to the frontend over the existing SSE channel.
+
+## Scope
+
+**v1 ships 4 tools:**
+
+| Tool | Wraps | Answers |
+|---|---|---|
+| `query_transfers` | `ExploreDataSource.TRANSACTIONS` filtered to operation=TRANSFER | "What domains transferred in the last 30 days for tld X?" |
+| `get_pricing_rules` | `ExploreDataSource.PRICING_RULES` | "What's the current pricing for tld X?" |
+| `query_registrar_activity` | `ExploreDataSource.DOMAIN_ACTIVITY` filtered by registrar | "What did registrar Y do last month?" |
+| `query_domain_details` | `Domain` JPA entity + `DomainHistory` join | "Tell me about example.tld" |
+
+**Deferred to a follow-up PR** (`run_explore_query`, `query_revenue_breakdown`, `query_renewal_rates`, `query_expiration_curve`, etc.) — see `.context/tier3-additional-tools-prompt.md`.
+
+## Architecture
+
+### Tool registry
+
+```
+core/src/main/java/google/registry/ai/tools/
+├── AiTool.java            // interface
+├── AiToolRegistry.java    // Map<name, AiTool>, Guice-bound
+├── QueryTransfersTool.java
+├── GetPricingRulesTool.java
+├── QueryRegistrarActivityTool.java
+└── QueryDomainDetailsTool.java
+```
+
+`AiTool`:
+```java
+public interface AiTool {
+  String name();
+  String description();
+  JsonObject inputSchema();   // Anthropic tool schema (JSON-Schema subset)
+  JsonElement execute(JsonObject args, User user);
+}
+```
+
+`AiToolRegistry` is a Guice-injected `Map<String, AiTool>` populated via `@IntoSet` (or an explicit `Multibinder`-style provider in `AnthropicModule`). Lookup by name; missing tool → `IllegalArgumentException` surfaced as a tool-use failure to Claude (the orchestrator turns it into a tool_result with `is_error: true`).
+
+### Multi-turn orchestrator
+
+`AiOrchestrator.run(systemPrompt, history, model, tools, eventSink)`:
+
+1. Send the conversation + tools list to Anthropic via `AnthropicClient`.
+2. As deltas stream in, emit `text` SSE events.
+3. When a `tool_use` block lands: emit a `tool_use` SSE event, call `registry.get(name).execute(args, user)`, emit a `tool_result` SSE event, append both as new conversation turns, send the request again.
+4. Repeat until Claude returns `stop_reason = "end_turn"` (or hits the **5-turn cap**).
+5. Emit `done`.
+
+### Anthropic client extension
+
+`AnthropicClient.streamMessage` gains an overload accepting `List<JsonObject> tools` and a richer callback that surfaces both text deltas and `tool_use` blocks. The current 4-arg overload remains and just forwards to the new one with `tools = List.of()`.
+
+### SSE event shape
+
+Frontend receives JSON-per-event:
+
+```
+data: {"type":"text","text":"Looking at the transfer activity..."}
+data: {"type":"tool_use","tool":"query_transfers","args":{"tld":"example","start_date":"2026-03-29","end_date":"2026-04-29"}}
+data: {"type":"tool_result","tool":"query_transfers","ok":true}
+data: {"type":"text","text":"In the last 30 days, 3 domains transferred..."}
+data: {"type":"done"}
+```
+
+(Result payload not sent in `tool_result` — only the boolean `ok`. Keeps the SSE stream cheap; result content is already baked into the next `text` from Claude.)
+
+## Backend Design
+
+### Permission model
+
+Every tool **must** verify the user can read the data it returns:
+
+- TLD-scoped tools: intersect requested TLD against `RegistryDashAccessUtil.getMappedTlds(user.email)` for non-admins (admins bypass per the existing pattern).
+- Registrar-scoped tools: same, against the user's registrar mapping.
+- `query_domain_details`: looks up the domain's TLD, then runs the same TLD scope check.
+
+Reuse `RegistryDashAccessUtil.applyFilter(accessScope, requestedFilter, isAdmin)` already in the registrydash codebase.
+
+### Rate limiting
+
+Folded into the existing per-user-per-hour `AiRateLimiter` budget. A single analyze request that fires 3 tool calls counts as 1 budget unit.
+
+### Logging
+
+Existing `logger.atInfo()` in `RegistryDashAiAction` extended:
+
+```java
+"AI analysis request: user=%s, page=%s, promptType=%s, model=%s, promptVersion=%s, historySize=%d, toolsUsed=%s"
+```
+
+`toolsUsed` = ordered list of tool names invoked (empty list if none).
+
+### Tool descriptions in prompt
+
+The system prompt receives a new section appended from `default-config.yaml`:
+
+```yaml
+ai:
+  prompts:
+    toolsHeader: |
+      ## Tools available
+      You have tools to fetch additional data. Prefer specific tools over general ones.
+      Use a tool when the user's question requires data not in the snapshot above.
+```
+
+The actual tool list (names + descriptions + schemas) is sent to Anthropic via the `tools` array, NOT inlined in the system prompt — Anthropic renders them on its end.
+
+## Frontend Design
+
+### `ai-analysis.service.ts`
+
+Parsing extended to handle the 3 new event types. The streamed observable now emits `{kind: 'text', text}`, `{kind: 'tool_use', tool, args}`, `{kind: 'tool_result', tool, ok}`, `{kind: 'done'}`.
+
+### Modal component
+
+A transient indicator appears below the streaming text when a `tool_use` event arrives:
+
+```
+🔍 Searching transfers…
+```
+
+The indicator clears on the matching `tool_result` event (matched by tool name; if multiple parallel tool calls appear the indicator shows each on its own line). Once cleared, the next text chunk continues normally.
+
+### Tool labels
+
+Hardcoded mapping in the modal:
+
+```ts
+const TOOL_LABELS: Record<string, string> = {
+  query_transfers: '🔍 Searching transfers',
+  get_pricing_rules: '💰 Looking up pricing',
+  query_registrar_activity: '📊 Checking registrar activity',
+  query_domain_details: '🔎 Looking up domain',
+};
+```
+
+## Data Payloads
+
+### `query_transfers`
+
+Args:
+```json
+{"tld": "example", "start_date": "2026-03-29", "end_date": "2026-04-29"}
+```
+
+Returns:
+```json
+{
+  "rows": [
+    {"timestamp": "2026-04-15T10:23:00Z", "domain_name": "foo.example",
+     "from_registrar": "OldRegistrar", "to_registrar": "NewRegistrar"}
+  ],
+  "rowCount": 1,
+  "truncated": false
+}
+```
+
+Capped at 100 rows; sets `truncated: true` when exceeded.
+
+### `get_pricing_rules`
+
+Args: `{"tld": "example", "registrar_id": "OldRegistrar"}` (registrar_id optional)
+
+Returns: `{"rules": [{"registrar": "...", "tld": "...", "operation": "CREATE", "priceAmount": 10.00}], "rowCount": N}`
+
+### `query_registrar_activity`
+
+Args: `{"registrar_id": "TheRegistrar", "tld": "example", "start_date": "...", "end_date": "..."}` (tld + dates optional)
+
+Returns: `{"rows": [{"period": "...", "tld": "...", "activity_type": "CREATE", "count": 42}], "rowCount": N, "truncated": bool}`
+
+### `query_domain_details`
+
+Args: `{"domain_name": "foo.example"}`
+
+Returns:
+```json
+{
+  "domain_name": "foo.example",
+  "tld": "example",
+  "current_registrar": "TheRegistrar",
+  "creation_time": "2024-01-01T00:00:00Z",
+  "expiration_time": "2027-01-01T00:00:00Z",
+  "status_flags": ["serverHold"],
+  "history": [
+    {"type": "DOMAIN_CREATE", "time": "...", "registrar": "..."},
+    {"type": "DOMAIN_TRANSFER_APPROVE", "time": "...", "registrar": "..."}
+  ]
+}
+```
+
+History capped at 50 most recent events.
+
+## New Files
+
+- `core/src/main/java/google/registry/ai/tools/AiTool.java`
+- `core/src/main/java/google/registry/ai/tools/AiToolRegistry.java`
+- `core/src/main/java/google/registry/ai/tools/QueryTransfersTool.java`
+- `core/src/main/java/google/registry/ai/tools/GetPricingRulesTool.java`
+- `core/src/main/java/google/registry/ai/tools/QueryRegistrarActivityTool.java`
+- `core/src/main/java/google/registry/ai/tools/QueryDomainDetailsTool.java`
+- `core/src/main/java/google/registry/ai/AiOrchestrator.java`
+- `core/src/test/java/google/registry/ai/tools/*Test.java` (4)
+- `core/src/test/java/google/registry/ai/AiOrchestratorTest.java`
+
+## Modified Files
+
+- `core/src/main/java/google/registry/ai/AnthropicClient.java` — add tools-aware overload
+- `core/src/main/java/google/registry/ai/AnthropicModule.java` — provide `AiToolRegistry` + `AiOrchestrator`
+- `core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java` — call orchestrator, log `toolsUsed`
+- `core/src/main/java/google/registry/config/RegistryConfigSettings.java` — `Prompts.toolsHeader` field
+- `core/src/main/java/google/registry/config/files/default-config.yaml` — `ai.prompts.toolsHeader`
+- `console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts` — parse new SSE event types
+- `console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts` — add `ToolUseEvent` etc.
+- `console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.{ts,html,scss}` — indicator UX
+
+## Verification
+
+End-to-end: `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh` + `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/seed-test-data.sh`. Open the analysis modal on the Domain Activity page, ask "what specific domains transferred in the last 30 days?". Confirm:
+
+- SSE stream emits a `tool_use` event for `query_transfers`.
+- Modal shows the transient "🔍 Searching transfers…" indicator that disappears when results arrive.
+- Final text references actual domain names from the seeded data.
+- Server log line includes `toolsUsed=[query_transfers]`.
+
+Targeted tests: `./gradlew :core:test --tests "google.registry.ai.*"` and `--tests "google.registry.ui.server.console.registrydash.RegistryDashAiActionTest"`.
+
+Frontend: `cd console-webapp && nvm use 22.16.0 && npm run build`.


### PR DESCRIPTION
## Summary

Tier 3 of the registry-dashboard AI feature. Lets Claude call backend tools mid-conversation via the Anthropic Messages API `tool_use` feature, so follow-up questions can fetch data not present in the page snapshot. Builds on Tier 1 (#114) and Tier 2 (#121, merged earlier today).

## What ships

- **`AiTool` interface + `AiToolRegistry`** — Dagger-bound registry of tools, exposes Anthropic-compatible `tools` array.
- **`AiOrchestrator`** — multi-turn loop: send → if Claude returns tool_use, execute via registry → append tool_result → resend → stop on text response or 5-turn cap. Streams `text`/`tool_use`/`tool_result`/`done` events to the caller.
- **`AnthropicClient.streamMessageWithTools`** — new tools-aware overload that yields a tagged-union `StreamEvent` (`TextDelta`/`ToolUseBlock`/`MessageStop`). The original 4-arg `streamMessage` is preserved for backwards compatibility.
- **4 tools (v1):**
  | Tool | Wraps | Answers |
  |---|---|---|
  | `query_transfers` | `ExploreDataSource.TRANSACTIONS` filtered to TRANSFER | "What domains transferred for tld X?" |
  | `get_pricing_rules` | `ExploreDataSource.PRICING_RULES` | "What's pricing for tld X?" |
  | `query_registrar_activity` | `ExploreDataSource.DOMAIN_ACTIVITY` filtered by registrar | "What did registrar Y do last month?" |
  | `query_domain_details` | `Domain` JPA + `DomainHistory` join | "Tell me about foo.example" |

  All four enforce TLD scope via `RegistryDashAccessUtil.applyFilter` for non-admin users; admins bypass.
- **`RegistryDashAiAction`** wires through the orchestrator instead of calling `AnthropicClient` directly. Log line extended with `toolsUsed=[…]`.
- **`default-config.yaml`** gets a new `ai.prompts.toolsHeader` field (and `RegistryConfigSettings.Prompts.toolsHeader`) for tool-selection hints in the system prompt.
- **Frontend:** `ai-analysis.service.ts` parses the new SSE event types; modal shows transient indicator lines (`🔍 Searching transfers…`) while tools are in flight, dismissed on `tool_result`.
- **Skill:** added Tier 3 test cases (18, 19, 20) to `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md`.

## Out of scope (deferred)

- `run_explore_query` — generic Explore-engine passthrough. Different design call about constrained vs. full schema, and adds expense risk. Spec'd in `.context/tier3-additional-tools-prompt.md` along with 14 other suggested follow-up tools (revenue breakdown, renewal rates, expiration curve, TLD/registrar config lookups, anomaly detection, etc.).
- Per-tool rate limiting — folded into existing per-user-per-hour analyze budget for v1.
- BigQuery audit export — log-line only for v1.
- Mutation tools — out of scope; Tier 3 is read-only by design.

## Deploy note

The new `ai.prompts.toolsHeader` field needs to land in `nomulus-secrets/.../default-config.yaml` for the deployed jar to see it (per the `cp -rf nomulus-secrets/* .` deploy step in `release/ud-cloudbuild-release-gke.yaml`). The local nomulus default-config.yaml in this PR is sufficient for unit tests.

## Test plan

- [x] `./gradlew :core:compileJava :core:compileTestJava` — green
- [x] `RegistryDashAiActionTest` — green (rewritten to mock `AiOrchestrator`)
- [x] `AnthropicClientTest` — green (after lazy `BlockBuilder` creation fix)
- [x] `cd console-webapp && npm run build` — green
- [ ] Local E2E via `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh`, ask a tool-triggering question, confirm `toolsUsed=[…]` in log + indicator UX in modal
- [ ] Cloud Build CI on this PR

## Spec / plan

- Spec: `docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md`
- Plan: `docs/superpowers/plans/2026-04-29-registry-dash-ai-tier3.md`
- Follow-up agent prompt for adding more tools: `.context/tier3-additional-tools-prompt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)