### PR TITLE
chore(registry-dash): bump prompt version to force fresh alpha build

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -651,7 +651,9 @@ ai:
   # Prompt content for the AI sparkle feature. Edit here to tweak prompts without redeploying
   # frontend code. The version field is logged on every request for observability.
   prompts:
-    version: "v1"
+    # Bumped 2026-04-29 to force a fresh nomulus image build for alpha-gke
+    # (prior deploy reused a cached image without the Tier 2 prompts content).
+    version: "v1.0.1"
     basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
     responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
     promptTypes:


### PR DESCRIPTION
## Summary
Tier 2 alpha deploy reused a cached image with stale baked yaml — \`/ai/prompts\` returns 404 on alpha for every page even after [secrets#76](https://github.com/unstoppabledomains/nomulus-secrets/pull/76) added the env yaml. The build trigger keys on nomulus commit SHA but the content of the image at this SHA was produced before #121 merged — likely a Gradle/Docker layer cache hit.

Bumping \`ai.prompts.version\` (v1 → v1.0.1) changes the source file contents, which guarantees the next build produces a fresh \`core.jar\` and the deployed pod's \`promptVersion=v1.0.1\` log line will confirm the new image rolled out.

## Test plan
- [x] Local diff is 1 file, 4 lines
- [ ] Merge + redeploy alpha-gke (this rebuild should NOT be skipped)
- [ ] curl alpha \`/ai/prompts?page=portfolio\` → 200 with version "v1.0.1"
- [ ] Server log shows \`promptVersion=v1.0.1\` on next analyze request

🤖 Generated with [Claude Code](https://claude.com/claude-code)