### PR TITLE
feat(registry-dash): AI Tier 3 batch 2 — registrar/tld/revenue/renewal/expiration tools

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -486,3 +486,22 @@
 - No more than 100 rows are sent in `chartData`.
 - The descriptor (`metadata.exploreDescriptor`) is present on the analyze request (DevTools → Network → request body) so a future backend follow-up can render it structurally.
 - No backend errors; existing sparkle button on every page still opens fresh chats independently.
+## Test 22: Tier 3 Batch 2 — get_registrar_details
+
+Goal: confirm get_registrar_details fires when the user asks about a specific registrar. Steps: open modal on Overview, ask "Tell me more about registrar TheRegistrar". Watch for the "Looking up registrar" indicator. Server log should include toolsUsed=[get_registrar_details]. Final text should cite type/state/allowedTlds.
+
+## Test 23: Tier 3 Batch 2 — get_tld_config
+
+Goal: confirm get_tld_config fires for "how is TLD X configured" questions. Steps: open modal on Overview, ask "How is the example TLD configured? Which registrars can sell on it?". Watch for the "Looking up TLD config" indicator. Final text should cite TLD state, currency, and at least one allowed registrar by name. TLDs with > 100 allowed registrars should mention truncation.
+
+## Test 24: Tier 3 Batch 2 — query_revenue_breakdown
+
+Goal: confirm query_revenue_breakdown fires for revenue drill-down questions. Steps: open modal on Financials > Registry Revenue, ask "Break down revenue for tld example over the last 6 months by operation". Repeat with "by period". Verify date ranges over 2 years are rejected by the tool, and group_by=registrar returns a tool error (not supported in v2).
+
+## Test 25: Tier 3 Batch 2 — query_renewal_rates
+
+Goal: confirm query_renewal_rates fires for renewal-trend questions. Steps: open modal on Overview, ask "What's the renewal rate for tld example over the last year?". Final text should cite a numeric renewal rate.
+
+## Test 26: Tier 3 Batch 2 — query_expiration_curve
+
+Goal: confirm query_expiration_curve fires for forward-looking expiration questions. Steps: open modal on Financials > Forecasting, ask "How many domains in tld example expire in the next 12 months, broken out by month?". Verify months_ahead outside [1, 60] is silently clamped.

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -80,4 +80,9 @@ export const TOOL_LABELS: Record<string, string> = {
   get_pricing_rules: '💰 Looking up pricing',
   query_registrar_activity: '📊 Checking registrar activity',
   query_domain_details: '🔎 Looking up domain',
+  get_registrar_details: '🏢 Looking up registrar',
+  get_tld_config: '⚙️ Looking up TLD config',
+  query_revenue_breakdown: '💵 Breaking down revenue',
+  query_renewal_rates: '🔄 Checking renewal rates',
+  query_expiration_curve: '📉 Mapping expirations',
 };

--- a/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
+++ b/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
@@ -33,10 +33,23 @@ public class AiToolRegistry {
       QueryTransfersTool queryTransfers,
       GetPricingRulesTool getPricingRules,
       QueryRegistrarActivityTool queryRegistrarActivity,
-      QueryDomainDetailsTool queryDomainDetails) {
+      QueryDomainDetailsTool queryDomainDetails,
+      GetRegistrarDetailsTool getRegistrarDetails,
+      GetTldConfigTool getTldConfig,
+      QueryRevenueBreakdownTool queryRevenueBreakdown,
+      QueryRenewalRatesTool queryRenewalRates,
+      QueryExpirationCurveTool queryExpirationCurve) {
     this(
         ImmutableList.of(
-            queryTransfers, getPricingRules, queryRegistrarActivity, queryDomainDetails));
+            queryTransfers,
+            getPricingRules,
+            queryRegistrarActivity,
+            queryDomainDetails,
+            getRegistrarDetails,
+            getTldConfig,
+            queryRevenueBreakdown,
+            queryRenewalRates,
+            queryExpirationCurve));
   }
 
   /** Test-friendly constructor. */

--- a/core/src/main/java/google/registry/ai/tools/GetRegistrarDetailsTool.java
+++ b/core/src/main/java/google/registry/ai/tools/GetRegistrarDetailsTool.java
@@ -1,0 +1,137 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.registrar.Registrar;
+import google.registry.model.registrar.RegistrarPoc;
+import google.registry.ui.server.console.registrydash.RegistryDashAccessUtil;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+
+/**
+ * AI tool: returns a registrar's profile (type, state, allowed TLDs, contacts).
+ *
+ * <p>Wraps the {@link Registrar} JPA entity. Permission: admin ({@link GlobalRole#FTE}) bypass;
+ * non-admins must be mapped (via RoRegistry) to a registry whose TLDs include at least one of the
+ * registrar's {@code allowedTlds}.
+ */
+@Singleton
+public class GetRegistrarDetailsTool implements AiTool {
+
+  @Inject
+  public GetRegistrarDetailsTool() {}
+
+  @Override
+  public String name() {
+    return "get_registrar_details";
+  }
+
+  @Override
+  public String description() {
+    return "Returns a registrar's profile: type (REAL/OTE/PDT/...), state (ACTIVE/SUSPENDED/...),"
+        + " IANA identifier, allowed TLDs, and contacts. Use when the user asks about a specific"
+        + " registrar by id or name (beyond what the chart snapshot already shows).";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject registrarId = new JsonObject();
+    registrarId.addProperty("type", "string");
+    registrarId.addProperty(
+        "description", "Registrar id (e.g. 'TheRegistrar') — the stable internal identifier");
+    props.add("registrar_id", registrarId);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("registrar_id");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    if (!args.has("registrar_id") || args.get("registrar_id").isJsonNull()) {
+      throw new AiToolException("Missing required arg: registrar_id");
+    }
+    String registrarId = args.get("registrar_id").getAsString();
+
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+    if (!isAdmin) {
+      ImmutableSet<String> mapped =
+          RegistryDashAccessUtil.getMappedRegistrarIds(user.getEmailAddress());
+      if (!mapped.contains(registrarId)) {
+        throw new AiToolException("Permission denied for registrar: " + registrarId);
+      }
+    }
+
+    Optional<Registrar> maybe = Registrar.loadByRegistrarId(registrarId);
+    if (maybe.isEmpty()) {
+      JsonObject err = new JsonObject();
+      err.addProperty("error", "Registrar not found: " + registrarId);
+      return err;
+    }
+    Registrar registrar = maybe.get();
+
+    JsonObject out = new JsonObject();
+    out.addProperty("registrar_id", registrar.getRegistrarId());
+    out.addProperty("registrar_name", registrar.getRegistrarName());
+    out.addProperty("type", registrar.getType() == null ? null : registrar.getType().toString());
+    out.addProperty("state", registrar.getState() == null ? null : registrar.getState().toString());
+    out.addProperty("iana_identifier", registrar.getIanaIdentifier());
+    out.addProperty("email_address", registrar.getEmailAddress());
+    out.addProperty("phone_number", registrar.getPhoneNumber());
+    out.addProperty("fax_number", registrar.getFaxNumber());
+    out.addProperty("whois_server", registrar.getWhoisServer());
+
+    JsonArray allowedTlds = new JsonArray();
+    for (String tld : registrar.getAllowedTlds()) {
+      allowedTlds.add(tld);
+    }
+    out.add("allowed_tlds", allowedTlds);
+
+    JsonArray rdapBaseUrls = new JsonArray();
+    for (String url : registrar.getRdapBaseUrls()) {
+      rdapBaseUrls.add(url);
+    }
+    out.add("rdap_base_urls", rdapBaseUrls);
+
+    JsonArray contacts = new JsonArray();
+    for (RegistrarPoc poc : registrar.getContacts()) {
+      JsonObject c = new JsonObject();
+      c.addProperty("name", poc.getName());
+      c.addProperty("email", poc.getEmailAddress());
+      c.addProperty("phone", poc.getPhoneNumber());
+      c.addProperty("fax", poc.getFaxNumber());
+      JsonArray types = new JsonArray();
+      poc.getTypes().forEach(t -> types.add(t.toString()));
+      c.add("types", types);
+      contacts.add(c);
+    }
+    out.add("contacts", contacts);
+
+    return out;
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/GetTldConfigTool.java
+++ b/core/src/main/java/google/registry/ai/tools/GetTldConfigTool.java
@@ -1,0 +1,152 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.model.registrar.Registrar;
+import google.registry.model.tld.Tld;
+import google.registry.ui.server.console.registrydash.RegistryDashAccessUtil;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+/**
+ * AI tool: returns a TLD's configuration (state, currency, premium/reserved list names, dns
+ * writers, and the registrars allowed to operate on it).
+ *
+ * <p>Wraps the {@link Tld} JPA entity. Permission: TLD-scoped via {@link
+ * ToolJpaHelper#assertTldAccess}. The "allowed registrars" listing reuses {@link
+ * RegistryDashAccessUtil#getRegistrarIdsForTlds} for the reverse lookup.
+ */
+@Singleton
+public class GetTldConfigTool implements AiTool {
+
+  static final int MAX_REGISTRARS = 100;
+
+  private final java.time.Clock clock;
+
+  @Inject
+  public GetTldConfigTool() {
+    this(java.time.Clock.systemUTC());
+  }
+
+  /** Test-friendly constructor. */
+  GetTldConfigTool(java.time.Clock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public String name() {
+    return "get_tld_config";
+  }
+
+  @Override
+  public String description() {
+    return "Returns a TLD's configuration: current state (PREDELEGATION/QUIET_PERIOD/"
+        + "GENERAL_AVAILABILITY), currency, premium/reserved list names, DNS writers, and the"
+        + " list of registrars allowed to operate on this TLD. Use when the user asks how a TLD"
+        + " is configured or which registrars can sell it.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to look up (e.g. 'example')");
+    props.add("tld", tld);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("tld");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    if (!args.has("tld") || args.get("tld").isJsonNull()) {
+      throw new AiToolException("Missing required arg: tld");
+    }
+    String tldStr = args.get("tld").getAsString();
+
+    ToolJpaHelper.assertTldAccess(user, tldStr);
+
+    Tld tld;
+    try {
+      tld = Tld.get(tldStr);
+    } catch (Tld.TldNotFoundException e) {
+      JsonObject err = new JsonObject();
+      err.addProperty("error", "TLD not found: " + tldStr);
+      return err;
+    }
+
+    JsonObject out = new JsonObject();
+    out.addProperty("tld", tld.getTldStr());
+    out.addProperty("tld_state", tld.getTldState(now()).toString());
+    out.addProperty("tld_type", tld.getTldType().toString());
+    out.addProperty("currency", tld.getCurrency() == null ? null : tld.getCurrency().toString());
+
+    Optional<String> premiumListName = tld.getPremiumListName();
+    out.addProperty("premium_list_name", premiumListName.orElse(null));
+
+    JsonArray reservedListNames = new JsonArray();
+    for (String name : tld.getReservedListNames()) {
+      reservedListNames.add(name);
+    }
+    out.add("reserved_list_names", reservedListNames);
+
+    JsonArray dnsWriters = new JsonArray();
+    for (String writer : tld.getDnsWriters()) {
+      dnsWriters.add(writer);
+    }
+    out.add("dns_writers", dnsWriters);
+
+    ImmutableSet<String> allowedIds =
+        RegistryDashAccessUtil.getRegistrarIdsForTlds(ImmutableSet.of(tldStr));
+    JsonArray allowedRegistrars = new JsonArray();
+    int included = 0;
+    for (String id : allowedIds) {
+      if (included >= MAX_REGISTRARS) {
+        break;
+      }
+      Optional<Registrar> registrar = Registrar.loadByRegistrarId(id);
+      JsonObject entry = new JsonObject();
+      entry.addProperty("registrar_id", id);
+      entry.addProperty(
+          "registrar_name", registrar.map(Registrar::getRegistrarName).orElse(null));
+      allowedRegistrars.add(entry);
+      included++;
+    }
+    out.add("allowed_registrars", allowedRegistrars);
+    out.addProperty("allowed_registrars_count", allowedIds.size());
+    out.addProperty("allowed_registrars_truncated", allowedIds.size() > MAX_REGISTRARS);
+
+    return out;
+  }
+
+  private DateTime now() {
+    return new DateTime(clock.instant().toEpochMilli(), DateTimeZone.UTC);
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryExpirationCurveTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryExpirationCurveTool.java
@@ -1,0 +1,130 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * AI tool: future-expiration curve for a TLD bucketed by month.
+ *
+ * <p>Wraps {@link ExploreDataSource#EXPIRATION_CURVE}. {@code months_ahead} is clamped to [1, 60].
+ */
+@Singleton
+public class QueryExpirationCurveTool implements AiTool {
+
+  static final int MAX_ROWS = 100;
+  static final int MIN_MONTHS = 1;
+  static final int MAX_MONTHS = 60;
+
+  private static final List<String> COLUMNS = List.of("tld", "month", "count_sum");
+
+  private final java.time.Clock clock;
+
+  @Inject
+  public QueryExpirationCurveTool() {
+    this(java.time.Clock.systemUTC());
+  }
+
+  /** Test-friendly constructor. */
+  QueryExpirationCurveTool(java.time.Clock clock) {
+    this.clock = clock;
+  }
+
+  @Override
+  public String name() {
+    return "query_expiration_curve";
+  }
+
+  @Override
+  public String description() {
+    return "Returns the count of domains in a TLD that expire in each upcoming month. Use when the"
+        + " user asks how many domains will expire in the next N months or wants to forecast"
+        + " renewals.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to query");
+    props.add("tld", tld);
+
+    JsonObject monthsAhead = new JsonObject();
+    monthsAhead.addProperty("type", "integer");
+    monthsAhead.addProperty(
+        "description", "How many months into the future to project (clamped to [1, 60])");
+    props.add("months_ahead", monthsAhead);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("tld");
+    required.add("months_ahead");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    if (!args.has("tld") || args.get("tld").isJsonNull()) {
+      throw new AiToolException("Missing required arg: tld");
+    }
+    String tld = args.get("tld").getAsString();
+    if (!args.has("months_ahead") || args.get("months_ahead").isJsonNull()) {
+      throw new AiToolException("Missing required arg: months_ahead");
+    }
+    int monthsAhead;
+    try {
+      monthsAhead = args.get("months_ahead").getAsInt();
+    } catch (NumberFormatException | UnsupportedOperationException e) {
+      throw new AiToolException("months_ahead must be an integer");
+    }
+    monthsAhead = Math.max(MIN_MONTHS, Math.min(MAX_MONTHS, monthsAhead));
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    LocalDate today = LocalDate.ofInstant(clock.instant(), java.time.ZoneOffset.UTC);
+    LocalDate endDate = today.plusMonths(monthsAhead);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.EXPIRATION_CURVE.name(),
+            List.of("tld", "month"),
+            List.of("count"),
+            List.of(tld),
+            List.of(),
+            List.of(),
+            List.of(),
+            today.toString(),
+            endDate.toString());
+
+    return ToolJpaHelper.runExplore(
+        ExploreDataSource.EXPIRATION_CURVE, desc, effectiveTlds, COLUMNS, MAX_ROWS);
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryRenewalRatesTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryRenewalRatesTool.java
@@ -1,0 +1,117 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+
+/**
+ * AI tool: returns renewal rate stats (renewals, deletions, rate) for a TLD over a date range.
+ *
+ * <p>Wraps {@link ExploreDataSource#RENEWAL_RATES}.
+ */
+@Singleton
+public class QueryRenewalRatesTool implements AiTool {
+
+  static final int MAX_ROWS = 100;
+
+  private static final List<String> COLUMNS =
+      List.of("tld", "renewals_sum", "deletions_sum", "renewalRate_sum");
+
+  @Inject
+  public QueryRenewalRatesTool() {}
+
+  @Override
+  public String name() {
+    return "query_renewal_rates";
+  }
+
+  @Override
+  public String description() {
+    return "Returns renewal-rate stats (renewals, deletions, computed rate) for a TLD over a date"
+        + " range. Use when the user asks how a TLD is performing on renewals or what the renewal"
+        + " rate trend looks like.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to query");
+    props.add("tld", tld);
+
+    JsonObject startDate = new JsonObject();
+    startDate.addProperty("type", "string");
+    startDate.addProperty("description", "ISO date inclusive");
+    props.add("start_date", startDate);
+
+    JsonObject endDate = new JsonObject();
+    endDate.addProperty("type", "string");
+    endDate.addProperty("description", "ISO date inclusive");
+    props.add("end_date", endDate);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("tld");
+    required.add("start_date");
+    required.add("end_date");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String tld = stringArg(args, "tld");
+    String startDate = stringArg(args, "start_date");
+    String endDate = stringArg(args, "end_date");
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.RENEWAL_RATES.name(),
+            List.of("tld"),
+            List.of("renewals", "deletions", "renewalRate"),
+            List.of(tld),
+            List.of(),
+            List.of(),
+            List.of(),
+            startDate,
+            endDate);
+
+    return ToolJpaHelper.runExplore(
+        ExploreDataSource.RENEWAL_RATES, desc, effectiveTlds, COLUMNS, MAX_ROWS);
+  }
+
+  private static String stringArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return args.get(key).getAsString();
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryRevenueBreakdownTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryRevenueBreakdownTool.java
@@ -1,0 +1,155 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * AI tool: revenue breakdown for a TLD over a date range, grouped by operation or period.
+ *
+ * <p>Wraps {@link ExploreDataSource#REVENUE}. Date range capped at 2 years to keep result sets and
+ * query times bounded.
+ */
+@Singleton
+public class QueryRevenueBreakdownTool implements AiTool {
+
+  static final int MAX_ROWS = 100;
+  private static final Period MAX_RANGE = Period.ofYears(2);
+  private static final ImmutableSet<String> ALLOWED_GROUP_BY =
+      ImmutableSet.of("operation", "period");
+
+  @Inject
+  public QueryRevenueBreakdownTool() {}
+
+  @Override
+  public String name() {
+    return "query_revenue_breakdown";
+  }
+
+  @Override
+  public String description() {
+    return "Returns revenue (amount and net-to-registry) for a TLD over a date range, grouped by"
+        + " 'operation' (CREATE/RENEW/TRANSFER/...) or 'period' (time bucket). Use when the user"
+        + " asks for revenue figures, what drove revenue, or revenue trends over time.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "TLD to query");
+    props.add("tld", tld);
+
+    JsonObject startDate = new JsonObject();
+    startDate.addProperty("type", "string");
+    startDate.addProperty("description", "ISO date inclusive (e.g. '2026-01-01')");
+    props.add("start_date", startDate);
+
+    JsonObject endDate = new JsonObject();
+    endDate.addProperty("type", "string");
+    endDate.addProperty("description", "ISO date inclusive (e.g. '2026-04-30')");
+    props.add("end_date", endDate);
+
+    JsonObject groupBy = new JsonObject();
+    groupBy.addProperty("type", "string");
+    groupBy.addProperty(
+        "description",
+        "Dimension to break revenue down by. Allowed: 'operation' (CREATE/RENEW/...) or 'period'"
+            + " (time bucket).");
+    JsonArray groupByEnum = new JsonArray();
+    ALLOWED_GROUP_BY.forEach(groupByEnum::add);
+    groupBy.add("enum", groupByEnum);
+    props.add("group_by", groupBy);
+
+    schema.add("properties", props);
+    JsonArray required = new JsonArray();
+    required.add("tld");
+    required.add("start_date");
+    required.add("end_date");
+    required.add("group_by");
+    schema.add("required", required);
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String tld = stringArg(args, "tld");
+    String startDateStr = stringArg(args, "start_date");
+    String endDateStr = stringArg(args, "end_date");
+    String groupBy = stringArg(args, "group_by");
+
+    if (!ALLOWED_GROUP_BY.contains(groupBy)) {
+      throw new AiToolException(
+          "Invalid group_by '" + groupBy + "'. Allowed: " + ALLOWED_GROUP_BY);
+    }
+
+    LocalDate start;
+    LocalDate end;
+    try {
+      start = LocalDate.parse(startDateStr);
+      end = LocalDate.parse(endDateStr);
+    } catch (DateTimeParseException e) {
+      throw new AiToolException("Invalid date: " + e.getMessage());
+    }
+    if (end.isBefore(start)) {
+      throw new AiToolException("end_date must be on or after start_date");
+    }
+    if (start.plus(MAX_RANGE).isBefore(end)) {
+      throw new AiToolException("Date range exceeds 2-year cap");
+    }
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.REVENUE.name(),
+            List.of(groupBy),
+            List.of("amount", "netAmountToRegistry"),
+            List.of(tld),
+            List.of(),
+            List.of(),
+            List.of(),
+            startDateStr,
+            endDateStr);
+
+    List<String> columns = List.of(groupBy, "amount_sum", "netAmountToRegistry_sum");
+    return ToolJpaHelper.runExplore(
+        ExploreDataSource.REVENUE, desc, effectiveTlds, columns, MAX_ROWS);
+  }
+
+  private static String stringArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return args.get(key).getAsString();
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
+++ b/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
@@ -103,22 +103,22 @@ final class ToolJpaHelper {
         () -> {
           Query query = tm().getEntityManager().createNativeQuery(sql);
           query.setParameter("maxRows", maxRows);
-          if (!effectiveTlds.isEmpty()) {
+          if (!effectiveTlds.isEmpty() && sql.contains(":tlds")) {
             query.setParameter("tlds", effectiveTlds);
           }
-          if (fStart != null) {
+          if (fStart != null && sql.contains(":startDate")) {
             query.setParameter("startDate", fStart);
           }
-          if (fEnd != null) {
+          if (fEnd != null && sql.contains(":endDate")) {
             query.setParameter("endDate", fEnd);
           }
-          if (!filters.getOperations().isEmpty()) {
+          if (!filters.getOperations().isEmpty() && sql.contains(":operations")) {
             query.setParameter("operations", filters.getOperations());
           }
-          if (!filters.getRegistrarIds().isEmpty()) {
+          if (!filters.getRegistrarIds().isEmpty() && sql.contains(":registrarIds")) {
             query.setParameter("registrarIds", filters.getRegistrarIds());
           }
-          if (!filters.getActivityTypes().isEmpty()) {
+          if (!filters.getActivityTypes().isEmpty() && sql.contains(":activityTypes")) {
             query.setParameter("activityTypes", filters.getActivityTypes());
           }
 

--- a/core/src/test/java/google/registry/ai/tools/GetRegistrarDetailsToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/GetRegistrarDetailsToolTest.java
@@ -1,0 +1,150 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.testing.DatabaseHelper.allowRegistrarAccess;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.model.registrydash.RoRegistry;
+import google.registry.model.registrydash.RoRegistryTld;
+import google.registry.model.registrydash.RoRegistryUser;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link GetRegistrarDetailsTool}. */
+class GetRegistrarDetailsToolTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-04-30T00:00:00.000Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private final GetRegistrarDetailsTool tool = new GetRegistrarDetailsTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    persistNewRegistrar("registrar1");
+    allowRegistrarAccess("registrar1", "tld");
+  }
+
+  private User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  private User createNonAdminUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  private void addMapping(String email, String registrarId, String tld) {
+    RoRegistry registry = new RoRegistry("registry-for-" + registrarId);
+    tm().transact(() -> tm().getEntityManager().persist(registry));
+    tm().transact(
+        () -> {
+          tm().getEntityManager().persist(new RoRegistryTld(registry.getId(), tld));
+          tm().getEntityManager().persist(new RoRegistryUser(registry.getId(), email));
+        });
+  }
+
+  private static JsonObject args(String registrarId) {
+    JsonObject obj = new JsonObject();
+    if (registrarId != null) {
+      obj.addProperty("registrar_id", registrarId);
+    }
+    return obj;
+  }
+
+  @Test
+  void execute_admin_returnsFullProfile() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("registrar1"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.get("registrar_id").getAsString()).isEqualTo("registrar1");
+    assertThat(obj.has("registrar_name")).isTrue();
+    assertThat(obj.has("type")).isTrue();
+    assertThat(obj.has("state")).isTrue();
+    assertThat(obj.has("allowed_tlds")).isTrue();
+    assertThat(obj.get("allowed_tlds").getAsJsonArray().get(0).getAsString()).isEqualTo("tld");
+    assertThat(obj.has("contacts")).isTrue();
+  }
+
+  @Test
+  void execute_mappedNonAdmin_returnsProfile() throws Exception {
+    User user = createNonAdminUser("ro@example.com");
+    addMapping("ro@example.com", "registrar1", "tld");
+
+    JsonElement result = tool.execute(args("registrar1"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.get("registrar_id").getAsString()).isEqualTo("registrar1");
+  }
+
+  @Test
+  void execute_unmappedNonAdmin_throwsPermissionDenied() {
+    User user = createNonAdminUser("stranger@example.com");
+
+    AiToolException ex =
+        assertThrows(AiToolException.class, () -> tool.execute(args("registrar1"), user));
+
+    assertThat(ex).hasMessageThat().contains("Permission denied for registrar");
+  }
+
+  @Test
+  void execute_unknownRegistrar_returnsErrorJson() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("does-not-exist"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("error")).isTrue();
+    assertThat(obj.get("error").getAsString()).contains("Registrar not found");
+  }
+
+  @Test
+  void execute_missingArg_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(AiToolException.class, () -> tool.execute(args(null), user));
+
+    assertThat(ex).hasMessageThat().contains("Missing required arg: registrar_id");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/GetTldConfigToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/GetTldConfigToolTest.java
@@ -1,0 +1,173 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.testing.DatabaseHelper.allowRegistrarAccess;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.model.registrydash.RoRegistry;
+import google.registry.model.registrydash.RoRegistryTld;
+import google.registry.model.registrydash.RoRegistryUser;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link GetTldConfigTool}. */
+class GetTldConfigToolTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-04-30T00:00:00.000Z"));
+  private final Clock javaClock =
+      Clock.fixed(Instant.parse("2026-04-30T00:00:00Z"), ZoneOffset.UTC);
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private final GetTldConfigTool tool = new GetTldConfigTool(javaClock);
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    persistNewRegistrar("registrar1");
+    allowRegistrarAccess("registrar1", "tld");
+  }
+
+  private User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  private User createNonAdminUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  private void addMapping(String email, String tld) {
+    RoRegistry registry = new RoRegistry("registry-for-" + email);
+    tm().transact(() -> tm().getEntityManager().persist(registry));
+    tm().transact(
+        () -> {
+          tm().getEntityManager().persist(new RoRegistryTld(registry.getId(), tld));
+          tm().getEntityManager().persist(new RoRegistryUser(registry.getId(), email));
+        });
+  }
+
+  private static JsonObject args(String tld) {
+    JsonObject obj = new JsonObject();
+    if (tld != null) {
+      obj.addProperty("tld", tld);
+    }
+    return obj;
+  }
+
+  @Test
+  void execute_admin_returnsConfig() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("tld"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.get("tld").getAsString()).isEqualTo("tld");
+    assertThat(obj.has("tld_state")).isTrue();
+    assertThat(obj.has("currency")).isTrue();
+    assertThat(obj.has("dns_writers")).isTrue();
+    assertThat(obj.has("allowed_registrars")).isTrue();
+    // createTld auto-grants TheRegistrar + NewRegistrar; setUp adds registrar1.
+    assertThat(obj.get("allowed_registrars_count").getAsInt()).isEqualTo(3);
+    assertThat(obj.get("allowed_registrars_truncated").getAsBoolean()).isFalse();
+  }
+
+  @Test
+  void execute_mappedNonAdmin_returnsConfig() throws Exception {
+    User user = createNonAdminUser("ro@example.com");
+    addMapping("ro@example.com", "tld");
+
+    JsonElement result = tool.execute(args("tld"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.get("tld").getAsString()).isEqualTo("tld");
+  }
+
+  @Test
+  void execute_unmappedNonAdmin_throwsPermissionDenied() {
+    User user = createNonAdminUser("stranger@example.com");
+
+    AiToolException ex =
+        assertThrows(AiToolException.class, () -> tool.execute(args("tld"), user));
+
+    assertThat(ex).hasMessageThat().contains("Permission denied for tld");
+  }
+
+  @Test
+  void execute_unknownTld_returnsErrorJson() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("nonexistent"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("error")).isTrue();
+    assertThat(obj.get("error").getAsString()).contains("TLD not found");
+  }
+
+  @Test
+  void execute_missingArg_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex = assertThrows(AiToolException.class, () -> tool.execute(args(null), user));
+
+    assertThat(ex).hasMessageThat().contains("Missing required arg: tld");
+  }
+
+  @Test
+  void execute_allowedRegistrarsCappedAt100() throws Exception {
+    User user = createFteUser("admin@example.com");
+    // setUp + createTld defaults give 3 registrars on "tld" already; add 109 more = 112 total.
+    for (int i = 2; i <= 110; i++) {
+      String registrarId = "registrar" + i;
+      persistNewRegistrar(registrarId);
+      allowRegistrarAccess(registrarId, "tld");
+    }
+
+    JsonElement result = tool.execute(args("tld"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.get("allowed_registrars").getAsJsonArray()).hasSize(100);
+    assertThat(obj.get("allowed_registrars_count").getAsInt()).isEqualTo(112);
+    assertThat(obj.get("allowed_registrars_truncated").getAsBoolean()).isTrue();
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryExpirationCurveToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryExpirationCurveToolTest.java
@@ -1,0 +1,130 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.allowRegistrarAccess;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link QueryExpirationCurveTool}. */
+class QueryExpirationCurveToolTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-04-30T00:00:00.000Z"));
+  private final Clock javaClock =
+      Clock.fixed(Instant.parse("2026-04-30T00:00:00Z"), ZoneOffset.UTC);
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private final QueryExpirationCurveTool tool = new QueryExpirationCurveTool(javaClock);
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    persistNewRegistrar("registrar1");
+    allowRegistrarAccess("registrar1", "tld");
+  }
+
+  private User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  private User createNonAdminUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  private static JsonObject args(String tld, Integer monthsAhead) {
+    JsonObject obj = new JsonObject();
+    if (tld != null) {
+      obj.addProperty("tld", tld);
+    }
+    if (monthsAhead != null) {
+      obj.addProperty("months_ahead", monthsAhead);
+    }
+    return obj;
+  }
+
+  @Test
+  void execute_admin_returnsRows() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("tld", 12), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("rows")).isTrue();
+    assertThat(obj.has("rowCount")).isTrue();
+  }
+
+  @Test
+  void execute_unmappedNonAdmin_throwsPermissionDenied() {
+    User user = createNonAdminUser("stranger@example.com");
+
+    AiToolException ex =
+        assertThrows(AiToolException.class, () -> tool.execute(args("tld", 12), user));
+
+    assertThat(ex).hasMessageThat().contains("Permission denied");
+  }
+
+  @Test
+  void execute_monthsAheadClamped_runsWithoutError() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    // Below min: 0 → clamped to 1.
+    tool.execute(args("tld", 0), user);
+    // Above max: 120 → clamped to 60.
+    tool.execute(args("tld", 120), user);
+  }
+
+  @Test
+  void execute_missingArg_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex1 =
+        assertThrows(AiToolException.class, () -> tool.execute(args(null, 12), user));
+    assertThat(ex1).hasMessageThat().contains("Missing required arg: tld");
+
+    AiToolException ex2 =
+        assertThrows(AiToolException.class, () -> tool.execute(args("tld", null), user));
+    assertThat(ex2).hasMessageThat().contains("Missing required arg: months_ahead");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryRenewalRatesToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryRenewalRatesToolTest.java
@@ -1,0 +1,119 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.allowRegistrarAccess;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link QueryRenewalRatesTool}. */
+class QueryRenewalRatesToolTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-04-30T00:00:00.000Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private final QueryRenewalRatesTool tool = new QueryRenewalRatesTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    persistNewRegistrar("registrar1");
+    allowRegistrarAccess("registrar1", "tld");
+  }
+
+  private User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  private User createNonAdminUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  private static JsonObject args(String tld, String startDate, String endDate) {
+    JsonObject obj = new JsonObject();
+    if (tld != null) {
+      obj.addProperty("tld", tld);
+    }
+    if (startDate != null) {
+      obj.addProperty("start_date", startDate);
+    }
+    if (endDate != null) {
+      obj.addProperty("end_date", endDate);
+    }
+    return obj;
+  }
+
+  @Test
+  void execute_admin_returnsRows() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("tld", "2026-01-01", "2026-04-30"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("rows")).isTrue();
+    assertThat(obj.has("rowCount")).isTrue();
+  }
+
+  @Test
+  void execute_unmappedNonAdmin_throwsPermissionDenied() {
+    User user = createNonAdminUser("stranger@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args("tld", "2026-01-01", "2026-04-30"), user));
+
+    assertThat(ex).hasMessageThat().contains("Permission denied");
+  }
+
+  @Test
+  void execute_missingArg_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args(null, "2026-01-01", "2026-04-30"), user));
+
+    assertThat(ex).hasMessageThat().contains("Missing required arg: tld");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryRevenueBreakdownToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryRevenueBreakdownToolTest.java
@@ -1,0 +1,171 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.allowRegistrarAccess;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link QueryRevenueBreakdownTool}. */
+class QueryRevenueBreakdownToolTest {
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2026-04-30T00:00:00.000Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  private final QueryRevenueBreakdownTool tool = new QueryRevenueBreakdownTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    persistNewRegistrar("registrar1");
+    allowRegistrarAccess("registrar1", "tld");
+  }
+
+  private User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  private User createNonAdminUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  private static JsonObject args(
+      String tld, String startDate, String endDate, String groupBy) {
+    JsonObject obj = new JsonObject();
+    if (tld != null) {
+      obj.addProperty("tld", tld);
+    }
+    if (startDate != null) {
+      obj.addProperty("start_date", startDate);
+    }
+    if (endDate != null) {
+      obj.addProperty("end_date", endDate);
+    }
+    if (groupBy != null) {
+      obj.addProperty("group_by", groupBy);
+    }
+    return obj;
+  }
+
+  @Test
+  void execute_admin_groupByOperation_returnsRows() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result =
+        tool.execute(args("tld", "2026-01-01", "2026-04-30", "operation"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("rows")).isTrue();
+    assertThat(obj.has("rowCount")).isTrue();
+    assertThat(obj.has("truncated")).isTrue();
+  }
+
+  @Test
+  void execute_admin_groupByPeriod_returnsRows() throws Exception {
+    User user = createFteUser("admin@example.com");
+
+    JsonElement result = tool.execute(args("tld", "2026-01-01", "2026-04-30", "period"), user);
+
+    JsonObject obj = result.getAsJsonObject();
+    assertThat(obj.has("rows")).isTrue();
+  }
+
+  @Test
+  void execute_unmappedNonAdmin_throwsPermissionDenied() {
+    User user = createNonAdminUser("stranger@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args("tld", "2026-01-01", "2026-04-30", "operation"), user));
+
+    assertThat(ex).hasMessageThat().contains("Permission denied");
+  }
+
+  @Test
+  void execute_dateRangeOver2Years_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args("tld", "2020-01-01", "2024-01-01", "operation"), user));
+
+    assertThat(ex).hasMessageThat().contains("2-year cap");
+  }
+
+  @Test
+  void execute_invalidGroupBy_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args("tld", "2026-01-01", "2026-04-30", "registrar"), user));
+
+    assertThat(ex).hasMessageThat().contains("Invalid group_by");
+  }
+
+  @Test
+  void execute_endBeforeStart_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args("tld", "2026-04-30", "2026-01-01", "operation"), user));
+
+    assertThat(ex).hasMessageThat().contains("end_date must be on or after start_date");
+  }
+
+  @Test
+  void execute_missingArg_throws() {
+    User user = createFteUser("admin@example.com");
+
+    AiToolException ex =
+        assertThrows(
+            AiToolException.class,
+            () -> tool.execute(args(null, "2026-01-01", "2026-04-30", "operation"), user));
+
+    assertThat(ex).hasMessageThat().contains("Missing required arg: tld");
+  }
+}

--- a/docs/superpowers/plans/2026-04-30-registry-dash-ai-tier3-tools-batch2.md
+++ b/docs/superpowers/plans/2026-04-30-registry-dash-ai-tier3-tools-batch2.md
@@ -1,0 +1,110 @@
+# TDD Plan — Tier 3 Tools Batch 2
+
+**Date:** 2026-04-30
+**Spec:** `docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-tools-batch2.md`
+**Tracking:** SRE-1941
+
+Each phase is one commit. Within a phase: write the test, watch it fail, write the implementation, watch it pass, refactor, commit. The test patterns mirror `RegistryDashPricingActionTest` (uses `JpaTestExtensions.JpaIntegrationTestExtension`, `RoRegistry` mapping helpers, FTE-vs-non-RO `User` fixtures).
+
+## Phase 1: `GetRegistrarDetailsTool`
+
+**Test cases** (`GetRegistrarDetailsToolTest.java`):
+
+1. `execute_admin_returnsFullProfile` — FTE user; persisted `Registrar` with `Type.REAL`, `State.ACTIVE`, `allowedTlds={"tld"}`; expects all fields populated.
+2. `execute_mappedNonAdmin_returnsFullProfile` — non-admin user mapped via RoRegistry to "registrar1"; expects success.
+3. `execute_unmappedNonAdmin_throwsPermissionDenied` — non-admin user with no mapping; `AiToolException` with "Permission denied for registrar".
+4. `execute_unknownRegistrar_returnsErrorJson` — admin asking for nonexistent ID; returns `{error: "Registrar not found: ..."}`.
+5. `execute_missingArg_throws` — `args = {}`; `AiToolException` "Missing required arg: registrar_id".
+
+**Implementation:**
+- Permission gate: admin bypass; otherwise `RegistryDashAccessUtil.getMappedRegistrarIds(user.email).contains(registrarId)`.
+- Load via `Registrar.loadByRegistrarId(id)`; if absent, return `{error: ...}`.
+- Build JSON with `registrar_id`, `registrar_name`, `type`, `state`, `iana_identifier`, `allowed_tlds`, `email_address`, `phone_number`, `fax_number`, `whois_server`, `rdap_base_urls`, `contacts[]` (each: `name`, `email`, `phone`, `types`).
+- Wire into `AiToolRegistry`.
+- Frontend: `get_registrar_details: '🏢 Looking up registrar'`.
+
+## Phase 2: `GetTldConfigTool`
+
+**Test cases:**
+
+1. `execute_admin_returnsConfig` — FTE user; `Tld` with state, currency, premium/reserved list names; expects all fields.
+2. `execute_mappedNonAdmin_returnsConfig` — non-admin user mapped to "tld" via RoRegistry; expects success.
+3. `execute_unmappedNonAdmin_throwsPermissionDenied` — non-admin asking about TLD not in mapping; `AiToolException`.
+4. `execute_unknownTld_returnsErrorJson` — admin asking for nonexistent TLD; returns `{error: ...}`.
+5. `execute_missingArg_throws`.
+6. `execute_allowedRegistrars_filteredAndCapped` — 101 registrars with `allowedTlds={"tld"}`; expects 100 in payload + `allowed_registrars_truncated: true`.
+
+**Implementation:**
+- Permission gate: `ToolJpaHelper.assertTldAccess(user, tld)`.
+- Load `Tld` via `Tld.get(tld)`; if absent, return `{error: ...}`.
+- Resolve `tldState` via `tld.getTldState(clock.nowUtc())` — needs a `Clock`.
+- Build JSON with current state, currency, premium/reserved list names, dnsWriters.
+- Allowed registrars: `RegistryDashAccessUtil.getRegistrarIdsForTlds(ImmutableSet.of(tld))`, then `Registrar.loadByRegistrarId` for each, cap at 100. Set `allowed_registrars_truncated`.
+- Inject `Clock` (constructor; tests use `FakeClock`).
+- Wire into `AiToolRegistry`.
+- Frontend: `get_tld_config: '⚙️ Looking up TLD config'`.
+
+## Phase 3: `QueryRevenueBreakdownTool`
+
+**Test cases:**
+
+1. `execute_admin_groupByOperation_returnsRows` — FTE user; seed billing events; expects rows with operation grouping.
+2. `execute_admin_groupByPeriod_returnsRows` — same seed; expects rows with period dimension.
+3. `execute_unmappedNonAdmin_throwsPermissionDenied`.
+4. `execute_dateRangeOver2Years_throws` — `start=2020-01-01, end=2023-01-01`; `AiToolException` with "Date range exceeds 2-year cap".
+5. `execute_invalidGroupBy_throws` — `group_by=registrar` (or any non-allowed value); `AiToolException`.
+6. `execute_missingArg_throws` — variants for each required arg.
+
+**Implementation:**
+- Permission gate: `ToolJpaHelper.assertTldAccess`.
+- Validate `group_by` ∈ {`operation`, `period`}.
+- Validate date range ≤ 2 years (use `LocalDate.parse` + `Period.between`).
+- Build descriptor: `metrics=[amount, netAmountToRegistry]`, `dimensions=[group_by]`, `filters={tlds:[tld], dateRange}`.
+- `ToolJpaHelper.runExplore(REVENUE, desc, effectiveTlds, columns, 100)`.
+- Wire + frontend label.
+
+## Phase 4: `QueryRenewalRatesTool`
+
+**Test cases:**
+
+1. `execute_admin_returnsRows` — FTE user; seed events; expects rows.
+2. `execute_unmappedNonAdmin_throwsPermissionDenied`.
+3. `execute_missingArg_throws` — variants.
+
+**Implementation:**
+- Permission gate: `ToolJpaHelper.assertTldAccess`.
+- Build descriptor: `metrics=[renewals, deletions, renewalRate]`, `dimensions=[tld]`, `filters={tlds:[tld], dateRange}`.
+- `runExplore` with `MAX_ROWS = 100`.
+- Wire + frontend label.
+
+## Phase 5: `QueryExpirationCurveTool`
+
+**Test cases:**
+
+1. `execute_admin_returnsRows` — FTE user; expect month-bucketed rows.
+2. `execute_unmappedNonAdmin_throwsPermissionDenied`.
+3. `execute_monthsAheadOutOfRange_clamps` — `months_ahead=0` → bumped to 1; `months_ahead=120` → clamped to 60. Verify by checking the dateRange filter we build.
+4. `execute_missingArg_throws`.
+
+**Implementation:**
+- Permission gate.
+- Clamp `months_ahead` to [1, 60].
+- Compute `start = clock.now()`, `end = start + months_ahead months`.
+- Build descriptor: `metrics=[count]`, `dimensions=[month]`, `filters={tlds:[tld], dateRange}`.
+- Inject `Clock`.
+- `runExplore` with `MAX_ROWS = 100`.
+- Wire + frontend label.
+
+## Phase 6: Test plan + verification
+
+1. Append 5 entries to `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md`.
+2. `./gradlew :core:compileJava :core:compileTestJava`
+3. `./gradlew :core:test --tests "google.registry.ai.tools.*"`
+4. `cd console-webapp && nvm use 22.16.0 && npm run build`
+5. Local E2E if stack is available.
+
+## Phase 7: PR
+
+1. Re-check `rabbit` and `hornbill` worktrees for committed changes; rebase if needed.
+2. Open PR against `master`. Title: `feat(registry-dash): AI Tier 3 batch 2 — registrar/tld/revenue/renewal/expiration tools`. Link SRE-1941.
+3. Update memory file `project_tier3_batch2_coordination.md` once any of the three lands.

--- a/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md
+++ b/docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md
@@ -23,7 +23,7 @@ The backend defines tools, Claude decides when to invoke them, the backend execu
 | `query_registrar_activity` | `ExploreDataSource.DOMAIN_ACTIVITY` filtered by registrar | "What did registrar Y do last month?" |
 | `query_domain_details` | `Domain` JPA entity + `DomainHistory` join | "Tell me about example.tld" |
 
-**Deferred to a follow-up PR** (`run_explore_query`, `query_revenue_breakdown`, `query_renewal_rates`, `query_expiration_curve`, etc.) — see `.context/tier3-additional-tools-prompt.md`.
+**Deferred to a follow-up PR** (`run_explore_query`, `query_revenue_breakdown`, `query_renewal_rates`, `query_expiration_curve`, etc.) — see `.context/tier3-followup-specific-tools-prompt.md`.
 
 ## Architecture
 

--- a/docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-tools-batch2.md
+++ b/docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-tools-batch2.md
@@ -1,0 +1,191 @@
+# Registry Dashboard AI — Tier 3 Tools Batch 2
+
+**Date:** 2026-04-30
+**Author:** torrey@unstoppabledomains.com
+**Status:** Implementing
+**Tracking:** SRE-1941
+**Predecessor:** Tier 3 v1 (PR #122) — see `2026-04-29-registry-dash-ai-tier3-design.md`
+**Source prompt:** `.context/tier3-followup-specific-tools-prompt.md`
+
+## Context
+
+Tier 3 v1 shipped 4 AI tools (`query_transfers`, `get_pricing_rules`, `query_registrar_activity`, `query_domain_details`). This batch adds 5 more tools that wrap existing query infrastructure. The orchestrator, `AiTool` interface, `ToolJpaHelper`, SSE event flow, and frontend wiring are unchanged — this is additive.
+
+## Scope
+
+| Tool | Wraps | Answers |
+|---|---|---|
+| `get_registrar_details` | `Registrar` JPA entity | "Tell me about registrar X" |
+| `get_tld_config` | `Tld` JPA entity + `RegistryDashAccessUtil.getRegistrarIdsForTlds` | "How is TLD example configured?" |
+| `query_revenue_breakdown` | `ExploreDataSource.REVENUE` | "Which registrar made us the most money last quarter?" |
+| `query_renewal_rates` | `ExploreDataSource.RENEWAL_RATES` | "What's the renewal rate for TLD example?" |
+| `query_expiration_curve` | `ExploreDataSource.EXPIRATION_CURVE` | "How many domains expire in the next 12 months?" |
+
+Each tool ships as its own commit (TDD: test first, then implementation), with frontend `TOOL_LABELS` updated and `AiToolRegistry` constructor extended.
+
+## Permission model
+
+Reuses Tier 3 v1's pattern verbatim (`ToolJpaHelper.assertTldAccess` for TLD-scoped tools). The one new permission shape is `get_registrar_details`, which is registrar-scoped:
+
+```
+isAdmin = user.userRoles.globalRole == FTE
+if !isAdmin:
+  mappedRegistrarIds = RegistryDashAccessUtil.getMappedRegistrarIds(user.email)
+  if registrar_id not in mappedRegistrarIds:
+    throw AiToolException("Permission denied for registrar: ...")
+```
+
+`get_tld_config` is TLD-scoped on the requested `tld`. The "allowed registrars" list it returns is also filtered to the user's access via `RegistryDashAccessUtil.getRegistrarIdsForTlds(ImmutableSet.of(tld))` — no separate check needed since the helper already scopes through `RoRegistry`.
+
+**PII decision:** Registrar contacts and addresses are returned as-is. The access check (`getMappedRegistrarIds`) ensures only users mapped to the registrar can see it; this is an internal tool and trusting the access check is consistent with the rest of the registry-dashboard surface.
+
+## Output caps
+
+- All Explore-engine tools: `MAX_ROWS = 100`, returns `{rows, rowCount, truncated}` via `ToolJpaHelper.runExplore`.
+- `get_registrar_details`: returns single object (no row cap needed); contacts list is bounded by the entity itself.
+- `get_tld_config`: allowed-registrars list capped at 100 entries (sets `allowedRegistrarsTruncated: true` if exceeded).
+- `query_revenue_breakdown`: rejects date ranges > 2 years.
+- `query_expiration_curve`: clamps `months_ahead` to [1, 60].
+
+## Tool specs
+
+### `get_registrar_details`
+
+**Args:** `{ registrar_id: string (required) }`
+
+**Returns:**
+```json
+{
+  "registrar_id": "TheRegistrar",
+  "registrar_name": "The Registrar",
+  "type": "REAL",
+  "state": "ACTIVE",
+  "iana_identifier": 9999,
+  "allowed_tlds": ["example", "test"],
+  "email_address": "abuse@example.com",
+  "phone_number": "+1.5551234567",
+  "fax_number": null,
+  "whois_server": "whois.example.com",
+  "rdap_base_urls": ["https://rdap.example.com/"],
+  "contacts": [
+    {"name": "Abuse Contact", "email": "abuse@example.com",
+     "phone": "+1.5551234567", "types": ["ABUSE"]}
+  ]
+}
+```
+
+### `get_tld_config`
+
+**Args:** `{ tld: string (required) }`
+
+**Returns:**
+```json
+{
+  "tld": "example",
+  "tld_state": "GENERAL_AVAILABILITY",
+  "currency": "USD",
+  "premium_list_name": "example_premium",
+  "reserved_list_names": ["example_reserved"],
+  "dns_writers": ["VoidDnsWriter"],
+  "allowed_registrars": [
+    {"registrar_id": "TheRegistrar", "registrar_name": "The Registrar"}
+  ],
+  "allowed_registrars_count": 1,
+  "allowed_registrars_truncated": false
+}
+```
+
+### `query_revenue_breakdown`
+
+**Args:** `{ tld: string (required), start_date: string (required), end_date: string (required), group_by: "registrar"|"operation"|"period" (required) }`
+
+**Validation:** `(end_date - start_date) <= 2 years`. Reject longer ranges with `AiToolException`.
+
+**Implementation:** Builds an `ExploreQueryDescriptor` for `REVENUE` with:
+- `metrics = [amount, netAmountToRegistry]`
+- `dimensions` chosen by `group_by`:
+  - `registrar` → not a dimension on REVENUE; downgrade by joining via `tld` and using `operation` plus a per-registrar split. Verify against `ExploreDataSource.REVENUE.allowedDimensions` = `{tld, operation, period}`. **`registrar` is not allowed** — see "Open question" below.
+  - `operation` → `[operation]`
+  - `period` → `[period]`
+
+**Returns:** `{rows: [{...}], rowCount, truncated}`.
+
+### `query_renewal_rates`
+
+**Args:** `{ tld: string (required), start_date: string (required), end_date: string (required) }`
+
+**Implementation:** Builds an `ExploreQueryDescriptor` for `RENEWAL_RATES`:
+- `metrics = [renewals, deletions, renewalRate]`
+- `dimensions = [tld]`
+- `filters = {tlds: [tld], dateRange: {start, end}}`
+
+**Returns:** `{rows: [{tld, renewals, deletions, renewalRate}], rowCount, truncated}`.
+
+### `query_expiration_curve`
+
+**Args:** `{ tld: string (required), months_ahead: integer (required, clamped to [1, 60]) }`
+
+**Implementation:** Computes `start_date = today`, `end_date = today + months_ahead months`, then builds an `ExploreQueryDescriptor` for `EXPIRATION_CURVE`:
+- `metrics = [count]`
+- `dimensions = [month]`
+- `filters = {tlds: [tld], dateRange}`
+
+**Returns:** `{rows: [{month, count}], rowCount, truncated}`.
+
+## Open question (resolved during implementation)
+
+`ExploreDataSource.REVENUE` declares `allowedDimensions = {tld, operation, period}` — no `registrar`. The prompt's `query_revenue_breakdown(group_by=registrar)` cannot be served by the existing Explore engine without extending `REVENUE`. **Resolution:** map `group_by=registrar` to a separate code path that runs a custom SQL via `ToolJpaHelper.runExplore`'s pattern, OR drop `registrar` from the `group_by` enum. We choose to drop it for v2 and document it as a future extension in the implementation plan, keeping `group_by` ∈ {operation, period} only. This keeps the PR scope tight and avoids touching `ExploreDataSource`.
+
+## Frontend
+
+`console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts` `TOOL_LABELS`:
+
+```ts
+get_registrar_details: '🏢 Looking up registrar',
+get_tld_config: '⚙️ Looking up TLD config',
+query_revenue_breakdown: '💵 Breaking down revenue',
+query_renewal_rates: '🔄 Checking renewal rates',
+query_expiration_curve: '📉 Mapping expirations',
+```
+
+## New files
+
+- `core/src/main/java/google/registry/ai/tools/GetRegistrarDetailsTool.java`
+- `core/src/main/java/google/registry/ai/tools/GetTldConfigTool.java`
+- `core/src/main/java/google/registry/ai/tools/QueryRevenueBreakdownTool.java`
+- `core/src/main/java/google/registry/ai/tools/QueryRenewalRatesTool.java`
+- `core/src/main/java/google/registry/ai/tools/QueryExpirationCurveTool.java`
+- `core/src/test/java/google/registry/ai/tools/GetRegistrarDetailsToolTest.java`
+- `core/src/test/java/google/registry/ai/tools/GetTldConfigToolTest.java`
+- `core/src/test/java/google/registry/ai/tools/QueryRevenueBreakdownToolTest.java`
+- `core/src/test/java/google/registry/ai/tools/QueryRenewalRatesToolTest.java`
+- `core/src/test/java/google/registry/ai/tools/QueryExpirationCurveToolTest.java`
+
+## Modified files
+
+- `core/src/main/java/google/registry/ai/tools/AiToolRegistry.java` — add 5 constructor params + append to `ImmutableList.of(...)`.
+- `console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts` — add 5 `TOOL_LABELS` entries.
+- `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` — add 5 new E2E tests.
+- `docs/superpowers/specs/2026-04-29-registry-dash-ai-tier3-design.md` — fix dangling reference to `tier3-additional-tools-prompt.md` (rename to `tier3-followup-specific-tools-prompt.md`).
+
+## Coordination
+
+Sibling worktrees in plan mode (no code yet) that will conflict on `AiToolRegistry`:
+- **rabbit** (`UDtorrey/tier3-followup-explore-add-to-chat`): "Add to AI Chat" feature.
+- **hornbill**: generic `run_explore_query` tool.
+
+Re-check both before opening PR; rebase mechanically if either lands first. Conflict surface is the `@Inject` constructor param list and the `ImmutableList.of(...)` body.
+
+## Verification
+
+- `./gradlew :core:compileJava :core:compileTestJava`
+- `./gradlew :core:test --tests "google.registry.ai.tools.*"`
+- Frontend: `cd console-webapp && nvm use 22.16.0 && npm run build`
+- Local E2E: start-local-stack + seed-test-data, fire 5 analyses (one per new tool), confirm `toolsUsed=[…]` in server log.
+
+## Anti-scope
+
+- No mutation tools.
+- No external service calls.
+- No `default-config.yaml` change.
+- No new `ExploreDataSource` enum values or new dimensions/metrics on existing sources.


### PR DESCRIPTION
## Summary

Adds 5 new AI tools to the registry-dashboard analysis modal, extending Tier 3 v1 (#122) with the next batch of specific data lookups. All read-only, all wrap existing query infrastructure.

| Tool | Wraps | Answers |
|---|---|---|
| `get_registrar_details` | `Registrar` JPA | "Tell me about registrar X" |
| `get_tld_config` | `Tld` JPA + `RegistryDashAccessUtil.getRegistrarIdsForTlds` | "How is TLD X configured?" |
| `query_revenue_breakdown` | `ExploreDataSource.REVENUE` | "Which operation drove revenue last quarter?" |
| `query_renewal_rates` | `ExploreDataSource.RENEWAL_RATES` | "What's the renewal rate for TLD X?" |
| `query_expiration_curve` | `ExploreDataSource.EXPIRATION_CURVE` | "How many domains expire in the next 12 months?" |

Linear: [SRE-1941](https://linear.app/unstoppable-domains/issue/SRE-1941/tier-3-batch-2-registrartldrevenuerenewalexpiration-tools-for-registry)
Spec: `docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-tools-batch2.md`

## Implementation notes

- **Permission model.** `get_registrar_details` is registrar-scoped via `RegistryDashAccessUtil.getMappedRegistrarIds`. The other four are TLD-scoped via `ToolJpaHelper.assertTldAccess`. Admins (`GlobalRole.FTE`) bypass, mirroring Tier 3 v1.
- **Output caps.** 100-row cap on Explore-engine tools. `get_tld_config` caps the allowed-registrars list at 100 with `allowed_registrars_truncated` flag. `query_revenue_breakdown` rejects ranges > 2 years. `query_expiration_curve` clamps `months_ahead` to [1, 60].
- **`group_by=registrar`** on `query_revenue_breakdown` is intentionally **not** supported — `ExploreDataSource.REVENUE.allowedDimensions` doesn't include it. Allowed values: `operation`, `period`.
- **Small infra change** in `ToolJpaHelper.runExplore`: only set named parameters that the source SQL actually references. This unblocks `EXPIRATION_CURVE`, whose SQL only consumes `:endDate` (not `:startDate`). Existing tools are unaffected — their SQL references both.
- **PII.** Per scope decision, registrar contacts are returned as-is. The access check is the boundary; this is an internal tool.

## Test plan

- [x] `./gradlew :core:standardTest --tests "google.registry.ai.tools.*"` — 25/25 passing (5+6+7+3+4)
- [x] `cd console-webapp && nvm use 22.16.0 && rtk npm run build` — clean (one pre-existing `financials.component.scss` budget warning unrelated to this PR)
- [x] `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` extended with Tests 21-25 (one E2E scenario per new tool)
- [ ] Local E2E with `ud-registry-dash:test-registry-dash` skill (start-local-stack → seed → fire 5 analyses → confirm `toolsUsed=[…]` in log) — **deferred to reviewer or follow-up; gradle harness validated unit-level behavior**

## Coordination

A sibling PR is being prepared in the **hornbill** worktree to add a generic `run_explore_query` tool. It will conflict with this PR on `AiToolRegistry`'s `@Inject` constructor and `ToolJpaHelper.java`. Resolution is mechanical (additional ctor parameter; merge unrelated guard clauses). Whoever merges second rebases.

A second sibling in **rabbit** is preparing an "Add explore results to AI Chat" feature; no overlap with this PR's surface.

## Anti-scope

- No mutation tools (Tier 3 stays read-only).
- No external service calls.
- No `default-config.yaml` change — `toolsHeader` is already generic enough.
- No new `ExploreDataSource` enum values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)