### PR TITLE
feat(registry-dash): "Add to AI Chat" from Data Exploration

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -441,3 +441,48 @@
 - No data from a TLD outside the user's access scope ever appears in the modal.
 - Final text is a clear "I don't have access" rather than a stack trace.
 
+
+
+---
+
+## Test 21: Add to AI Chat from Explore
+
+**Goal:** Verify the Data Exploration page can hand a query result off to the AI chat — either as a fresh chat or appended to an existing in-session conversation.
+
+### Prerequisites:
+- Same as Test 1 (dashboard access, local dev or alpha).
+- Test data seeded so a query produces non-empty results.
+
+### Steps — happy path "Add to current chat":
+1. Navigate to **Domain Activity** (`/#/registry-dash/domain-activity`).
+2. Open the AI modal via the sparkle button, choose "Summarize trends". Wait for the initial analysis.
+3. In the follow-up box, ask one or two questions (e.g. "What about TLD `example`?"). Confirm Claude responds.
+4. Close the modal.
+5. Navigate to **Data Exploration** (`/#/registry-dash/explore`).
+6. Configure a query (Source: Domain Activity, Metric: Count, Group By: TLD) and click **Run Query**.
+7. Verify the new **Add to AI Chat** button appears next to the run controls (icon: `auto_awesome`, label: "Add to AI Chat") and is **enabled**.
+8. Click **Add to AI Chat** — menu shows two items: `add` **Start new chat** and `forum` **Add to current chat** (enabled).
+9. Click **Add to current chat**.
+10. The AI modal opens reflecting the prior conversation (the questions from step 3 and Claude's responses are visible) **plus** a new user turn that contains a one-line descriptor summary, the JSON descriptor, and the first 100 rows.
+11. Wait for Claude's response. It should reference both the prior context (Domain Activity discussion) and the new Explore data.
+
+### Steps — happy path "Start new chat":
+1. From a fresh tab/session (no prior AI conversation), navigate to **Data Exploration**.
+2. Run a query (any).
+3. Click **Add to AI Chat** — menu shows **Start new chat** enabled and **Add to current chat** **disabled** (no conversation exists).
+4. Click **Start new chat**.
+5. The AI modal opens with no prior conversation; the seed user turn is the standard explore "Summarize trends" message and Claude's response references only the Explore data.
+6. Close and reopen via the existing sparkle button on the Explore page — confirm it now resumes the conversation rather than starting a new one (the modal shows the prior turns).
+
+### Edge cases:
+- Before any query is run on the Explore page, the **Add to AI Chat** button is **disabled**.
+- "Add to current chat" menu item is **disabled** when no AI conversation exists in the session (hard-refresh the page to clear in-memory state, then return to Explore — the menu item must be greyed out).
+- Run an Explore query that returns more than 100 rows. Verify the "Add to current chat" user turn explicitly notes truncation (e.g. "100 of 4213 rows attached") and that `chartData.rows.length === 100` in the network request payload (DevTools → Network → analyze).
+- Click "Start new chat" link in the modal header while an existing conversation is in progress — confirm the modal clears the prior history.
+
+### Expected:
+- Cross-page resume works: the prior conversation survives the modal close and the page navigation.
+- Claude's response in the resumed chat references both the prior context and the new Explore data.
+- No more than 100 rows are sent in `chartData`.
+- The descriptor (`metadata.exploreDescriptor`) is present on the analyze request (DevTools → Network → request body) so a future backend follow-up can render it structurally.
+- No backend errors; existing sparkle button on every page still opens fresh chats independently.

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.html
@@ -1,4 +1,16 @@
-<h2 mat-dialog-title>{{ data.title }}</h2>
+<div class="modal-title-row">
+  <h2 mat-dialog-title>{{ data.title }}</h2>
+  <button
+    mat-button
+    class="start-new-chat-btn"
+    type="button"
+    (click)="startNewChat()"
+    [disabled]="streaming()"
+    title="Discard current conversation and reseed">
+    <mat-icon>refresh</mat-icon>
+    Start new chat
+  </button>
+</div>
 <mat-dialog-content>
   <!-- Context line -->
   <div class="context-bar">

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.scss
@@ -2,6 +2,29 @@
   display: block;
 }
 
+.modal-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  h2 {
+    margin: 0;
+  }
+
+  .start-new-chat-btn {
+    font-size: 12px;
+    color: var(--ud-text-secondary);
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      margin-right: 2px;
+    }
+  }
+}
+
 .context-bar {
   display: flex;
   align-items: center;

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -54,7 +54,7 @@ export interface AiAnalysisModalData {
 })
 export class AiAnalysisModalComponent implements OnInit {
   selectedModel = signal<AiModelChoice>('sonnet');
-  conversationHistory = signal<ConversationMessage[]>([]);
+  conversationHistory = computed(() => this.aiService.conversationHistory());
   followUpText = '';
   showAdvanced = signal(false);
   editableSystemPrompt = '';
@@ -67,7 +67,7 @@ export class AiAnalysisModalComponent implements OnInit {
   constructor(
     public dialogRef: MatDialogRef<AiAnalysisModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: AiAnalysisModalData,
-    private aiService: AiAnalysisService,
+    public aiService: AiAnalysisService,
     private dashService: RegistryDashService,
   ) {
     if (data.savedModel) {
@@ -76,14 +76,15 @@ export class AiAnalysisModalComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.sendInitialRequest();
+    if (!this.aiService.hasActiveConversation()) {
+      this.sendInitialRequest();
+    }
   }
 
   private async sendInitialRequest() {
     const history: ConversationMessage[] = [
       { role: 'user', content: this.data.userMessage },
     ];
-    this.conversationHistory.set(history);
 
     await this.aiService.analyze({
       page: this.data.page,
@@ -94,13 +95,6 @@ export class AiAnalysisModalComponent implements OnInit {
       systemPrompt: this.showAdvanced() ? this.editableSystemPrompt : undefined,
       conversationHistory: history,
     });
-
-    if (!this.error()) {
-      this.conversationHistory.update(h => [
-        ...h,
-        { role: 'assistant', content: this.streamedText() },
-      ]);
-    }
   }
 
   async sendFollowUp() {
@@ -111,7 +105,6 @@ export class AiAnalysisModalComponent implements OnInit {
       ...this.conversationHistory(),
       { role: 'user', content: input },
     ];
-    this.conversationHistory.set(updatedHistory);
     this.followUpText = '';
 
     await this.aiService.analyze({
@@ -123,13 +116,11 @@ export class AiAnalysisModalComponent implements OnInit {
       systemPrompt: this.showAdvanced() ? this.editableSystemPrompt : undefined,
       conversationHistory: updatedHistory,
     });
+  }
 
-    if (!this.error()) {
-      this.conversationHistory.update(h => [
-        ...h,
-        { role: 'assistant', content: this.streamedText() },
-      ]);
-    }
+  startNewChat() {
+    this.aiService.resetConversation();
+    this.sendInitialRequest();
   }
 
   onModelChange(model: AiModelChoice) {

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -22,6 +22,18 @@ export interface AiAnalyzeRequest {
     | 'portfolio'
     | 'pricing';
   promptType: string;
+  /**
+   * Free-form context bag forwarded to the backend. Well-known keys:
+   * - `dateRange` (required): `{ start: string; end: string }`.
+   * - `granularity`: optional bucket size e.g. `'DAY'`.
+   * - `filteredTlds` (required): list of TLD names currently selected.
+   * - `filteredRegistrars` (required): list of registrar IDs currently selected.
+   * - `exploreDescriptor`: optional `ExploreQuery`-shaped object describing the
+   *   query that produced `chartData` when the request originated from the
+   *   Data Exploration page. Currently inlined into the user-turn text by the
+   *   frontend; the backend ignores unknown keys.
+   * Additional keys are allowed and silently passed through.
+   */
   metadata: {
     dateRange: { start: string; end: string };
     granularity?: string;
@@ -34,6 +46,9 @@ export interface AiAnalyzeRequest {
   systemPrompt?: string;
   conversationHistory: ConversationMessage[];
 }
+
+/** Maximum number of Explore rows attached to an AI request. */
+export const EXPLORE_AI_ROW_CAP = 100;
 
 export interface ConversationMessage {
   role: 'user' | 'assistant';

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.spec.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.spec.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TestBed } from '@angular/core/testing';
+import { AiAnalysisService } from './ai-analysis.service';
+import { AiAnalyzeRequest } from './ai-analysis.models';
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(encoder.encode(c));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+function baseRequest(): AiAnalyzeRequest {
+  return {
+    page: 'explore',
+    promptType: 'summarize_trends',
+    metadata: {
+      dateRange: { start: '', end: '' },
+      filteredTlds: [],
+      filteredRegistrars: [],
+    },
+    chartData: { rows: [], columns: [] },
+    conversationHistory: [],
+  };
+}
+
+describe('AiAnalysisService', () => {
+  let service: AiAnalysisService;
+  let fetchSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AiAnalysisService);
+    fetchSpy = spyOn(window, 'fetch');
+  });
+
+  it('hasActiveConversation is false initially', () => {
+    expect(service.hasActiveConversation()).toBeFalse();
+    expect(service.conversationHistory()).toEqual([]);
+  });
+
+  it('analyze appends assistant turn on success', async () => {
+    fetchSpy.and.resolveTo(
+      streamResponse([
+        'data: {"type":"text","text":"hello"}\n\n',
+        'data: {"type":"text","text":" world"}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    );
+    const req = baseRequest();
+    req.conversationHistory = [{ role: 'user', content: 'hi' }];
+    await service.analyze(req);
+
+    expect(service.error()).toBeNull();
+    const history = service.conversationHistory();
+    expect(history.length).toBe(2);
+    expect(history[0]).toEqual({ role: 'user', content: 'hi' });
+    expect(history[1].role).toBe('assistant');
+    expect(history[1].content).toBe('hello world');
+    expect(service.hasActiveConversation()).toBeTrue();
+    expect(service.lastRequest()?.page).toBe('explore');
+  });
+
+  it('analyze does not append assistant turn on error', async () => {
+    fetchSpy.and.resolveTo(new Response('boom', { status: 500 }));
+    const req = baseRequest();
+    req.conversationHistory = [{ role: 'user', content: 'hi' }];
+    await service.analyze(req);
+
+    expect(service.error()).toBeTruthy();
+    // user turn captured at the start; no assistant turn appended
+    expect(service.conversationHistory().length).toBe(1);
+    expect(service.lastRequest()).toBeNull();
+  });
+
+  it('appendUserTurnAndAnalyze appends one user turn and one assistant turn on success', async () => {
+    // Seed one prior round.
+    fetchSpy.and.resolveTo(
+      streamResponse(['data: {"type":"text","text":"first"}\n\n', 'data: [DONE]\n\n']),
+    );
+    const req = baseRequest();
+    req.conversationHistory = [{ role: 'user', content: 'q1' }];
+    await service.analyze(req);
+    expect(service.conversationHistory().length).toBe(2);
+
+    // Now follow up via appendUserTurnAndAnalyze.
+    fetchSpy.and.resolveTo(
+      streamResponse(['data: {"type":"text","text":"second"}\n\n', 'data: [DONE]\n\n']),
+    );
+    await service.appendUserTurnAndAnalyze('follow up', {
+      chartData: { rows: [], columns: [] },
+    });
+
+    const history = service.conversationHistory();
+    expect(history.length).toBe(4);
+    expect(history[2]).toEqual({ role: 'user', content: 'follow up' });
+    expect(history[3].role).toBe('assistant');
+    expect(history[3].content).toBe('second');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('appendUserTurnAndAnalyze sets error when no prior request and no overrides', async () => {
+    await service.appendUserTurnAndAnalyze('hi', { chartData: {} });
+    expect(service.error()).toBeTruthy();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('resetConversation clears state', async () => {
+    fetchSpy.and.resolveTo(
+      streamResponse(['data: {"type":"text","text":"x"}\n\n', 'data: [DONE]\n\n']),
+    );
+    const req = baseRequest();
+    req.conversationHistory = [{ role: 'user', content: 'hi' }];
+    await service.analyze(req);
+    expect(service.hasActiveConversation()).toBeTrue();
+
+    service.resetConversation();
+    expect(service.hasActiveConversation()).toBeFalse();
+    expect(service.conversationHistory()).toEqual([]);
+    expect(service.lastRequest()).toBeNull();
+    expect(service.streamedText()).toBe('');
+    expect(service.error()).toBeNull();
+    expect(service.toolsInFlight()).toEqual([]);
+    expect(service.toolsUsed()).toEqual([]);
+  });
+});

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Injectable, signal } from '@angular/core';
+import { Injectable, computed, signal } from '@angular/core';
 import {
   AiAnalyzeRequest,
   AiStreamFrame,
+  ConversationMessage,
   TOOL_LABELS,
   ToolInFlight,
 } from './ai-analysis.models';
+
+type LastRequestShape = Pick<
+  AiAnalyzeRequest,
+  'page' | 'promptType' | 'metadata' | 'systemPrompt' | 'model'
+>;
 
 @Injectable({ providedIn: 'root' })
 export class AiAnalysisService {
@@ -28,12 +34,30 @@ export class AiAnalysisService {
   toolsInFlight = signal<ToolInFlight[]>([]);
   toolsUsed = signal<string[]>([]);
 
+  conversationHistory = signal<ConversationMessage[]>([]);
+  lastRequest = signal<LastRequestShape | null>(null);
+  hasActiveConversation = computed(() => this.conversationHistory().length > 0);
+
+  resetConversation(): void {
+    this.conversationHistory.set([]);
+    this.lastRequest.set(null);
+    this.streamedText.set('');
+    this.error.set(null);
+    this.toolsInFlight.set([]);
+    this.toolsUsed.set([]);
+  }
+
   async analyze(request: AiAnalyzeRequest): Promise<void> {
     this.streaming.set(true);
     this.streamedText.set('');
     this.error.set(null);
     this.toolsInFlight.set([]);
     this.toolsUsed.set([]);
+
+    // The incoming request carries the authoritative conversation up to and
+    // including the new user turn. Capture it now so the modal renders the
+    // user turn immediately while the assistant response streams in.
+    this.conversationHistory.set([...request.conversationHistory]);
 
     try {
       const response = await fetch('/console-api/registry-dash/ai/analyze', {
@@ -113,12 +137,63 @@ export class AiAnalysisService {
           }
         }
       }
+
+      if (!this.error()) {
+        this.conversationHistory.update(h => [
+          ...h,
+          { role: 'assistant', content: accumulated },
+        ]);
+        this.lastRequest.set({
+          page: request.page,
+          promptType: request.promptType,
+          metadata: request.metadata,
+          systemPrompt: request.systemPrompt,
+          model: request.model,
+        });
+      }
     } catch (e) {
       this.error.set('Response interrupted. Try again?');
     } finally {
       this.streaming.set(false);
       this.toolsInFlight.set([]);
     }
+  }
+
+  async appendUserTurnAndAnalyze(
+    content: string,
+    overrides: Partial<Omit<AiAnalyzeRequest, 'conversationHistory'>>,
+  ): Promise<void> {
+    const last = this.lastRequest();
+    const page = overrides.page ?? last?.page;
+    const promptType = overrides.promptType ?? last?.promptType;
+    if (!page || !promptType) {
+      this.error.set('Cannot continue conversation: no prior request context.');
+      return;
+    }
+
+    const metadata = overrides.metadata ?? last?.metadata ?? {
+      dateRange: { start: '', end: '' },
+      filteredTlds: [],
+      filteredRegistrars: [],
+    };
+    const systemPrompt = overrides.systemPrompt ?? last?.systemPrompt;
+    const model = overrides.model ?? last?.model;
+    const chartData = overrides.chartData;
+
+    const newHistory: ConversationMessage[] = [
+      ...this.conversationHistory(),
+      { role: 'user', content },
+    ];
+
+    await this.analyze({
+      page,
+      promptType,
+      metadata,
+      chartData,
+      model,
+      systemPrompt,
+      conversationHistory: newHistory,
+    });
   }
 }
 

--- a/console-webapp/src/app/registry-dash/explore/explore.component.html
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.html
@@ -28,6 +28,27 @@
       <mat-spinner diameter="16"></mat-spinner>
       Running...
     </span>
+    <button
+      mat-stroked-button
+      class="add-to-ai-chat-btn"
+      [matMenuTriggerFor]="addAiMenu"
+      [disabled]="!result()">
+      <mat-icon>auto_awesome</mat-icon>
+      Add to AI Chat
+    </button>
+    <mat-menu #addAiMenu="matMenu">
+      <button mat-menu-item (click)="addToNewChat()">
+        <mat-icon>add</mat-icon>
+        <span>Start new chat</span>
+      </button>
+      <button
+        mat-menu-item
+        (click)="addToCurrentChat()"
+        [disabled]="!aiService.hasActiveConversation()">
+        <mat-icon>forum</mat-icon>
+        <span>Add to current chat</span>
+      </button>
+    </mat-menu>
   </div>
 
   <!-- Result Info -->

--- a/console-webapp/src/app/registry-dash/explore/explore.component.spec.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.spec.ts
@@ -1,0 +1,209 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { signal, computed, Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { ExploreComponent } from './explore.component';
+import { ExploreService } from './explore.service';
+import { ExploreResult } from './explore.models';
+import { RegistryDashService } from '../registry-dash.service';
+import { AiAnalysisService } from '../ai/ai-analysis.service';
+import { ExploreBuilderComponent } from './explore-builder/explore-builder.component';
+import { ExploreChartComponent } from './explore-chart/explore-chart.component';
+import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
+
+@Component({ selector: 'app-explore-builder', standalone: true, template: '' })
+class StubExploreBuilderComponent {
+  @Input() query: any;
+  @Input() chartType: any;
+}
+
+@Component({ selector: 'app-explore-chart', standalone: true, template: '' })
+class StubExploreChartComponent {
+  @Input() result: any;
+  @Input() chartType: any;
+  @Input() dimensions: any;
+  @Input() metricColumn: any;
+}
+
+@Component({ selector: 'app-ai-sparkle-button', standalone: true, template: '' })
+class StubAiSparkleButtonComponent {
+  @Input() page: any;
+  @Input() prompts: any;
+  @Input() chartData: any;
+  @Input() isAdmin: any;
+}
+
+describe('ExploreComponent', () => {
+  let fixture: ComponentFixture<ExploreComponent>;
+  let component: ExploreComponent;
+  let exploreServiceStub: any;
+  let dashServiceStub: any;
+  let aiServiceStub: any;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
+
+  const sampleResult: ExploreResult = {
+    columns: ['tld', 'count_sum'],
+    rows: [
+      { tld: 'modem', count_sum: 100 },
+      { tld: 'nft', count_sum: 50 },
+    ],
+    truncated: false,
+    totalRows: 2,
+  };
+
+  beforeEach(async () => {
+    exploreServiceStub = {
+      result: signal<ExploreResult | undefined>(undefined),
+      loading: signal(false),
+      error: signal<string | undefined>(undefined),
+      pendingQuery: signal(null),
+      explore: jasmine.createSpy('explore').and.returnValue(of(sampleResult)),
+    };
+    dashServiceStub = {
+      hasActiveFilters: () => false,
+      selectedTlds: signal<string[]>([]),
+      selectedRegistrarIds: signal<string[]>([]),
+      selectedTimeRange: signal('7d'),
+      selectedRangeConfig: computed(() => ({ lookbackHours: 168, granularity: 'day' })),
+      settingsCache: signal<Record<string, any>>({}),
+    };
+    aiServiceStub = {
+      conversationHistory: signal<any[]>([]),
+      hasActiveConversation: signal(false),
+      resetConversation: jasmine.createSpy('resetConversation'),
+      appendUserTurnAndAnalyze: jasmine.createSpy('appendUserTurnAndAnalyze')
+        .and.returnValue(Promise.resolve()),
+    };
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+
+    await TestBed.configureTestingModule({
+      imports: [ExploreComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ExploreService, useValue: exploreServiceStub },
+        { provide: RegistryDashService, useValue: dashServiceStub },
+        { provide: AiAnalysisService, useValue: aiServiceStub },
+        { provide: MatDialog, useValue: dialogSpy },
+      ],
+    })
+      .overrideComponent(ExploreComponent, {
+        remove: {
+          imports: [
+            ExploreBuilderComponent,
+            ExploreChartComponent,
+            AiSparkleButtonComponent,
+          ],
+        },
+        add: {
+          imports: [
+            StubExploreBuilderComponent,
+            StubExploreChartComponent,
+            StubAiSparkleButtonComponent,
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ExploreComponent);
+    component = fixture.componentInstance;
+  });
+
+  function findAddToAiBtn(): HTMLButtonElement | null {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button');
+    return Array.from(buttons).find(b =>
+      b.textContent?.includes('Add to AI Chat'),
+    ) as HTMLButtonElement | null;
+  }
+
+  it('Add to AI Chat button is disabled when there is no result', () => {
+    fixture.detectChanges();
+    const btn = findAddToAiBtn();
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBeTrue();
+  });
+
+  it('Add to AI Chat button is enabled when result is set', () => {
+    exploreServiceStub.result.set(sampleResult);
+    fixture.detectChanges();
+    const btn = findAddToAiBtn();
+    expect(btn).not.toBeNull();
+    expect(btn!.disabled).toBeFalse();
+  });
+
+  it('addToNewChat resets the conversation and opens the dialog with exploreDescriptor metadata', () => {
+    exploreServiceStub.result.set(sampleResult);
+    fixture.detectChanges();
+    component.addToNewChat();
+    expect(aiServiceStub.resetConversation).toHaveBeenCalled();
+    expect(dialogSpy.open).toHaveBeenCalledTimes(1);
+    const data = dialogSpy.open.calls.first().args[1]!.data as any;
+    expect(data.page).toBe('explore');
+    expect(data.metadata.exploreDescriptor).toBeTruthy();
+    expect(data.metadata.exploreDescriptor.dataSource).toBe('DOMAIN_ACTIVITY');
+    expect(data.chartData.rows.length).toBe(2);
+  });
+
+  it('addToCurrentChat is a no-op when there is no active conversation', () => {
+    exploreServiceStub.result.set(sampleResult);
+    aiServiceStub.hasActiveConversation.set(false);
+    fixture.detectChanges();
+    component.addToCurrentChat();
+    expect(aiServiceStub.appendUserTurnAndAnalyze).not.toHaveBeenCalled();
+    expect(dialogSpy.open).not.toHaveBeenCalled();
+  });
+
+  it('addToCurrentChat calls appendUserTurnAndAnalyze and opens the dialog when a chat is active', () => {
+    exploreServiceStub.result.set(sampleResult);
+    aiServiceStub.hasActiveConversation.set(true);
+    fixture.detectChanges();
+    component.addToCurrentChat();
+    expect(aiServiceStub.appendUserTurnAndAnalyze).toHaveBeenCalledTimes(1);
+    const args = aiServiceStub.appendUserTurnAndAnalyze.calls.first().args;
+    const userTurn = args[0] as string;
+    const overrides = args[1] as any;
+    expect(userTurn).toContain('I just ran an Explore query');
+    expect(userTurn).toContain('Descriptor:');
+    expect(overrides.page).toBe('explore');
+    expect(overrides.metadata.exploreDescriptor).toBeTruthy();
+    expect(dialogSpy.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncatedChartData includes rows, returnedRows, totalRows, and truncated=false when under the cap', () => {
+    exploreServiceStub.result.set(sampleResult);
+    const t = component.truncatedChartData();
+    expect(t).not.toBeNull();
+    expect(t!.rows.length).toBe(2);
+    expect(t!.returnedRows).toBe(2);
+    expect(t!.totalRows).toBe(2);
+    expect(t!.truncated).toBeFalse();
+  });
+
+  it('truncatedChartData truncates and reports truncated=true when row count exceeds the cap', () => {
+    const bigRows = Array.from({ length: 250 }, (_, i) => ({ tld: `tld${i}`, count_sum: i }));
+    exploreServiceStub.result.set({
+      columns: ['tld', 'count_sum'],
+      rows: bigRows,
+      truncated: false,
+      totalRows: 250,
+    });
+    const t = component.truncatedChartData();
+    expect(t!.rows.length).toBe(100);
+    expect(t!.returnedRows).toBe(100);
+    expect(t!.truncated).toBeTrue();
+  });
+});

--- a/console-webapp/src/app/registry-dash/explore/explore.component.ts
+++ b/console-webapp/src/app/registry-dash/explore/explore.component.ts
@@ -15,6 +15,7 @@
 import { Component, computed, DestroyRef, effect, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
 import { catchError, debounceTime, EMPTY, filter, switchMap } from 'rxjs';
 import { MaterialModule } from '../../material.module';
 import { RegistryDashService } from '../registry-dash.service';
@@ -24,6 +25,12 @@ import { ExploreChartComponent } from './explore-chart/explore-chart.component';
 import { ChartType, DEFAULT_QUERY, ExploreQuery } from './explore.models';
 import { AiSparkleButtonComponent } from '../ai/ai-sparkle-button.component';
 import { EXPLORE_PROMPTS } from '../ai/ai-prompts';
+import { AiAnalysisService } from '../ai/ai-analysis.service';
+import {
+  AiAnalysisModalComponent,
+  AiAnalysisModalData,
+} from '../ai/ai-analysis-modal.component';
+import { EXPLORE_AI_ROW_CAP, AiModelChoice } from '../ai/ai-analysis.models';
 
 @Component({
   selector: 'app-explore',
@@ -35,7 +42,9 @@ import { EXPLORE_PROMPTS } from '../ai/ai-prompts';
 export class ExploreComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private dashService = inject(RegistryDashService);
+  private dialog = inject(MatDialog);
   exploreService = inject(ExploreService);
+  aiService = inject(AiAnalysisService);
   readonly aiPrompts = EXPLORE_PROMPTS;
 
   query = signal<ExploreQuery>({ ...DEFAULT_QUERY, filters: { ...DEFAULT_QUERY.filters } });
@@ -95,6 +104,110 @@ export class ExploreComponent implements OnInit {
     this.exploreService.explore(this.query()).subscribe();
   }
 
+  truncatedChartData() {
+    const r = this.result();
+    if (!r) return null;
+    const cap = EXPLORE_AI_ROW_CAP;
+    const slicedRows = r.rows.slice(0, cap);
+    return {
+      columns: r.columns,
+      rows: slicedRows,
+      totalRows: r.totalRows,
+      returnedRows: slicedRows.length,
+      truncated: r.rows.length > cap,
+    };
+  }
+
+  descriptorSummary(): string {
+    const q = this.query();
+    const metricStr = q.metrics
+      .map(m => `${m.field}_${m.aggregation}`)
+      .join(', ') || 'count_sum';
+    const dimsStr = q.dimensions.length > 0
+      ? `grouped by ${q.dimensions.join(', ')}`
+      : 'no grouping';
+    const range = this.dashService.selectedRangeConfig();
+    const rangeLabel = range ? `last ${range.lookbackHours}h, ${range.granularity}` : '';
+    return [q.dataSource, dimsStr, metricStr, rangeLabel]
+      .filter(Boolean)
+      .join(', ');
+  }
+
+  private buildMetadata(): AiAnalysisModalData['metadata'] {
+    const range = this.dashService.selectedRangeConfig();
+    return {
+      dateRange: { start: '', end: '' },
+      granularity: range?.granularity,
+      filteredTlds: this.dashService.selectedTlds(),
+      filteredRegistrars: this.dashService.selectedRegistrarIds(),
+      exploreDescriptor: this.query(),
+    };
+  }
+
+  private savedAiModel(): AiModelChoice | undefined {
+    return (this.dashService.settingsCache()?.['aiModel']
+      || localStorage.getItem('ai-model-preference')) as AiModelChoice | undefined;
+  }
+
+  addToNewChat(): void {
+    const truncated = this.truncatedChartData();
+    if (!truncated) return;
+    this.aiService.resetConversation();
+
+    const data: AiAnalysisModalData = {
+      title: 'Explore Analysis — Data Exploration',
+      page: 'explore',
+      promptType: 'summarize_trends',
+      userMessage: EXPLORE_PROMPTS[0].userMessage,
+      metadata: this.buildMetadata(),
+      chartData: truncated,
+      isAdmin: false,
+      savedModel: this.savedAiModel(),
+    };
+
+    this.dialog.open(AiAnalysisModalComponent, {
+      width: '800px',
+      maxHeight: '90vh',
+      data,
+    });
+  }
+
+  addToCurrentChat(): void {
+    if (!this.aiService.hasActiveConversation()) return;
+    const truncated = this.truncatedChartData();
+    if (!truncated) return;
+
+    const userTurn =
+      `I just ran an Explore query: ${this.descriptorSummary()}.\n\n` +
+      `Descriptor: ${JSON.stringify(this.query())}\n\n` +
+      `Data (${truncated.returnedRows} of ${truncated.totalRows} rows` +
+      (truncated.truncated ? ', truncated' : '') +
+      `): ${JSON.stringify(truncated.rows)}`;
+
+    this.aiService.appendUserTurnAndAnalyze(userTurn, {
+      chartData: truncated,
+      metadata: this.buildMetadata(),
+      page: 'explore',
+      promptType: 'summarize_trends',
+    });
+
+    const data: AiAnalysisModalData = {
+      title: 'Explore Analysis — Data Exploration',
+      page: 'explore',
+      promptType: 'summarize_trends',
+      userMessage: EXPLORE_PROMPTS[0].userMessage,
+      metadata: this.buildMetadata(),
+      chartData: truncated,
+      isAdmin: false,
+      savedModel: this.savedAiModel(),
+    };
+    this.dialog.open(AiAnalysisModalComponent, {
+      width: '800px',
+      maxHeight: '90vh',
+      data,
+    });
+  }
+
   exportCsv(): void {
     const r = this.result();
     if (!r || r.rows.length === 0) return;
@@ -109,7 +222,7 @@ export class ExploreComponent implements OnInit {
 
     const header = r.columns.map(escape).join(',');
     const rows = r.rows.map(row => r.columns.map(col => escape(row[col])).join(','));
-    const csv = '\uFEFF' + header + '\n' + rows.join('\n');
+    const csv = '﻿' + header + '\n' + rows.join('\n');
 
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);

--- a/docs/superpowers/plans/2026-04-30-registry-dash-ai-explore-add-to-chat.md
+++ b/docs/superpowers/plans/2026-04-30-registry-dash-ai-explore-add-to-chat.md
@@ -1,0 +1,70 @@
+# Registry Dashboard AI — "Add to AI Chat" from Explore — Implementation Plan
+
+**Spec:** [`2026-04-30-registry-dash-ai-explore-add-to-chat.md`](../specs/2026-04-30-registry-dash-ai-explore-add-to-chat.md)
+**Linear:** SRE-1942
+
+## Step-by-step (TDD-flavoured; compile-clean each step)
+
+### 1. Models additions
+
+- `ai-analysis.models.ts`: add JSDoc above `metadata` documenting well-known keys including `exploreDescriptor`. Export `EXPLORE_AI_ROW_CAP = 100`.
+- No new tests needed (type-only changes).
+
+### 2. Service refactor
+
+- Add `conversationHistory`, `lastRequest`, `hasActiveConversation`, `resetConversation()` to `AiAnalysisService`.
+- Modify `analyze` to:
+  - capture `request.conversationHistory` into the service signal at the start, so the user turn renders immediately;
+  - on success, append `{role: 'assistant', content: streamedText}` to history and capture `lastRequest`;
+  - on error, leave history at the captured user-turn state (no assistant append).
+- Add `appendUserTurnAndAnalyze(content, overrides)` that merges current history + `lastRequest` defaults + overrides and calls `analyze`. Returns early with `error.set(...)` if neither `lastRequest` nor an explicit `page`/`promptType` override is present.
+- Tests in `ai-analysis.service.spec.ts`:
+  - hasActiveConversation false initially.
+  - analyze on success: assistant turn appended, lastRequest set.
+  - analyze on error: no assistant turn appended, lastRequest stays null.
+  - appendUserTurnAndAnalyze: appends one user + one assistant turn after a prior round.
+  - appendUserTurnAndAnalyze without prior request and no overrides: error is set.
+  - resetConversation clears all state.
+
+### 3. Modal adaptation
+
+- Replace local `conversationHistory` signal with `computed(() => aiService.conversationHistory())`.
+- `ngOnInit` only calls `sendInitialRequest()` when `hasActiveConversation()` is false.
+- Remove all local `conversationHistory.set/update` calls — the service owns history now.
+- Add a "Start new chat" button to the modal header that calls `resetConversation()` then `sendInitialRequest()`.
+- The HTML template iterates over `conversationHistory()` exactly as before — it works with both `signal` and `computed`.
+
+### 4. Explore page wiring
+
+- `explore.component.ts`: inject `AiAnalysisService` (public) and `MatDialog`.
+- Add `truncatedChartData()` returning `{ columns, rows, totalRows, returnedRows, truncated }` slicing at `EXPLORE_AI_ROW_CAP`.
+- Add `descriptorSummary()` producing a short string from `query()` and the active range config.
+- Add `addToNewChat()`: `resetConversation()` then `dialog.open(AiAnalysisModalComponent, { data })` with `metadata.exploreDescriptor = query()`.
+- Add `addToCurrentChat()`: bail when `!hasActiveConversation()`; call `appendUserTurnAndAnalyze(userTurn, { chartData, metadata, page: 'explore', promptType: 'summarize_trends' })`; then open the modal.
+- `explore.component.html`: add `mat-stroked-button [matMenuTriggerFor]="addAiMenu" *ngIf="result()"` to `.run-controls`, with two `mat-menu-item`s. The "Add to current chat" item is `[disabled]="!aiService.hasActiveConversation()"`.
+
+### 5. Component tests
+
+`explore.component.spec.ts`:
+- Stubs for `ExploreService`, `RegistryDashService`, `AiAnalysisService`, `MatDialog`.
+- Asserts:
+  - "Add to AI Chat" hidden when result is null; visible after `result.set(...)`.
+  - `addToNewChat()` calls `resetConversation()` and `dialog.open` with `data.metadata.exploreDescriptor` set.
+  - `addToCurrentChat()` is a no-op when `hasActiveConversation` is false.
+  - `addToCurrentChat()` calls `appendUserTurnAndAnalyze` with `page='explore'` and an `exploreDescriptor` in metadata, then opens the dialog when a chat is active.
+  - `truncatedChartData()` truncates at 100 rows and reports `truncated: true` when the source has more.
+
+### 6. Test plan
+
+Append **Test 21** to `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` covering both golden paths and the edge cases (button hidden before query, menu item disabled with no prior conversation, truncation hint above 100 rows).
+
+### 7. Verification
+
+- `cd console-webapp && nvm use 22.16.0 && npm run build`
+- `cd console-webapp && nvm use 22.16.0 && ng test --browsers=ChromeHeadless --watch=false`
+- Manual e2e per Test 21.
+- `git diff master -- core/` is empty (no backend changes).
+
+## PR
+
+Open against `unstoppabledomains/nomulus:master`. Reference SRE-1942.

--- a/docs/superpowers/specs/2026-04-30-registry-dash-ai-explore-add-to-chat.md
+++ b/docs/superpowers/specs/2026-04-30-registry-dash-ai-explore-add-to-chat.md
@@ -1,0 +1,94 @@
+# Registry Dashboard AI — "Add to AI Chat" from Data Exploration
+
+**Date:** 2026-04-30
+**Author:** torrey@unstoppabledomains.com
+**Status:** Implemented (frontend-only, no backend changes)
+**Linear:** SRE-1942
+**Predecessors:** Tier 1 (PR #114), Tier 2 (PR #121), Tier 3 v1
+
+## Context
+
+A registry analyst on an AI chat thread (e.g. Domain Activity) currently has to close the modal, navigate to **Data Exploration**, build a query, and re-open AI on Explore — losing the prior conversation and re-stating context. This change adds an **"Add to AI Chat"** affordance to the Explore page so a query result can either start a new chat or be appended to the user's existing conversation.
+
+The existing `/console-api/registry-dash/ai/analyze` endpoint already handles multi-turn conversations and arbitrary `chartData`. This is a frontend-only change.
+
+## Scope
+
+In scope:
+
+- Lift conversation state from `AiAnalysisModalComponent` into `AiAnalysisService` so it survives modal close.
+- Add an `Add to AI Chat` split button on `ExploreComponent` with two actions: `Start new chat` and `Add to current chat`.
+- Inline the `ExploreQueryDescriptor` and a row sample into the user-turn text (no backend changes — `metadata` keys other than `dateRange`/`filteredTlds` are ignored server-side today).
+- Cap the attached row payload at 100 rows and surface the truncation hint in the user turn.
+- Add a `Start new chat` control to the modal header so users can deliberately reseed.
+
+Out of scope (covered by follow-up prompts):
+
+- Persistence of conversation state across page reload (`localStorage`).
+- Cross-tab synchronisation (`BroadcastChannel`).
+- Server-side rendering of `metadata.exploreDescriptor` into the system prompt.
+- Introducing a new `analyze_explore_query` `promptType` — we reuse `summarize_trends`.
+- Persistent floating "Resume chat" widget.
+
+## Architecture
+
+### Frontend (only)
+
+```
+console-webapp/src/app/registry-dash/
+├── ai/
+│   ├── ai-analysis.service.ts          // owns conversationHistory + lastRequest
+│   ├── ai-analysis-modal.component.ts  // reads history from service
+│   ├── ai-analysis.models.ts           // EXPLORE_AI_ROW_CAP, metadata JSDoc
+│   └── ...
+└── explore/
+    ├── explore.component.ts            // addToNewChat / addToCurrentChat
+    └── explore.component.html          // mat-stroked-button + mat-menu
+```
+
+### Service contract
+
+`AiAnalysisService`:
+
+- `conversationHistory: WritableSignal<ConversationMessage[]>` — full transcript.
+- `lastRequest: WritableSignal<Pick<AiAnalyzeRequest, 'page' | 'promptType' | 'metadata' | 'systemPrompt' | 'model'> | null>` — replay-able request shape.
+- `hasActiveConversation = computed(() => conversationHistory().length > 0)`.
+- `resetConversation()` — clears history, lastRequest, streamedText, error, tools.
+- `analyze(request)` — captures the incoming `request.conversationHistory` immediately (so the user turn renders instantly), appends the assistant turn on success, captures `lastRequest` on success.
+- `appendUserTurnAndAnalyze(content, overrides)` — pushes a user turn, merges with current history + `lastRequest` defaults + overrides, calls `analyze`.
+
+### Modal contract changes
+
+- `conversationHistory` becomes a `computed` over the service signal. The modal stops mutating history directly.
+- `ngOnInit` only fires the seed request when `aiService.hasActiveConversation()` is false.
+- New header button `Start new chat` calls `resetConversation()` then `sendInitialRequest()`.
+
+### User-turn payload (Explore -> chat)
+
+```text
+I just ran an Explore query: <descriptorSummary>.
+
+Descriptor: <ExploreQuery JSON>
+
+Data (<returnedRows> of <totalRows> rows[, truncated]): <rows JSON>
+```
+
+`chartData` is also attached as `{ columns, rows: rows.slice(0, 100), totalRows, returnedRows, truncated }`. The descriptor is also placed in `metadata.exploreDescriptor` for forward-compatibility — the backend ignores it today (see follow-up #3).
+
+## Testing
+
+- New `ai-analysis.service.spec.ts` — covers user/assistant turn capture, error path, `appendUserTurnAndAnalyze`, `resetConversation`, `hasActiveConversation`.
+- New `explore.component.spec.ts` — button visibility, menu enablement, dialog data shape, truncation behaviour.
+- Manual e2e: see Test 21 in `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md`.
+
+## Risks & mitigations
+
+- **Modal double-append regression** — old modal appended assistant turns externally; we now do it in the service. Mitigation: modal no longer mutates history; service is the single writer. Covered by `ai-analysis.service.spec.ts`.
+- **Conversation leakage across pages** — service is `providedIn: 'root'`, so history persists across navigation. This is the intended new behaviour but means a user closing the modal mid-conversation still sees the prior turns when re-opening from a sparkle. The header `Start new chat` button is the explicit reset.
+- **Payload size** — capped at 100 rows + descriptor JSON; comparable in size to existing `chartData` payloads on other pages.
+
+## Follow-ups
+
+- `.context/tier3-followup-explore-add-to-chat-persistence-prompt.md`
+- `.context/tier3-followup-explore-add-to-chat-multitab-prompt.md`
+- `.context/tier3-followup-explore-add-to-chat-backend-descriptor-prompt.md`


### PR DESCRIPTION
## Summary

Lets a registry analyst push the result of an Explore query into the AI chat — either as a fresh chat or as additional context for the existing in-session conversation. Closes the workflow gap where switching from a chart-page modal to **Data Exploration** lost the prior conversation.

- Lifts conversation state from `AiAnalysisModalComponent` into `AiAnalysisService` so it survives modal close and page navigation.
- Adds an **Add to AI Chat** button next to the Run Query controls on the Explore page with a two-item menu: **Start new chat** / **Add to current chat** (the latter disabled when no conversation exists).
- Caps the attached row payload at **100 rows** (`EXPLORE_AI_ROW_CAP`); descriptor + truncation hint included in the user turn.
- Adds a **Start new chat** link to the modal header for explicit reset.
- **Frontend only** — `RegistryDashAiAction` renders `metadata` selectively today, so the descriptor rides in the user-turn text. Structured backend rendering is queued as a follow-up.

## Linear

[SRE-1942](https://linear.app/unstoppable-domains/issue/SRE-1942/featregistry-dash-add-to-ai-chat-from-data-exploration)

## Synergy

Once the parallel `run_explore_query` Tier-3 tool ships (separate PR), Claude can re-run the attached descriptor on demand to fetch more rows than the 100-row cap allows. Mentioned in `metadata.exploreDescriptor` so a future backend follow-up can render it as a structured system-prompt block.

## Follow-up prompts authored to workspace `.context/`

Three standalone prompts for follow-up agents (all depend on this PR):

- `.context/tier3-followup-explore-add-to-chat-persistence-prompt.md` — persist conversation state across page reload.
- `.context/tier3-followup-explore-add-to-chat-multitab-prompt.md` — `BroadcastChannel` cross-tab sync.
- `.context/tier3-followup-explore-add-to-chat-backend-descriptor-prompt.md` — render `metadata.exploreDescriptor` structurally in the system prompt.

## Test plan

- Test 21 added to `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` covering both happy paths and edge cases (button disabled before query runs, "Add to current chat" disabled when no conversation, 100-row truncation).

## Test plan checklist

- [x] `npm run build` passes locally
- [ ] `ng test --browsers=ChromeHeadless --watch=false` — unit specs added; local execution OOM-killed in this environment, will be verified by CI
- [ ] Manual E2E per Test 21 (cross-page resume, new-chat path, edge cases)
- [x] No backend (`core/`) files modified — verified with `git diff master --name-only -- core/` showing only prior-commit files, none in this PR
- [x] Existing sparkle button on Explore page still mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)