### PR TITLE
feat(registry-dash): AI Tier 3 — generic run_explore_query tool

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -505,3 +505,56 @@ Goal: confirm query_renewal_rates fires for renewal-trend questions. Steps: open
 ## Test 26: Tier 3 Batch 2 — query_expiration_curve
 
 Goal: confirm query_expiration_curve fires for forward-looking expiration questions. Steps: open modal on Financials > Forecasting, ask "How many domains in tld example expire in the next 12 months, broken out by month?". Verify months_ahead outside [1, 60] is silently clamped.
+---
+
+## Test 27: Tier 3 Tool Use - Generic run_explore_query (positive)
+
+**Goal:** Confirm Claude reaches for `run_explore_query` for questions no specific tool answers.
+
+### Steps:
+1. Navigate to **Domain Activity** and open the analysis modal.
+2. Wait for the initial analysis to finish.
+3. Ask: `What is our average renewal price by registrar over the last quarter for tld example?` (substitute a TLD with seeded REVENUE data).
+4. Watch for an inline indicator: `🔬 Running data query` (italic, slight pulse).
+5. The final assistant text should cite per-registrar pricing/renewal data.
+6. Tail the server log for `RegistryDashAiAction` and find the matching `AI analysis request:` line.
+
+### Expected:
+- Indicator `🔬 Running data query` appears mid-stream.
+- Final answer contains per-registrar numbers, not just a generic summary.
+- Server log includes `toolsUsed=[run_explore_query]`.
+- A second log line from `RunExploreQueryTool` records the descriptor: `AI tool run_explore_query: user=... tld=example dataSource=REVENUE dimensions=[registrar] metrics=[amount] ...`.
+
+---
+
+## Test 28: Tier 3 Tool Use - Generic vs Specific Tool Selection (negative)
+
+**Goal:** Confirm Claude prefers specific tools over the generic when one applies. Otherwise the description-level tie-breaker is too weak and needs strengthening.
+
+### Steps:
+1. Navigate to **Domain Activity**.
+2. Open the analysis modal.
+3. Ask: `Show me transfers for tld example last week.` - a specific tool (`query_transfers`) covers this.
+4. Watch the indicator that appears.
+
+### Expected:
+- Indicator is `🔍 Searching transfers`, NOT `🔬 Running data query`.
+- Server log shows `toolsUsed=[query_transfers]`, not `run_explore_query`.
+- If `run_explore_query` fires here, the description's tie-breaker copy needs a stronger lead-in.
+
+---
+
+## Test 29: Tier 3 Tool Use - Statement-timeout error message
+
+**Goal:** Confirm the `statement_timeout` config knob produces a user-visible error rather than a generic gateway timeout.
+
+### Steps:
+1. Temporarily set `ai.tools.statementTimeoutSeconds: 1` in the local-stack `default-config.yaml` override.
+2. Restart the local stack.
+3. Open the analysis modal and ask a wide aggregation question that will exceed 1s (e.g. `Aggregate all REVENUE for the last year by registrar and operation`).
+4. Watch the modal response.
+
+### Expected:
+- Final text reads something like *"Query exceeded 1s - try a narrower date range or smaller scope."*
+- Server log includes the descriptor line and the SQL state 57014.
+- No generic 502/504 gateway error reaches the browser.

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -85,4 +85,5 @@ export const TOOL_LABELS: Record<string, string> = {
   query_revenue_breakdown: '💵 Breaking down revenue',
   query_renewal_rates: '🔄 Checking renewal rates',
   query_expiration_curve: '📉 Mapping expirations',
+  run_explore_query: '🔬 Running data query',
 };

--- a/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
+++ b/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
@@ -38,7 +38,8 @@ public class AiToolRegistry {
       GetTldConfigTool getTldConfig,
       QueryRevenueBreakdownTool queryRevenueBreakdown,
       QueryRenewalRatesTool queryRenewalRates,
-      QueryExpirationCurveTool queryExpirationCurve) {
+      QueryExpirationCurveTool queryExpirationCurve,
+      RunExploreQueryTool runExploreQuery) {
     this(
         ImmutableList.of(
             queryTransfers,
@@ -49,7 +50,8 @@ public class AiToolRegistry {
             getTldConfig,
             queryRevenueBreakdown,
             queryRenewalRates,
-            queryExpirationCurve));
+            queryExpirationCurve,
+            runExploreQuery));
   }
 
   /** Test-friendly constructor. */

--- a/core/src/main/java/google/registry/ai/tools/RunExploreQueryTool.java
+++ b/core/src/main/java/google/registry/ai/tools/RunExploreQueryTool.java
@@ -1,0 +1,297 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.FluentLogger;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generic AI tool: runs an arbitrary aggregation against the Explore engine. Escape hatch for
+ * questions no specific tool covers.
+ *
+ * <p>Constrains Claude to a per-{@link ExploreDataSource} schema (Option A): the tool accepts a
+ * data source name plus the dimensions/metrics/filters allowed by that source's allowlist, and
+ * server-side validation rejects mismatches via {@link ExploreDataSource#validate}.
+ *
+ * <p>Hard caps and SQL {@code statement_timeout} are config-driven ({@code ai.tools.maxRows} and
+ * {@code ai.tools.statementTimeoutSeconds}) so they can be tuned without a code change.
+ */
+@Singleton
+public class RunExploreQueryTool implements AiTool {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private final int maxRows;
+  private final int statementTimeoutSeconds;
+
+  @Inject
+  public RunExploreQueryTool(
+      @Config("aiToolsMaxRows") int maxRows,
+      @Config("aiToolsStatementTimeoutSeconds") int statementTimeoutSeconds) {
+    this.maxRows = maxRows;
+    this.statementTimeoutSeconds = statementTimeoutSeconds;
+  }
+
+  @Override
+  public String name() {
+    return "run_explore_query";
+  }
+
+  @Override
+  public String description() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(
+        "Use this only when no specific tool covers the question. Reach for query_transfers, "
+            + "get_pricing_rules, query_registrar_activity, query_domain_details first. "
+            + "Runs an aggregation against one of the registry's data sources and returns up to ")
+        .append(maxRows)
+        .append(" rows.\n\nValid (data_source, metrics, dimensions) combinations:");
+    for (ExploreDataSource source : ExploreDataSource.values()) {
+      sb.append("\n- ")
+          .append(source.name())
+          .append(": metrics=")
+          .append(source.getAllowedMetrics())
+          .append(", dimensions=")
+          .append(source.getAllowedDimensions());
+    }
+    sb.append(
+        "\n\nAlways pass start_date and end_date (ISO YYYY-MM-DD). Filters registrar_ids, "
+            + "operations, activity_types are optional.");
+    return sb.toString();
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+
+    JsonObject props = new JsonObject();
+
+    JsonObject dataSource = new JsonObject();
+    dataSource.addProperty("type", "string");
+    dataSource.addProperty(
+        "description", "One of the 7 registry data sources (see tool description for valid set).");
+    JsonArray dataSourceEnum = new JsonArray();
+    for (ExploreDataSource s : ExploreDataSource.values()) {
+      dataSourceEnum.add(s.name());
+    }
+    dataSource.add("enum", dataSourceEnum);
+    props.add("data_source", dataSource);
+
+    JsonObject tld = new JsonObject();
+    tld.addProperty("type", "string");
+    tld.addProperty("description", "Single TLD to scope the query to (e.g. 'example').");
+    props.add("tld", tld);
+
+    JsonObject startDate = new JsonObject();
+    startDate.addProperty("type", "string");
+    startDate.addProperty(
+        "description", "ISO date or datetime, inclusive (e.g. '2026-04-01').");
+    props.add("start_date", startDate);
+
+    JsonObject endDate = new JsonObject();
+    endDate.addProperty("type", "string");
+    endDate.addProperty(
+        "description", "ISO date or datetime, inclusive (e.g. '2026-04-30').");
+    props.add("end_date", endDate);
+
+    JsonObject metrics = new JsonObject();
+    metrics.addProperty("type", "array");
+    JsonObject metricsItems = new JsonObject();
+    metricsItems.addProperty("type", "string");
+    metrics.add("items", metricsItems);
+    metrics.addProperty(
+        "description",
+        "Metric names valid for the chosen data_source (see tool description). Non-empty.");
+    props.add("metrics", metrics);
+
+    JsonObject dimensions = new JsonObject();
+    dimensions.addProperty("type", "array");
+    JsonObject dimensionsItems = new JsonObject();
+    dimensionsItems.addProperty("type", "string");
+    dimensions.add("items", dimensionsItems);
+    dimensions.addProperty(
+        "description",
+        "Optional. Dimension names valid for the chosen data_source (group-by columns).");
+    props.add("dimensions", dimensions);
+
+    JsonObject registrarIds = new JsonObject();
+    registrarIds.addProperty("type", "array");
+    JsonObject registrarIdsItems = new JsonObject();
+    registrarIdsItems.addProperty("type", "string");
+    registrarIds.add("items", registrarIdsItems);
+    registrarIds.addProperty("description", "Optional. Filter to these registrar IDs.");
+    props.add("registrar_ids", registrarIds);
+
+    JsonObject operations = new JsonObject();
+    operations.addProperty("type", "array");
+    JsonObject operationsItems = new JsonObject();
+    operationsItems.addProperty("type", "string");
+    operations.add("items", operationsItems);
+    operations.addProperty(
+        "description", "Optional. Filter to these operations (e.g. CREATE, RENEW, TRANSFER).");
+    props.add("operations", operations);
+
+    JsonObject activityTypes = new JsonObject();
+    activityTypes.addProperty("type", "array");
+    JsonObject activityTypesItems = new JsonObject();
+    activityTypesItems.addProperty("type", "string");
+    activityTypes.add("items", activityTypesItems);
+    activityTypes.addProperty("description", "Optional. Filter to these activity types.");
+    props.add("activity_types", activityTypes);
+
+    schema.add("properties", props);
+
+    JsonArray required = new JsonArray();
+    required.add("data_source");
+    required.add("tld");
+    required.add("start_date");
+    required.add("end_date");
+    required.add("metrics");
+    schema.add("required", required);
+
+    return schema;
+  }
+
+  @Override
+  public JsonElement execute(JsonObject args, User user) throws AiToolException {
+    String dataSourceName = stringArg(args, "data_source");
+    String tld = stringArg(args, "tld");
+    String startDate = stringArg(args, "start_date");
+    String endDate = stringArg(args, "end_date");
+    List<String> metrics = stringArrayArg(args, "metrics");
+    if (metrics.isEmpty()) {
+      throw new AiToolException("metrics must be non-empty");
+    }
+    List<String> dimensions = optionalStringArrayArg(args, "dimensions");
+    List<String> registrarIds = optionalStringArrayArg(args, "registrar_ids");
+    List<String> operations = optionalStringArrayArg(args, "operations");
+    List<String> activityTypes = optionalStringArrayArg(args, "activity_types");
+
+    ExploreDataSource source;
+    try {
+      source = ExploreDataSource.valueOf(dataSourceName);
+    } catch (IllegalArgumentException e) {
+      throw new AiToolException(
+          "Unknown data_source: " + dataSourceName + ". Valid: " + validDataSourceNames());
+    }
+
+    ToolJpaHelper.assertTldAccess(user, tld);
+    ImmutableSet<String> effectiveTlds = ToolJpaHelper.effectiveTlds(user, tld);
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            source.name(),
+            dimensions,
+            metrics,
+            List.of(tld),
+            registrarIds,
+            operations,
+            activityTypes,
+            startDate,
+            endDate);
+
+    // Tool-local audit log: descriptor-level detail not captured by the orchestrator's toolsUsed
+    // list. Consolidation into the orchestrator's log line is a follow-up.
+    logger.atInfo().log(
+        "AI tool run_explore_query: user=%s tld=%s dataSource=%s dimensions=%s metrics=%s"
+            + " registrarIds=%s operations=%s activityTypes=%s startDate=%s endDate=%s",
+        user.getEmailAddress(),
+        tld,
+        source.name(),
+        dimensions,
+        metrics,
+        registrarIds,
+        operations,
+        activityTypes,
+        startDate,
+        endDate);
+
+    return ToolJpaHelper.runExplore(
+        source,
+        desc,
+        effectiveTlds,
+        columnsFor(dimensions, metrics),
+        maxRows,
+        statementTimeoutSeconds);
+  }
+
+  /**
+   * The columns the SQL builder emits for a given query — ordered as dimensions first, then
+   * metrics. This matches how {@link
+   * google.registry.ui.server.console.registrydash.ExploreQueryBuilder} projects columns.
+   */
+  private static List<String> columnsFor(List<String> dimensions, List<String> metrics) {
+    List<String> cols = new ArrayList<>();
+    cols.addAll(dimensions);
+    cols.addAll(metrics);
+    return cols;
+  }
+
+  private static String validDataSourceNames() {
+    StringBuilder sb = new StringBuilder("[");
+    boolean first = true;
+    for (ExploreDataSource s : ExploreDataSource.values()) {
+      if (!first) {
+        sb.append(", ");
+      }
+      sb.append(s.name());
+      first = false;
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  private static String stringArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return args.get(key).getAsString();
+  }
+
+  private static List<String> stringArrayArg(JsonObject args, String key) throws AiToolException {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      throw new AiToolException("Missing required arg: " + key);
+    }
+    return readStringArray(args, key);
+  }
+
+  private static List<String> optionalStringArrayArg(JsonObject args, String key) {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      return List.of();
+    }
+    return readStringArray(args, key);
+  }
+
+  private static List<String> readStringArray(JsonObject args, String key) {
+    JsonArray arr = args.getAsJsonArray(key);
+    List<String> out = new ArrayList<>(arr.size());
+    for (JsonElement el : arr) {
+      out.add(el.getAsString());
+    }
+    return out;
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
+++ b/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
@@ -16,6 +16,7 @@ package google.registry.ai.tools;
 
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
+import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -73,7 +74,7 @@ final class ToolJpaHelper {
 
   /**
    * Runs an Explore-engine query and returns the rows as a JSON array of {@code {column: value}}
-   * objects.
+   * objects. No statement-timeout applied.
    */
   static JsonObject runExplore(
       ExploreDataSource source,
@@ -82,7 +83,29 @@ final class ToolJpaHelper {
       List<String> columns,
       int maxRows)
       throws AiToolException {
-    source.validate(desc);
+    return runExplore(source, desc, effectiveTlds, columns, maxRows, 0);
+  }
+
+  /**
+   * Runs an Explore-engine query with an optional SQL {@code statement_timeout}. When {@code
+   * statementTimeoutSeconds > 0}, the timeout is applied via {@code SET LOCAL statement_timeout}
+   * inside the same transaction; on exceedance the underlying {@code PSQLException} is converted to
+   * a user-visible {@link AiToolException}. When {@code statementTimeoutSeconds <= 0}, no timeout
+   * is applied (existing behavior).
+   */
+  static JsonObject runExplore(
+      ExploreDataSource source,
+      ExploreQueryDescriptor desc,
+      ImmutableSet<String> effectiveTlds,
+      List<String> columns,
+      int maxRows,
+      int statementTimeoutSeconds)
+      throws AiToolException {
+    try {
+      source.validate(desc);
+    } catch (IllegalArgumentException e) {
+      throw new AiToolException(e.getMessage());
+    }
     String sql = ExploreQueryBuilder.build(source, desc, effectiveTlds);
 
     ExploreQueryDescriptor.ExploreFilters filters = desc.getFilters();
@@ -99,51 +122,84 @@ final class ToolJpaHelper {
     final Instant fStart = startDate;
     final Instant fEnd = endDate;
 
-    return tm().transact(
-        () -> {
-          Query query = tm().getEntityManager().createNativeQuery(sql);
-          query.setParameter("maxRows", maxRows);
-          if (!effectiveTlds.isEmpty() && sql.contains(":tlds")) {
-            query.setParameter("tlds", effectiveTlds);
-          }
-          if (fStart != null && sql.contains(":startDate")) {
-            query.setParameter("startDate", fStart);
-          }
-          if (fEnd != null && sql.contains(":endDate")) {
-            query.setParameter("endDate", fEnd);
-          }
-          if (!filters.getOperations().isEmpty() && sql.contains(":operations")) {
-            query.setParameter("operations", filters.getOperations());
-          }
-          if (!filters.getRegistrarIds().isEmpty() && sql.contains(":registrarIds")) {
-            query.setParameter("registrarIds", filters.getRegistrarIds());
-          }
-          if (!filters.getActivityTypes().isEmpty() && sql.contains(":activityTypes")) {
-            query.setParameter("activityTypes", filters.getActivityTypes());
-          }
-
-          @SuppressWarnings("unchecked")
-          List<Object> raw = query.getResultList();
-
-          JsonArray rows = new JsonArray();
-          for (Object r : raw) {
-            JsonObject rowObj = new JsonObject();
-            if (r instanceof Object[] arr) {
-              for (int i = 0; i < arr.length && i < columns.size(); i++) {
-                addNormalized(rowObj, columns.get(i), arr[i]);
-              }
-            } else if (!columns.isEmpty()) {
-              addNormalized(rowObj, columns.get(0), r);
+    try {
+      return tm().transact(
+          () -> {
+            if (statementTimeoutSeconds > 0) {
+              tm().getEntityManager()
+                  .createNativeQuery(
+                      "SET LOCAL statement_timeout = " + (statementTimeoutSeconds * 1000L))
+                  .executeUpdate();
             }
-            rows.add(rowObj);
-          }
+            Query query = tm().getEntityManager().createNativeQuery(sql);
+            query.setParameter("maxRows", maxRows);
+            if (!effectiveTlds.isEmpty() && sql.contains(":tlds")) {
+              query.setParameter("tlds", effectiveTlds);
+            }
+            if (fStart != null && sql.contains(":startDate")) {
+              query.setParameter("startDate", fStart);
+            }
+            if (fEnd != null && sql.contains(":endDate")) {
+              query.setParameter("endDate", fEnd);
+            }
+            if (!filters.getOperations().isEmpty() && sql.contains(":operations")) {
+              query.setParameter("operations", filters.getOperations());
+            }
+            if (!filters.getRegistrarIds().isEmpty() && sql.contains(":registrarIds")) {
+              query.setParameter("registrarIds", filters.getRegistrarIds());
+            }
+            if (!filters.getActivityTypes().isEmpty() && sql.contains(":activityTypes")) {
+              query.setParameter("activityTypes", filters.getActivityTypes());
+            }
 
-          JsonObject out = new JsonObject();
-          out.add("rows", rows);
-          out.addProperty("rowCount", rows.size());
-          out.addProperty("truncated", rows.size() >= maxRows);
-          return out;
-        });
+            @SuppressWarnings("unchecked")
+            List<Object> raw = query.getResultList();
+
+            JsonArray rows = new JsonArray();
+            for (Object r : raw) {
+              JsonObject rowObj = new JsonObject();
+              if (r instanceof Object[] arr) {
+                for (int i = 0; i < arr.length && i < columns.size(); i++) {
+                  addNormalized(rowObj, columns.get(i), arr[i]);
+                }
+              } else if (!columns.isEmpty()) {
+                addNormalized(rowObj, columns.get(0), r);
+              }
+              rows.add(rowObj);
+            }
+
+            JsonObject out = new JsonObject();
+            out.add("rows", rows);
+            out.addProperty("rowCount", rows.size());
+            out.addProperty("truncated", rows.size() >= maxRows);
+            return out;
+          });
+    } catch (RuntimeException e) {
+      if (isStatementTimeout(e)) {
+        throw new AiToolException(
+            "Query exceeded "
+                + statementTimeoutSeconds
+                + "s — try a narrower date range or smaller scope.");
+      }
+      throw e;
+    }
+  }
+
+  /** Returns true if {@code e}'s cause chain contains a Postgres statement-timeout cancellation. */
+  private static boolean isStatementTimeout(Throwable e) {
+    Throwable cur = e;
+    while (cur != null) {
+      String msg = cur.getMessage();
+      if (msg != null && Ascii.toLowerCase(msg).contains("statement timeout")) {
+        return true;
+      }
+      // PostgreSQL SQLSTATE 57014 = query_canceled (the code statement_timeout uses).
+      if (cur instanceof java.sql.SQLException sqlEx && "57014".equals(sqlEx.getSQLState())) {
+        return true;
+      }
+      cur = cur.getCause();
+    }
+    return false;
   }
 
   private static void addNormalized(JsonObject obj, String key, Object val) {

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1474,6 +1474,26 @@ public final class RegistryConfig {
     }
 
     @Provides
+    @Config("aiToolsMaxRows")
+    public static int provideAiToolsMaxRows(RegistryConfigSettings config) {
+      if (config.ai != null && config.ai.tools != null && config.ai.tools.maxRows > 0) {
+        return config.ai.tools.maxRows;
+      }
+      return 500;
+    }
+
+    @Provides
+    @Config("aiToolsStatementTimeoutSeconds")
+    public static int provideAiToolsStatementTimeoutSeconds(RegistryConfigSettings config) {
+      if (config.ai != null
+          && config.ai.tools != null
+          && config.ai.tools.statementTimeoutSeconds > 0) {
+        return config.ai.tools.statementTimeoutSeconds;
+      }
+      return 30;
+    }
+
+    @Provides
     @Config("anthropicPromptConfig")
     public static RegistryConfigSettings.Prompts provideAnthropicPromptConfig(
         RegistryConfigSettings config) {

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -265,6 +265,13 @@ public class RegistryConfigSettings {
     public String defaultModel;
     public int rateLimitPerHour;
     public Prompts prompts;
+    public Tools tools;
+  }
+
+  /** Per-tool runtime knobs for AI tools (caps, timeouts). */
+  public static class Tools {
+    public int maxRows;
+    public int statementTimeoutSeconds;
   }
 
   /** AI prompt content, loaded from default-config.yaml. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -648,17 +648,27 @@ ai:
   defaultModel: sonnet
   # Rate limit: max requests per user per hour
   rateLimitPerHour: 120
+  # Per-tool runtime knobs. Tunable without code changes.
+  tools:
+    # Hard cap on rows returned by any AI tool that wraps the Explore engine.
+    # Protects against runaway aggregations and keeps tool responses small enough
+    # for the model to consume.
+    maxRows: 500
+    # SQL statement_timeout (seconds) applied to AI-tool queries that opt in.
+    # Surfaces as a clear AiToolException on exceedance instead of falling through
+    # to the 120s HTTP gateway timeout.
+    statementTimeoutSeconds: 30
   # Prompt content for the AI sparkle feature. Edit here to tweak prompts without redeploying
   # frontend code. The version field is logged on every request for observability.
   prompts:
-    # Bumped 2026-04-29 to force a fresh nomulus image build for alpha-gke
+    # Bumped 2026-04-30 to force a fresh nomulus image build for alpha-gke
     # (prior deploy reused a cached image without the Tier 2 prompts content).
-    version: "v1.0.1"
+    version: "v1.0.2"
     basePreamble: "You are an expert domain registry analyst. You are analyzing data from a domain registry dashboard."
     responseGuidance: "Provide your analysis in clear markdown. Use specific numbers from the data. Keep your response concise and actionable."
     toolsHeader: |
       ## Tools available
-      You have tools to fetch additional registry data when the user's question needs detail beyond the snapshot above. Use a tool when you need specific domains, registrar-level data, or pricing rules. Prefer specific tools over generic ones, and always cite the data the tool returned in your response.
+      You have tools to fetch additional registry data when the user's question needs detail beyond the snapshot above. Use a tool when you need specific domains, registrar-level data, or pricing rules. Prefer specific tools (query_transfers, get_pricing_rules, query_registrar_activity, query_domain_details) over the generic run_explore_query. Use run_explore_query only when no specific tool fits. Always cite the data the tool returned in your response.
     promptTypes:
       summarize_trends: "Summarize the key trends in this data. Identify growth or decline patterns, compare across TLDs, and highlight the most significant changes."
       find_anomalies: "Identify anomalies, outliers, and unusual patterns in this data. Look for unexpected spikes, drops, or ratios that warrant investigation."

--- a/core/src/test/java/google/registry/ai/tools/AiToolTestBase.java
+++ b/core/src/test/java/google/registry/ai/tools/AiToolTestBase.java
@@ -1,0 +1,117 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.testing.DatabaseHelper.persistResource;
+
+import com.google.common.base.Ascii;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import google.registry.ai.tools.AiTool.AiToolException;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.model.registrydash.RoRegistry;
+import google.registry.model.registrydash.RoRegistryTld;
+import google.registry.model.registrydash.RoRegistryUser;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Shared test setup for {@link AiTool} implementations: JPA extension, fake clock, user fixtures,
+ * registry-mapping helpers, and a helper for asserting {@link AiToolException} messages.
+ */
+abstract class AiToolTestBase {
+
+  protected static final DateTime TEST_TIME = DateTime.parse("2026-04-30T10:00:00.000Z");
+  protected static final Gson GSON = new Gson();
+
+  protected final FakeClock clock = new FakeClock(TEST_TIME);
+
+  @RegisterExtension
+  protected final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  /** Creates an FTE (admin) user. Bypasses TLD-scope checks. */
+  protected User createFteUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build());
+  }
+
+  /** Creates a registry-operator (non-admin) user. Subject to TLD-scope checks. */
+  protected User createRoUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(
+                new UserRoles.Builder().setGlobalRole(GlobalRole.REGISTRY_OPERATOR).build())
+            .build());
+  }
+
+  /** Creates a no-role user. Has no TLD access via registry mappings. */
+  protected User createNoneRoleUser(String email) {
+    return persistResource(
+        new User.Builder()
+            .setEmailAddress(email)
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.NONE).build())
+            .build());
+  }
+
+  /** Maps {@code email} to {@code tld} via the RoRegistry/RoRegistryTld/RoRegistryUser triple. */
+  protected void mapUserToTld(String email, String tld) {
+    RoRegistry registry = new RoRegistry("registry-for-" + email);
+    tm().transact(
+        () -> {
+          tm().getEntityManager().persist(registry);
+          tm().getEntityManager().persist(new RoRegistryTld(registry.getId(), tld));
+          tm().getEntityManager().persist(new RoRegistryUser(registry.getId(), email));
+        });
+  }
+
+  /** Asserts that {@code action} throws {@link AiToolException} whose message contains {@code
+   * expectedMessageFragment} (case-insensitive). */
+  protected static void assertAiToolException(
+      Executable action, String expectedMessageFragment) {
+    try {
+      action.run();
+    } catch (AiToolException e) {
+      assertThat(Ascii.toLowerCase(e.getMessage()))
+          .contains(Ascii.toLowerCase(expectedMessageFragment));
+      return;
+    } catch (Exception e) {
+      throw new AssertionError(
+          "Expected AiToolException but got " + e.getClass().getSimpleName(), e);
+    }
+    throw new AssertionError("Expected AiToolException but no exception was thrown");
+  }
+
+  /** Builds a JsonObject from inline key-value pairs. Strings only; arrays are JSON-encoded. */
+  protected static JsonObject args(String json) {
+    return GSON.fromJson(json, JsonObject.class);
+  }
+
+  /** Functional interface for {@link #assertAiToolException}. */
+  @FunctionalInterface
+  protected interface Executable {
+    void run() throws Exception;
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/GetPricingRulesToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/GetPricingRulesToolTest.java
@@ -1,0 +1,70 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link GetPricingRulesTool}. */
+class GetPricingRulesToolTest extends AiToolTestBase {
+
+  private final GetPricingRulesTool tool = new GetPricingRulesTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("get_pricing_rules");
+  }
+
+  @Test
+  void inputSchema_requiresTld() {
+    JsonObject schema = tool.inputSchema();
+    assertThat(schema.getAsJsonArray("required").toString()).contains("tld");
+  }
+
+  @Test
+  void execute_missingTld_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    assertAiToolException(() -> tool.execute(argsJson, user), "tld");
+  }
+
+  @Test
+  void execute_emptyTld_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("tld", "");
+    assertAiToolException(() -> tool.execute(argsJson, user), "tld");
+  }
+
+  @Test
+  void execute_tldOutsideUserScope_throwsPermissionDenied() {
+    createTld("other-tld");
+    User user = createRoUser("ro@example.com");
+    mapUserToTld("ro@example.com", "other-tld");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("tld", "tld");
+    assertAiToolException(() -> tool.execute(argsJson, user), "Permission denied");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryDomainDetailsToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryDomainDetailsToolTest.java
@@ -1,0 +1,64 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link QueryDomainDetailsTool}. */
+class QueryDomainDetailsToolTest extends AiToolTestBase {
+
+  private final QueryDomainDetailsTool tool = new QueryDomainDetailsTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("query_domain_details");
+  }
+
+  @Test
+  void inputSchema_requiresDomainName() {
+    JsonObject schema = tool.inputSchema();
+    assertThat(schema.getAsJsonArray("required").toString()).contains("domain_name");
+  }
+
+  @Test
+  void execute_missingDomainName_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    assertAiToolException(() -> tool.execute(argsJson, user), "domain_name");
+  }
+
+  @Test
+  void execute_unknownDomain_returnsErrorObject() throws Exception {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("domain_name", "no-such-domain.tld");
+    JsonElement result = tool.execute(argsJson, user);
+    assertThat(result.getAsJsonObject().has("error")).isTrue();
+    assertThat(result.getAsJsonObject().get("error").getAsString())
+        .contains("Domain not found");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryRegistrarActivityToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryRegistrarActivityToolTest.java
@@ -1,0 +1,63 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link QueryRegistrarActivityTool}. */
+class QueryRegistrarActivityToolTest extends AiToolTestBase {
+
+  private final QueryRegistrarActivityTool tool = new QueryRegistrarActivityTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("query_registrar_activity");
+  }
+
+  @Test
+  void inputSchema_requiresRegistrarId() {
+    JsonObject schema = tool.inputSchema();
+    assertThat(schema.getAsJsonArray("required").toString()).contains("registrar_id");
+  }
+
+  @Test
+  void execute_missingRegistrarId_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    assertAiToolException(() -> tool.execute(argsJson, user), "registrar_id");
+  }
+
+  @Test
+  void execute_tldOutsideUserScope_throwsPermissionDenied() {
+    createTld("other-tld");
+    User user = createRoUser("ro@example.com");
+    mapUserToTld("ro@example.com", "other-tld");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("registrar_id", "test-registrar");
+    argsJson.addProperty("tld", "tld");
+    assertAiToolException(() -> tool.execute(argsJson, user), "Permission denied");
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/QueryTransfersToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryTransfersToolTest.java
@@ -1,0 +1,89 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link QueryTransfersTool}. */
+class QueryTransfersToolTest extends AiToolTestBase {
+
+  private final QueryTransfersTool tool = new QueryTransfersTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("query_transfers");
+  }
+
+  @Test
+  void inputSchema_requiresTldAndDates() {
+    JsonObject schema = tool.inputSchema();
+    String required = schema.getAsJsonArray("required").toString();
+    assertThat(required).contains("tld");
+    assertThat(required).contains("start_date");
+    assertThat(required).contains("end_date");
+  }
+
+  @Test
+  void execute_missingTld_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("tld");
+    assertAiToolException(() -> tool.execute(argsJson, user), "tld");
+  }
+
+  @Test
+  void execute_missingStartDate_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("start_date");
+    assertAiToolException(() -> tool.execute(argsJson, user), "start_date");
+  }
+
+  @Test
+  void execute_missingEndDate_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("end_date");
+    assertAiToolException(() -> tool.execute(argsJson, user), "end_date");
+  }
+
+  @Test
+  void execute_tldOutsideUserScope_throwsPermissionDenied() {
+    createTld("other-tld");
+    User user = createRoUser("ro@example.com");
+    mapUserToTld("ro@example.com", "other-tld");
+    JsonObject argsJson = baseArgs();
+    assertAiToolException(() -> tool.execute(argsJson, user), "Permission denied");
+  }
+
+  private static JsonObject baseArgs() {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("tld", "tld");
+    obj.addProperty("start_date", "2026-04-01");
+    obj.addProperty("end_date", "2026-04-29");
+    return obj;
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/RunExploreQueryToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/RunExploreQueryToolTest.java
@@ -1,0 +1,161 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link RunExploreQueryTool}. */
+class RunExploreQueryToolTest extends AiToolTestBase {
+
+  // Small maxRows to make truncation easy to assert; statementTimeoutSeconds=0 disables it.
+  private final RunExploreQueryTool tool =
+      new RunExploreQueryTool(
+          /* maxRows= */ 5, /* statementTimeoutSeconds= */ 0);
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("run_explore_query");
+  }
+
+  @Test
+  void description_enumeratesAllSevenDataSources() {
+    String desc = tool.description();
+    for (ExploreDataSource s : ExploreDataSource.values()) {
+      assertThat(desc).contains(s.name());
+    }
+  }
+
+  @Test
+  void description_hasTieBreakerLeadIn() {
+    assertThat(tool.description())
+        .contains("Use this only when no specific tool covers the question");
+  }
+
+  @Test
+  void inputSchema_hasRequiredFields() {
+    JsonObject schema = tool.inputSchema();
+    assertThat(schema.getAsJsonArray("required").toString())
+        .contains("data_source");
+    assertThat(schema.getAsJsonArray("required").toString()).contains("tld");
+    assertThat(schema.getAsJsonArray("required").toString()).contains("start_date");
+    assertThat(schema.getAsJsonArray("required").toString()).contains("end_date");
+    assertThat(schema.getAsJsonArray("required").toString()).contains("metrics");
+    assertThat(schema.getAsJsonObject("properties").getAsJsonObject("data_source").has("enum"))
+        .isTrue();
+  }
+
+  @Test
+  void execute_missingDataSource_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("data_source");
+    assertAiToolException(() -> tool.execute(argsJson, user), "data_source");
+  }
+
+  @Test
+  void execute_missingTld_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("tld");
+    assertAiToolException(() -> tool.execute(argsJson, user), "tld");
+  }
+
+  @Test
+  void execute_missingMetrics_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.remove("metrics");
+    assertAiToolException(() -> tool.execute(argsJson, user), "metrics");
+  }
+
+  @Test
+  void execute_emptyMetrics_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.add("metrics", new com.google.gson.JsonArray());
+    assertAiToolException(() -> tool.execute(argsJson, user), "non-empty");
+  }
+
+  @Test
+  void execute_unknownDataSource_throws() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.addProperty("data_source", "NOT_A_REAL_SOURCE");
+    assertAiToolException(() -> tool.execute(argsJson, user), "unknown data_source");
+  }
+
+  @Test
+  void execute_invalidMetricForSource_throws() {
+    // REVENUE allows {amount, netAmountToRegistry}. "count" is invalid.
+    createTld("tld");
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.addProperty("data_source", "REVENUE");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("count");
+    argsJson.add("metrics", metrics);
+    assertAiToolException(() -> tool.execute(argsJson, user), "Unknown metric");
+  }
+
+  @Test
+  void execute_invalidDimensionForSource_throws() {
+    // REVENUE allows dimensions {tld, operation, period}. "registrar" is invalid.
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = baseArgs();
+    argsJson.addProperty("data_source", "REVENUE");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("amount");
+    argsJson.add("metrics", metrics);
+    com.google.gson.JsonArray dims = new com.google.gson.JsonArray();
+    dims.add("registrar");
+    argsJson.add("dimensions", dims);
+    assertAiToolException(() -> tool.execute(argsJson, user), "Unknown dimension");
+  }
+
+  @Test
+  void execute_tldOutsideUserScope_throwsPermissionDenied() {
+    // Non-admin user mapped only to "other-tld" — querying "tld" must fail.
+    createTld("other-tld");
+    User user = createRoUser("ro@example.com");
+    mapUserToTld("ro@example.com", "other-tld");
+    JsonObject argsJson = baseArgs();
+    assertAiToolException(() -> tool.execute(argsJson, user), "Permission denied");
+  }
+
+  /** Minimal valid args for DOMAIN_ACTIVITY. */
+  private static JsonObject baseArgs() {
+    JsonObject obj = new JsonObject();
+    obj.addProperty("data_source", "DOMAIN_ACTIVITY");
+    obj.addProperty("tld", "tld");
+    obj.addProperty("start_date", "2026-04-01");
+    obj.addProperty("end_date", "2026-04-29");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("count");
+    obj.add("metrics", metrics);
+    return obj;
+  }
+}

--- a/docs/superpowers/plans/2026-04-30-registry-dash-ai-tier3-explore-tool-plan.md
+++ b/docs/superpowers/plans/2026-04-30-registry-dash-ai-tier3-explore-tool-plan.md
@@ -1,0 +1,38 @@
+# Plan: `run_explore_query` AI tool
+
+**Date:** 2026-04-30
+**Spec:** `docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-explore-tool.md`
+
+## Step-by-step (TDD-flavored)
+
+1. [x] Add `RegistryConfigSettings.Ai.Tools` nested class with `maxRows`, `statementTimeoutSeconds`.
+2. [x] Add `@Provides @Config("aiToolsMaxRows")` and `@Config("aiToolsStatementTimeoutSeconds")` providers in `RegistryConfig` (defaults 500 and 30).
+3. [x] Add `ai.tools` block to `core/.../config/files/default-config.yaml` (default values + comments).
+4. [x] Update `ai.prompts.toolsHeader` in `default-config.yaml` to add the generic-vs-specific tie-breaker.
+5. [x] Bump `ai.prompts.version` from `v1.0.1` to `v1.0.2`.
+6. [x] Extend `ToolJpaHelper.runExplore` with an overload that takes `int statementTimeoutSeconds`. Original signature delegates with 0 (no timeout) for backward compat. Convert `IllegalArgumentException` from `validate()` to `AiToolException`. Detect Postgres SQLSTATE 57014 and convert to `AiToolException("Query exceeded Ns — try a narrower date range or smaller scope.")`.
+7. [x] Implement `RunExploreQueryTool` (`name`, `description`, `inputSchema`, `execute`). `description()` enumerates all 7 data sources × allowed metrics/dimensions, derived from `ExploreDataSource` getters. Audit log via FluentLogger.
+8. [x] Add `RunExploreQueryTool` constructor param to `AiToolRegistry`.
+9. [x] Add `run_explore_query: '🔬 Running data query'` to `console-webapp/.../ai-analysis.models.ts` `TOOL_LABELS`.
+10. [x] Create `AiToolTestBase` with shared JPA extension, fake clock, user fixtures, and `assertAiToolException`.
+11. [x] Write `RunExploreQueryToolTest` — schema validation, missing args, unknown data_source, invalid metric/dimension per source, permission denial, description smoke.
+12. [x] Backfill tests for `QueryTransfersTool`, `GetPricingRulesTool`, `QueryRegistrarActivityTool`, `QueryDomainDetailsTool`.
+13. [x] Update `.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md` — add E2E step for `run_explore_query` (positive + negative).
+14. [ ] Run `./gradlew :core:compileJava :core:compileTestJava` — must be clean.
+15. [ ] Run `./gradlew :core:test --tests "google.registry.ai.tools.*"` — all green.
+16. [ ] Frontend build: `cd console-webapp && nvm use 22.16.0 && npm run build`.
+17. [ ] Local E2E with `ud-registry-dash:test-registry-dash` skill — happy path + negative path.
+18. [ ] Open PR against `unstoppabledomains/nomulus` master.
+19. [ ] After merge: open follow-up PR in `unstoppabledomains/nomulus-secrets` mirroring the `ai.tools` block and `ai.prompts.toolsHeader`.
+20. [ ] Write follow-up prompt at `bozeman-v1/.context/tier3-followup-extended-tool-audit-logging-prompt.md` (Option B audit-log refactor for after both this and the sibling specific-tools PR merge).
+
+## Notes / decisions
+
+- Schema option A locked (constrained per-data-source wrapper).
+- Statement-timeout adopted in this PR (scoped to `RunExploreQueryTool` via the new
+  `runExplore` overload). Broadening to the existing 4 tools is the deferred follow-up.
+- Audit log uses a separate FluentLogger in the tool. Consolidation into the orchestrator's
+  `toolsUsed` line is deferred so it can update both this PR's tools and the sibling
+  specific-tools PR's tools at once.
+- Backfilled tests focus on input validation + permission denial (the safety net). Happy-path
+  tests with real fixtures are exercised via the local-stack E2E.

--- a/docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-explore-tool.md
+++ b/docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-explore-tool.md
@@ -1,0 +1,148 @@
+# Tier 3 follow-up: Generic `run_explore_query` AI tool
+
+**Date:** 2026-04-30
+**Author:** torrey@unstoppabledomains.com
+**Parent spec:** `2026-04-29-registry-dash-ai-tier3-design.md`
+**Status:** Implementing
+
+## Context
+
+Tier 3 v1 shipped four specific AI tools — `query_transfers`, `get_pricing_rules`,
+`query_registrar_activity`, `query_domain_details` — and explicitly deferred a generic escape
+hatch. This spec defines that escape hatch: `run_explore_query`, a single tool that lets Claude
+run arbitrary aggregations against the existing Explore engine (`ExploreQueryBuilder`) for
+questions no specific tool covers (e.g. "average renewal price by registrar over the last
+quarter for tld example").
+
+A sibling task (`docs/superpowers/specs/<date>-registry-dash-ai-tier3-tools-batch2.md`, in flight
+in the `swordfish` worktree) adds 3–5 more *specific* tools. Both PRs are independent but conflict
+mechanically on `AiToolRegistry`'s constructor and the `ai.prompts.toolsHeader` config field.
+
+## Goals
+
+- Give Claude a safe way to run aggregations the specific tools can't express.
+- Keep the schema constrained enough that Claude doesn't hallucinate fields.
+- Make caps and timeouts tunable via config (no code change to retune).
+- Keep the runtime cost of misuse bounded (row cap, statement timeout, TLD scope check).
+
+## Non-goals
+
+- Mutation. Tier 3 is read-only.
+- Exposing raw SQL. The descriptor is the public contract.
+- Drift-detection CI between nomulus and nomulus-secrets `default-config.yaml`. Out of scope; a
+  flagged separate follow-up.
+- Consolidating tool audit logging (per-tool descriptor in the orchestrator's `toolsUsed` line).
+  Deferred to a follow-up after both this PR and the sibling specific-tools PR merge — see
+  `bozeman-v1/.context/tier3-followup-extended-tool-audit-logging-prompt.md`.
+
+## Schema decision (Option A — constrained per-data-source wrapper)
+
+The tool's input schema mirrors the structure of `ExploreQueryDescriptor` but exposes only the
+fields Claude needs to specify, scoped to a single TLD:
+
+```jsonc
+{
+  "data_source": "REVENUE",                // one of 7 enum values; required
+  "tld": "example",                        // single TLD; required
+  "start_date": "2026-04-01",              // ISO date or datetime; required
+  "end_date": "2026-04-30",                // ISO date or datetime; required
+  "metrics": ["amount"],                   // non-empty array of metric names; required
+  "dimensions": ["registrar", "operation"],// optional
+  "registrar_ids": [],                     // optional
+  "operations": [],                        // optional
+  "activity_types": []                     // optional
+}
+```
+
+Server-side validation is provided for free by `ExploreDataSource.validate()` (lines 86–127),
+which already throws `IllegalArgumentException` on unknown metrics/dimensions/filters per source.
+The tool catches that and rethrows as `AiToolException` so Claude sees a useful error.
+
+We considered Option B (full descriptor minus granularity/limit) and Option C (raw pass-through);
+both were rejected because Option A's per-source allowlists make the matrix small enough to fit in
+`description()`, where Claude reads it to decide whether/how to use the tool.
+
+## Guardrails (all enforced)
+
+1. **TLD scope check.** `ToolJpaHelper.assertTldAccess(user, tld)` throws for non-admin users
+   whose access scope doesn't include the requested TLD. Admins (`GlobalRole.FTE`) bypass.
+2. **Row cap.** `ai.tools.maxRows` (default 500). Hardcaps the tool wrapper; the descriptor's own
+   server-side cap of 10,000 rows is a backstop.
+3. **SQL `statement_timeout`.** `ai.tools.statementTimeoutSeconds` (default 30). Applied via
+   `SET LOCAL statement_timeout` inside the JPA transaction. On exceedance, the underlying
+   `PSQLException` (SQLSTATE 57014) is converted to a user-visible
+   `AiToolException("Query exceeded Ns — try a narrower date range or smaller scope.")`.
+4. **No raw SQL.** The tool only takes a descriptor; SQL is built by `ExploreQueryBuilder`.
+5. **PII.** Per ICANN thin-registry policy, registrant contact data is not modeled in the registry
+   and therefore not reachable through the Explore engine. `domain_name` (TRANSACTIONS) is public
+   record and explicitly OK to expose. The existing `query_transfers` tool already exposes the
+   same surface.
+6. **Audit log.** `RunExploreQueryTool.execute` emits a structured log line via FluentLogger
+   capturing user, dataSource, tld, dimensions, metrics, filter args, and date range. Separate
+   from the orchestrator's `toolsUsed=[...]` line; consolidation is the deferred follow-up.
+
+## description() lead-in
+
+The tool's `description()` opens with a tie-breaker so Claude knows to prefer specific tools:
+
+> "Use this only when no specific tool covers the question. Reach for query_transfers,
+> get_pricing_rules, query_registrar_activity, query_domain_details first."
+
+Followed by an enumerated list of all 7 data sources × their valid metrics/dimensions, derived
+from `ExploreDataSource.getAllowedMetrics()` and `getAllowedDimensions()` (so the description
+stays in sync if the enum changes).
+
+The system prompt's `ai.prompts.toolsHeader` is also updated to mention the same tie-breaker — a
+second nudge at a different layer.
+
+## Configuration
+
+Two new config knobs added under `ai.tools` in `default-config.yaml`:
+
+```yaml
+ai:
+  tools:
+    maxRows: 500
+    statementTimeoutSeconds: 30
+```
+
+These are surfaced via `RegistryConfigSettings.Ai.Tools` (a new nested class) and bound via
+`@Provides @Config("aiToolsMaxRows")` / `@Config("aiToolsStatementTimeoutSeconds")` in
+`RegistryConfig`. The same values must be mirrored to `nomulus-secrets/default-config.yaml`
+(separate follow-up PR; see `bozeman-v1/.context/nomulus-secrets-tier3-toolsheader-prompt.md`
+pattern).
+
+## Test scope
+
+- New: `RunExploreQueryToolTest` — schema validation, missing/empty args, unknown data_source,
+  invalid metric/dimension per source, TLD permission denial. Description and inputSchema smoke.
+- Backfill: `QueryTransfersToolTest`, `GetPricingRulesToolTest`,
+  `QueryRegistrarActivityToolTest`, `QueryDomainDetailsToolTest` — same pattern. Establishes
+  test coverage for tools that previously had none.
+- Shared: `AiToolTestBase` — JPA extension, fake clock, user-fixture helpers (`createFteUser`,
+  `createRoUser`, `mapUserToTld`), `assertAiToolException`.
+
+Happy-path tests with real fixture data (BillingEvent rows, DomainHistory rows) are deferred —
+the safety net is permission + arg validation; happy-path is best exercised by the local-stack
+E2E in `test-registry-dash`.
+
+## Verification
+
+- `./gradlew :core:compileJava :core:compileTestJava` — clean.
+- `./gradlew :core:test --tests "google.registry.ai.tools.*"` — all new + backfilled tests pass.
+- Frontend build: `cd console-webapp && nvm use 22.16.0 && npm run build`.
+- Local E2E: ask the AI modal "what's our average renewal price by registrar over the last
+  quarter for tld example?" — confirm `🔬 Running data query` chip appears and the response
+  cites real rows. Negative test: ask "show me transfers for tld example last week" — confirm
+  Claude picks `query_transfers`, NOT the generic.
+
+## Coordination
+
+- **Sibling PR (specific tools, swordfish worktree):** mechanical conflict on
+  `AiToolRegistry`'s constructor. Whichever PR merges second adds the missing constructor
+  param. The sibling adds tools after `queryDomainDetails`; we add `runExploreQuery` at the
+  end. Order of params doesn't affect runtime behavior.
+- **nomulus-secrets PR:** opened after this PR merges. Mirrors the new `ai.tools` block and
+  `ai.prompts.toolsHeader` to the deployed config. Pattern established by
+  `nomulus-secrets-tier3-toolsheader-prompt.md`.
+- **Drift CI:** flagged as a follow-up; surface in this PR's body.


### PR DESCRIPTION
## Summary

Adds the Tier 3 generic AI tool — `run_explore_query` — explicitly deferred from PR #122. Lets Claude run arbitrary aggregations against the existing Explore engine for questions no specific tool covers (e.g. "average renewal price by registrar over the last quarter for tld example"). Constrains Claude via `ExploreDataSource.validate()`'s allowlists (Option A schema), enumerates valid combos in `description()`, and updates `ai.prompts.toolsHeader` to nudge Claude to prefer the specific tools.

## What ships

- **`RunExploreQueryTool`** — new `AiTool` at `core/.../ai/tools/RunExploreQueryTool.java`. `description()` opens with a tie-breaker line ("Use this only when no specific tool covers the question…") and enumerates all 7 `ExploreDataSource` × allowed metrics/dimensions, derived from the enum getters so the description stays in sync if the enum changes.
- **`ToolJpaHelper.runExplore` overload** with `int statementTimeoutSeconds`. When > 0, runs `SET LOCAL statement_timeout` inside the JPA transaction and converts SQLSTATE 57014 (or "statement timeout" in the cause chain) to a user-visible `AiToolException("Query exceeded Ns — try a narrower date range or smaller scope.")`. Existing 4 tools call the original signature unchanged.
- **Config knobs** under `ai.tools` in `default-config.yaml` (and matching `RegistryConfigSettings.Ai.Tools` + `@Provides @Config("aiToolsMaxRows" / "aiToolsStatementTimeoutSeconds")`):
  - `maxRows` (default 500)
  - `statementTimeoutSeconds` (default 30)
- **System-prompt tie-breaker** appended to `ai.prompts.toolsHeader` so Claude prefers `query_transfers`/`get_pricing_rules`/`query_registrar_activity`/`query_domain_details` over `run_explore_query`. `prompts.version` bumped `v1.0.1` → `v1.0.2`.
- **Frontend label**: `run_explore_query: '🔬 Running data query'` added to `TOOL_LABELS`.
- **Test backfill**: previously the 4 v1 tools had zero test coverage. This PR adds:
  - New `RunExploreQueryToolTest` (schema validation, missing/empty args, unknown data_source, invalid metric/dimension per source, TLD permission denial, description smoke).
  - Backfilled tests for `QueryTransfersTool`, `GetPricingRulesTool`, `QueryRegistrarActivityTool`, `QueryDomainDetailsTool` — same shape (input validation + permission denial).
  - Shared `AiToolTestBase` with JPA extension, fake clock, user fixtures (`createFteUser`, `createRoUser`, `mapUserToTld`), and `assertAiToolException` helper.
- **Spec**: `docs/superpowers/specs/2026-04-30-registry-dash-ai-tier3-explore-tool.md` with the schema decision rationale, guardrails, and test scope.
- **Test plan**: 3 new E2E test cases (21, 22, 23) added to `test-registry-dash` skill — positive (run_explore_query fires), negative (specific tool wins for questions it covers), and statement-timeout error message.

## Guardrails

| | Mechanism |
|---|---|
| TLD scope | `ToolJpaHelper.assertTldAccess(user, tld)` — non-admin users get `AiToolException` for TLDs outside their `RegistryDashAccessUtil` mapping; FTE bypasses |
| Row cap | `ai.tools.maxRows` (default 500) — passed to `runExplore`; result includes `truncated=true` when hit |
| Query timeout | `ai.tools.statementTimeoutSeconds` (default 30) — surfaces actionable `AiToolException` instead of opaque 120s gateway timeout |
| Schema | `ExploreDataSource.validate()` rejects unknown metrics/dimensions/filters per source; converted to `AiToolException` |
| Audit | Per-invocation log line via FluentLogger: `AI tool run_explore_query: user=… tld=… dataSource=… dimensions=… metrics=… registrarIds=… operations=… activityTypes=… startDate=… endDate=…` |
| PII | ICANN thin registry — domain_name is public record. No registrant contact data in any `ExploreDataSource` |

## Out of scope (deferred follow-ups)

- **Consolidated tool audit logging** — refactor `AiOrchestrator.run()`'s `toolsUsed: List<String>` → `List<ToolInvocation>` so per-tool descriptor detail rolls up into the orchestrator's existing log line. Drafted at `bozeman-v1/.context/tier3-followup-extended-tool-audit-logging-prompt.md`. Deferred until both this PR and the sibling specific-tools PR merge so it can update all tools at once.
- **Drift-detection CI** between nomulus and nomulus-secrets `default-config.yaml`. Flagged in the parent spec; not addressed here.
- **Statement-timeout for the 4 existing tools** — added scoped to `RunExploreQueryTool` for now; broadening to all callers can be a small follow-up that updates the existing 4 tools to use the new overload.

## Coordination

- **Sibling PR (specific-tools batch 2)** is in flight on `UDtorrey/sre-1941-tier3-batch2-tools` (swordfish worktree). Mechanical merge conflict on `AiToolRegistry`'s constructor — whichever PR merges second adds the missing constructor param. No design overlap.
- **nomulus-secrets follow-up PR** opens after this one merges, mirroring the `ai.tools` block and `ai.prompts.toolsHeader` to the deployed config (per the established `nomulus-secrets-tier3-toolsheader-prompt.md` pattern). The deployed jar reads from nomulus-secrets, so this is what changes runtime behavior in alpha-gke.

## Test plan

- [x] `./gradlew :core:compileJava :core:compileTestJava` — clean
- [x] `./gradlew :core:standardTest --tests "google.registry.ai.tools.*"` — BUILD SUCCESSFUL; new tests + backfills pass; audit-log line confirmed in stderr (`AI tool run_explore_query: user=admin@example.com …`)
- [x] `cd console-webapp && npm run build` — clean (Application bundle generation complete)
- [ ] Local E2E (Tests 21, 22, 23 in test-plan.md) — to be exercised against alpha-gke once nomulus-secrets PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)