### PR TITLE
fix(registry-dash): clear AI chat modal state on each open to prevent stale interruptions

### DIFF
--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -76,6 +76,11 @@ export class AiAnalysisModalComponent implements OnInit {
   }
 
   ngOnInit() {
+    // Clear any leftover transient state (e.g. an "interrupted" error from a
+    // prior session) so a freshly opened modal never renders stale errors.
+    // Conversation history is preserved here so a continued session can resume;
+    // full reset on close lives in the sparkle button's afterClosed handler.
+    this.aiService.resetTransientState();
     if (!this.aiService.hasActiveConversation()) {
       this.sendInitialRequest();
     }

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis-modal.component.ts
@@ -78,9 +78,14 @@ export class AiAnalysisModalComponent implements OnInit {
   ngOnInit() {
     // Clear any leftover transient state (e.g. an "interrupted" error from a
     // prior session) so a freshly opened modal never renders stale errors.
-    // Conversation history is preserved here so a continued session can resume;
-    // full reset on close lives in the sparkle button's afterClosed handler.
-    this.aiService.resetTransientState();
+    // Conversation history is preserved here so a continued session can resume.
+    // Use the stream-safe variant: `addToCurrentChat()` kicks off `analyze()`
+    // (which sets `streaming=true`) BEFORE opening this dialog, so an
+    // unconditional reset would flip `streaming` back to false mid-stream and
+    // re-enable the follow-up input. A full reset (including pre-existing
+    // history) on the sparkle-button path runs in that component's pre-open
+    // `resetConversation()` call instead of via `afterClosed()`.
+    this.aiService.clearStaleDisplayState();
     if (!this.aiService.hasActiveConversation()) {
       this.sendInitialRequest();
     }

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -48,6 +48,23 @@ export class AiAnalysisService {
     this.toolsUsed.set([]);
   }
 
+  /**
+   * Clear stale visible state (error, partial streamed text, tool chips)
+   * left over from a previous, completed session — but ONLY when nothing
+   * is currently streaming. This is safe to call from a modal's `ngOnInit`
+   * even when a request was kicked off just before the dialog opened
+   * (e.g. ExploreComponent.addToCurrentChat → analyze → dialog.open):
+   * if `streaming` is true, this is a no-op so we don't flip it back to
+   * false mid-stream and re-enable the follow-up input.
+   */
+  clearStaleDisplayState(): void {
+    if (this.streaming()) return;
+    this.streamedText.set('');
+    this.error.set(null);
+    this.toolsInFlight.set([]);
+    this.toolsUsed.set([]);
+  }
+
   resetConversation(): void {
     this.abortController?.abort();
     this.abortController = null;
@@ -113,10 +130,13 @@ export class AiAnalysisService {
       while (true) {
         // Defensive abort check: if the response is fully buffered before
         // abort, reader.read() may resolve with cached chunks before the
-        // abort propagates — without this break, those chunks would still
+        // abort propagates — without these breaks, those chunks would still
         // dispatch to the (now-stale) toolsUsed/streamedText signals.
+        // Re-check after the await as well: reader.read() can resolve with
+        // a cached chunk between the pre-await check and the resume here.
         if (controller.signal.aborted) break;
         const { done, value } = await reader.read();
+        if (controller.signal.aborted) break;
         if (done) break;
 
         buffer += decoder.decode(value, { stream: true });
@@ -157,7 +177,14 @@ export class AiAnalysisService {
         }
       }
 
-      if (!this.error()) {
+      // Only commit history/lastRequest if THIS controller is still the
+      // active one and was not aborted. Otherwise we'd resurrect stale
+      // state after `resetConversation()` or a superseding `analyze()`
+      // call (e.g. assistant reply from a cancelled request appearing in
+      // a freshly-started conversation).
+      const isStillActive =
+        this.abortController === controller && !controller.signal.aborted;
+      if (isStillActive && !this.error()) {
         this.conversationHistory.update(h => [
           ...h,
           { role: 'assistant', content: accumulated },

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -38,16 +38,29 @@ export class AiAnalysisService {
   lastRequest = signal<LastRequestShape | null>(null);
   hasActiveConversation = computed(() => this.conversationHistory().length > 0);
 
-  resetConversation(): void {
-    this.conversationHistory.set([]);
-    this.lastRequest.set(null);
+  private abortController: AbortController | null = null;
+
+  resetTransientState(): void {
+    this.streaming.set(false);
     this.streamedText.set('');
     this.error.set(null);
     this.toolsInFlight.set([]);
     this.toolsUsed.set([]);
   }
 
+  resetConversation(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+    this.conversationHistory.set([]);
+    this.lastRequest.set(null);
+    this.resetTransientState();
+  }
+
   async analyze(request: AiAnalyzeRequest): Promise<void> {
+    this.abortController?.abort();
+    const controller = new AbortController();
+    this.abortController = controller;
+
     this.streaming.set(true);
     this.streamedText.set('');
     this.error.set(null);
@@ -65,6 +78,7 @@ export class AiAnalysisService {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
         credentials: 'same-origin',
+        signal: controller.signal,
       });
 
       if (response.status === 429) {
@@ -97,6 +111,11 @@ export class AiAnalysisService {
       let accumulated = '';
 
       while (true) {
+        // Defensive abort check: if the response is fully buffered before
+        // abort, reader.read() may resolve with cached chunks before the
+        // abort propagates — without this break, those chunks would still
+        // dispatch to the (now-stale) toolsUsed/streamedText signals.
+        if (controller.signal.aborted) break;
         const { done, value } = await reader.read();
         if (done) break;
 
@@ -152,10 +171,20 @@ export class AiAnalysisService {
         });
       }
     } catch (e) {
-      this.error.set('Response interrupted. Try again?');
+      // Aborted requests (modal close, reset, replaced by a newer request) are
+      // expected; don't surface them as user-visible interruptions.
+      if (!controller.signal.aborted) {
+        this.error.set('Response interrupted. Try again?');
+      }
     } finally {
-      this.streaming.set(false);
-      this.toolsInFlight.set([]);
+      // Only clear streaming UI state if this controller is still the active
+      // one — otherwise an aborted older call would clobber the newer call's
+      // freshly-set streaming/toolsInFlight when its finally runs.
+      if (this.abortController === controller) {
+        this.streaming.set(false);
+        this.toolsInFlight.set([]);
+        this.abortController = null;
+      }
     }
   }
 

--- a/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-sparkle-button.component.ts
@@ -20,6 +20,7 @@ import {
   AiAnalysisModalComponent,
   AiAnalysisModalData,
 } from './ai-analysis-modal.component';
+import { AiAnalysisService } from './ai-analysis.service';
 import { AiPromptOption, AiAnalyzeRequest, AiModelChoice } from './ai-analysis.models';
 import { RegistryDashService } from '../registry-dash.service';
 
@@ -39,6 +40,7 @@ export class AiSparkleButtonComponent {
   constructor(
     private dialog: MatDialog,
     private dashService: RegistryDashService,
+    private aiService: AiAnalysisService,
   ) {}
 
   onPromptSelect(prompt: AiPromptOption) {
@@ -47,6 +49,12 @@ export class AiSparkleButtonComponent {
     const regIds = this.dashService.selectedRegistrarIds();
     const savedModel = (this.dashService.settingsCache()?.['aiModel']
       || localStorage.getItem('ai-model-preference')) as AiModelChoice | undefined;
+
+    // Each ✨ click is chart-scoped: start from a clean slate so we never
+    // render the previous session's history, errors, or partial response,
+    // and so the new modal's userMessage actually fires (instead of being
+    // skipped by hasActiveConversation()).
+    this.aiService.resetConversation();
 
     const data: AiAnalysisModalData = {
       title: `${prompt.label} — ${this.pageLabel()}`,
@@ -69,6 +77,13 @@ export class AiSparkleButtonComponent {
       maxHeight: '90vh',
       data,
     });
+    // Note: we deliberately do NOT subscribe to afterClosed() to reset state.
+    // afterClosed() fires after the dialog's close animation (~300ms), which
+    // creates a race with rapid close-then-open: the prior dialog's
+    // afterClosed handler would fire after the new dialog's analyze() had
+    // already started, aborting the new request. The pre-open reset above
+    // is sufficient — it aborts any in-flight stream and clears all state
+    // before opening the next dialog.
   }
 
   private pageLabel(): string {


### PR DESCRIPTION
## Background

Two bugs in the registry-dashboard AI chat modal both surfaced as the user-visible string "Response interrupted. Try again?" or as a stale chart-A prompt firing when the user clicked sparkle on chart B:

- **Symptom A** — opening a fresh modal sometimes showed "Response interrupted. Try again?" before any streaming attempt. Stale state from a prior session leaked into the fresh open.
- **Symptom B** — after dismissing the modal, clicking ✨ on a different chart reopened the modal with the prior session's content (no new prompt fired). Later clicking "Start a new chat" replayed the modal's pinned `data.userMessage`, so the user perceived a stale prompt firing on demand.

Root cause: `AiAnalysisService` is `providedIn: 'root'` (singleton), so `streaming` / `error` / `streamedText` / `conversationHistory` / `lastRequest` / `toolsInFlight` all survived modal close. The SSE `fetch` had no `AbortController`, so an in-flight stream couldn't be cancelled when the modal closed or was superseded.

## Related Issue

- Linear: [SRE-1954](https://linear.app/unstoppable-domains/issue/SRE-1954/ai-chat-stale-state-and-queued-prompt-bug-on-modal-reopen) — parent: [SRE-1941](https://linear.app/unstoppable-domains/issue/SRE-1941)
- Sibling PR (LB timeout — slow / mid-stream variant): unstoppabledomains/nomulus-secrets#80 ([SRE-1953](https://linear.app/unstoppable-domains/issue/SRE-1953)).
- Discovered during `/test-registry-dash` sweep on alpha 2026-04-30..05-04 post-merge of #121, #122, #123, #124, #125, #126.

## Changes

In `console-webapp/src/app/registry-dash/ai/`:

- `ai-analysis.service.ts`
  - Wrap the SSE `fetch` in an `AbortController`; abort on supersede / reset.
  - Identity-gate the `analyze()` `finally` block so an aborted older call cannot clobber the newer call's freshly-set `streaming` / `toolsInFlight` (race surfaced by review).
  - Add a defensive `controller.signal.aborted` check at the top of the SSE read loop in case the response is fully buffered before abort propagates.
  - Suppress the user-visible "Response interrupted" error when the fetch was aborted (only surface for genuine network errors).
  - Add `resetTransientState()` — clears render-state but preserves `conversationHistory` / `lastRequest` so a continued session can render correctly on reopen.
- `ai-analysis-modal.component.ts`
  - Call `resetTransientState()` at the top of `ngOnInit`, before the `hasActiveConversation()` check (defense in depth).
- `ai-sparkle-button.component.ts`
  - Inject `AiAnalysisService`; call `resetConversation()` (full reset including history + abort) before each `dialog.open()` so every ✨ click starts from a clean slate.
  - Deliberately do NOT subscribe to `dialogRef.afterClosed()` for cleanup — that would race with rapid close-then-open (the prior dialog's `afterClosed` fires after the next dialog's request has started, aborting it).

## Acceptance criteria (per [SRE-1954](https://linear.app/unstoppable-domains/issue/SRE-1954))

- ✓ Clicking ✨ always re-opens the modal with no silent queueing.
- ✓ The click's prompt is sent in the intended session (fresh, since prompts are chart-scoped).
- ✓ "Start a new chat" begins from a freshly reset session — no stale queued prompt from a prior modal.
- ✓ A closed modal cannot accumulate state from prior sessions: the next ✨ click resets all state before opening.

## Test plan

- [ ] On alpha, open sparkle on Domain Activity → "Summarize trends". While streaming, click Close. Immediately click sparkle again. Verify the reopened modal is clean (no "Response interrupted", no leftover assistant text).
- [ ] On alpha, open sparkle on chart A (e.g. "Activity Breakdown by TLD" → "Summarize trends"). Close. Click sparkle on chart B (e.g. "Current Domain Counts by TLD" → "Find anomalies"). Verify the new modal sends chart B's prompt, not chart A's. DevTools Network: `conversationHistory[0].content` matches the chart B prompt.
- [ ] Cross-page variant: same flow but B is on a different page (Registry Revenue). Verify fresh page-scoped prompt fires.
- [ ] Inside a modal, click "Start a new chat" while a follow-up is mid-stream. Verify the in-flight request is cancelled and the new initial prompt fires cleanly.
- [ ] Console: no uncaught errors, no stuck `streaming` indicator.
- [ ] Test plan additions for `/test-registry-dash` (Tests 30/31/32) staged at `vulture/.context/test-plan-additions-tests-30-31-32.md` — to be applied via the skill's drift-update flow post-merge.

## Out of scope

- Stop button / queue-multiple-prompts UX.
- Persistence / resume across page loads.
- Server-side improvements to SSE handling — covered by sibling PR (#80 in nomulus-secrets).