### PR TITLE
fix(registry-dash): set utf-8 charset on AI SSE response

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -16,9 +16,11 @@ package google.registry.ui.server.console.registrydash;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
+import com.google.common.net.MediaType;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -113,8 +115,11 @@ public class RegistryDashAiAction extends ConsoleApiAction {
       // Set Content-Type (with charset) before getWriter(): the writer's encoding is fixed at the
       // moment getWriter() is called. Without this, Jetty defaults the writer to ISO-8859-1 and
       // any non-Latin-1 characters from Anthropic (em-dash, smart quotes, emoji) get substituted
-      // with '?' on the way out.
-      consoleApiParams.response().setHeader("Content-Type", "text/event-stream; charset=utf-8");
+      // with '?' on the way out. setContentType() is the canonical Jakarta Servlet API for both
+      // header and writer encoding (vs. setHeader, which is container-dependent).
+      consoleApiParams
+          .response()
+          .setContentType(MediaType.create("text", "event-stream").withCharset(UTF_8));
       consoleApiParams.response().setHeader("Cache-Control", "no-cache");
       consoleApiParams.response().setHeader("Connection", "keep-alive");
       consoleApiParams.response().setStatus(200);

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/RegistryDashAiAction.java
@@ -110,11 +110,15 @@ public class RegistryDashAiAction extends ConsoleApiAction {
     String resolvedModel = AnthropicClient.resolveModelId(model != null ? model : "sonnet");
 
     try {
-      PrintWriter writer = consoleApiParams.response().getWriter();
-      consoleApiParams.response().setHeader("Content-Type", "text/event-stream");
+      // Set Content-Type (with charset) before getWriter(): the writer's encoding is fixed at the
+      // moment getWriter() is called. Without this, Jetty defaults the writer to ISO-8859-1 and
+      // any non-Latin-1 characters from Anthropic (em-dash, smart quotes, emoji) get substituted
+      // with '?' on the way out.
+      consoleApiParams.response().setHeader("Content-Type", "text/event-stream; charset=utf-8");
       consoleApiParams.response().setHeader("Cache-Control", "no-cache");
       consoleApiParams.response().setHeader("Connection", "keep-alive");
       consoleApiParams.response().setStatus(200);
+      PrintWriter writer = consoleApiParams.response().getWriter();
 
       ImmutableList<String> toolsUsed =
           orchestrator.run(

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -122,7 +122,8 @@ class RegistryDashAiActionTest {
     String openQuote = "“";
     String closeQuote = "”";
     String emoji = "🚀"; // rocket
-    String multibyteText = "Anomaly " + openQuote + "spike" + closeQuote + " " + emDash + " " + emoji;
+    String multibyteText =
+        "Anomaly " + openQuote + "spike" + closeQuote + " " + emDash + " " + emoji;
 
     doAnswer(
             invocation -> {

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -99,7 +99,7 @@ class RegistryDashAiActionTest {
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(200);
-    assertThat(response.getHeaders().get("Content-Type"))
+    assertThat(response.getContentType().toString())
         .isEqualTo("text/event-stream; charset=utf-8");
     String written = response.getStringWriter().toString();
     assertThat(written).contains("Hello ");

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -99,10 +99,52 @@ class RegistryDashAiActionTest {
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.getHeaders().get("Content-Type"))
+        .isEqualTo("text/event-stream; charset=utf-8");
     String written = response.getStringWriter().toString();
     assertThat(written).contains("Hello ");
     assertThat(written).contains("world");
     assertThat(written).contains("[DONE]");
+  }
+
+  @Test
+  void testSuccess_preservesNonLatin1Characters() throws Exception {
+    String payload =
+        "{\"page\":\"domain-activity\",\"promptType\":\"summarize_trends\","
+            + "\"chartData\":{\"activity\":[]},\"conversationHistory\":["
+            + "{\"role\":\"user\",\"content\":\"Summarize trends\"}"
+            + "]}";
+    JsonElement json = JsonParser.parseString(payload);
+
+    // Em-dash, smart quotes, and emoji all live outside Latin-1 (ISO-8859-1) and would be
+    // substituted with '?' if the response writer were not configured for UTF-8.
+    String emDash = "—";
+    String openQuote = "“";
+    String closeQuote = "”";
+    String emoji = "🚀"; // rocket
+    String multibyteText = "Anomaly " + openQuote + "spike" + closeQuote + " " + emDash + " " + emoji;
+
+    doAnswer(
+            invocation -> {
+              Consumer<AiOrchestrator.OrchestratorEvent> sink = invocation.getArgument(4);
+              sink.accept(new AiOrchestrator.TextEvent(multibyteText));
+              sink.accept(new AiOrchestrator.DoneEvent());
+              return ImmutableList.of();
+            })
+        .when(orchestrator)
+        .run(any(), any(), any(), any(), any());
+
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params, Optional.of(json), orchestrator, rateLimiter, defaultPromptConfig());
+    action.run();
+
+    String written = response.getStringWriter().toString();
+    assertThat(written).contains(emDash);
+    assertThat(written).contains(openQuote);
+    assertThat(written).contains(closeQuote);
+    assertThat(written).contains(emoji);
+    assertThat(written).doesNotContain("?");
   }
 
   @Test


### PR DESCRIPTION
## Summary

The AI chat modal was rendering `?` / `??` in place of em-dashes, smart quotes, and emoji from Anthropic. Two-part root cause in `RegistryDashAiAction`:

1. `getWriter()` was called before the Content-Type was set, so Jetty locked the writer's `CharsetEncoder` to its ISO-8859-1 default — every non-Latin-1 char was substituted with `0x3F` on the way out.
2. The `Content-Type` header itself didn't carry a charset.

Reorder so headers and status are set before `getWriter()`, and emit `text/event-stream; charset=utf-8`.

Linear: [SRE-1952](https://linear.app/unstoppable-domains/issue/SRE-1952/ai-chat-fix-sse-response-charset-iso-8859-1-utf-8)

## Test plan

- [x] New unit test `testSuccess_preservesNonLatin1Characters` pumps em-dash, smart quotes, and 🚀 through the orchestrator and asserts they survive with no `?` substitution.
- [x] Existing success test now also asserts the Content-Type header is `text/event-stream; charset=utf-8`.
- [x] `./gradlew :core:standardTest --tests RegistryDashAiActionTest` green.
- [ ] On alpha after deploy: open Interactive Analysis modal, trigger "Find anomalies" preset, confirm DevTools shows utf-8 Content-Type and no `?` rendering.

## Rollback

Trivially `git revert` — no schema, config, or data changes.