### PR TITLE
docs(registry-dash): SSE streaming caveat + test-plan refresh for tier-3 / state-fix / utf-8 [SRE-1955]

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
@@ -98,14 +98,14 @@ The AI sparkle flow uses Server-Sent Events on `/console-api/registry-dash/ai/an
 
 Safe ways to inspect a streaming response during a sweep:
 
-- Pass-through capture: if you must observe the bytes from JS, replace the body with a single `ReadableStream` you control, read each chunk once, forward it to the original consumer, and accumulate a copy for inspection. One reader, no `clone()`, no `tee()`.
+- Pass-through capture: if you must observe the bytes from JS, return a new `Response` whose body is a single `ReadableStream` you control, read each chunk once, forward it to the original consumer, and accumulate a copy for inspection. (`Response.body` is read-only on an existing response, so the interceptor must construct a replacement, not mutate in place.) One reader, no `clone()`, no `tee()`.
 - Out-of-band observation (preferred): Chrome DevTools (Network tab → EventStream / Response), the browser network log via Chrome MCP, or the test server logs. None of these touch the in-page response object, so they cannot perturb the stream.
 
 If the modal shows "Response interrupted. Try again?" during a `/test-registry-dash` run, assume tooling first, not the app. Before logging it as a bug:
 
-1. Check the Network tab / Chrome MCP network log — did `/ai/analyze` return 200 with a complete event stream?
+1. Check the Network tab / Chrome MCP network log — did `/console-api/registry-dash/ai/analyze` return 200 with a complete event stream?
 2. Check the test server logs — did the handler finish without error?
-3. Confirm no interceptor in the current session is calling `response.clone()` / `body.tee()` on `/ai/analyze`.
+3. Confirm no interceptor in the current session is calling `response.clone()` / `body.tee()` on `/console-api/registry-dash/ai/analyze`.
 
 Only if all three confirm a real failure is this an app bug worth filing.
 

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
@@ -92,6 +92,23 @@ Print a summary table with one row per test: ✅ Passed / ⚠️ Partial / ❌ F
 
 If any new bugs are discovered, offer to log them as Linear tickets in the RSP project, Registry Dashboard milestone, with `bug` label.
 
+## Streaming endpoints
+
+The AI sparkle flow uses Server-Sent Events on `/console-api/registry-dash/ai/analyze`. The Angular client owns the response body and reads it with a single `ReadableStream` reader. Do NOT install fetch/XHR interceptors that call `response.clone()` (or otherwise tee the underlying stream) on this endpoint during a test run — `clone()` produces two parallel readers racing the same stream, and the client-side reader will throw mid-stream. The modal's catch path then renders "Response interrupted. Try again?" even though the server completed the SSE response cleanly.
+
+Safe ways to inspect a streaming response during a sweep:
+
+- Pass-through capture: if you must observe the bytes from JS, replace the body with a single `ReadableStream` you control, read each chunk once, forward it to the original consumer, and accumulate a copy for inspection. One reader, no `clone()`, no `tee()`.
+- Out-of-band observation (preferred): Chrome DevTools (Network tab → EventStream / Response), the browser network log via Chrome MCP, or the test server logs. None of these touch the in-page response object, so they cannot perturb the stream.
+
+If the modal shows "Response interrupted. Try again?" during a `/test-registry-dash` run, assume tooling first, not the app. Before logging it as a bug:
+
+1. Check the Network tab / Chrome MCP network log — did `/ai/analyze` return 200 with a complete event stream?
+2. Check the test server logs — did the handler finish without error?
+3. Confirm no interceptor in the current session is calling `response.clone()` / `body.tee()` on `/ai/analyze`.
+
+Only if all three confirm a real failure is this an app bug worth filing.
+
 ## Constraints
 
 - Do not modify `metadata.json` outside of an open PR. Local edits to it are not authoritative.

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastReviewedCommit": "0e786ebf24e0e0169a75c538df74807bc6b3153c",
-  "lastReviewedAt": "2026-04-29",
+  "lastReviewedCommit": "e8626eb68db64bcbd42b6d21b5bfa4a645f751bd",
+  "lastReviewedAt": "2026-05-05",
   "lastReviewer": "torrey@unstoppabledomains.com",
-  "lastReviewerNote": "Tier 2: Portfolio + Pricing sparkle, AiPromptsService, GET /ai/prompts endpoint, YAML-driven prompts, promptVersion logging. Adds tests 13-17."
+  "lastReviewerNote": "Tier 3 (PRs #122, #124, #126), Add-to-AI-Chat (#125), modal state reset / abort fix (#127, SRE-1954), and SSE UTF-8 charset fix (#128, SRE-1952). Adds tests 30-37 covering tool fan-out, batch-2 guardrails, registrar-scoped permission, post-#127 conversation lifecycle, promptVersion=v1.0.2, maxRows truncation, modal abort/reset behavior, and multibyte rendering."
 }

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -558,3 +558,188 @@ Goal: confirm query_expiration_curve fires for forward-looking expiration questi
 - Final text reads something like *"Query exceeded 1s - try a narrower date range or smaller scope."*
 - Server log includes the descriptor line and the SQL state 57014.
 - No generic 502/504 gateway error reaches the browser.
+
+---
+
+## Test 30: Tier 3 v1 — All four tools fire with correct indicator
+
+**Goal:** Verify each of the four PR #122 tools (`query_transfers`, `get_pricing_rules`, `query_registrar_activity`, `query_domain_details`) is reachable from a natural-language prompt and that the SSE wire format includes `tool_use` / `tool_result` / `done` events for at least one of them.
+
+### Prerequisites:
+- Local-dev or alpha. Local-dev: run `helpers/seed-test-data.sh` so seeded transfer history, pricing rules, and at least one domain with multi-event history exist.
+
+### Steps:
+1. Navigate to **Domain Activity**, open the analysis modal via sparkle.
+2. After the initial analysis completes, in the follow-up box ask: `What domains transferred on tld example in the last 30 days?` Watch for the `🔍 Searching transfers` indicator.
+3. In the same modal, follow up: `What's the current pricing for tld example?` Watch for `💰 Looking up pricing`.
+4. Follow up: `What activity did TheRegistrar do last month on tld example?` Watch for `📊 Checking registrar activity`.
+5. Follow up: `Tell me everything about the domain <name from step 2>.` Watch for `🔎 Looking up domain`.
+6. Open DevTools → Network → click the most recent `/console-api/registry-dash/ai/analyze` request → **EventStream** tab. (Do **not** install any in-page response interceptor that calls `response.clone()` — see SKILL.md note.)
+7. Tail the test server log (or Cloud Logging on alpha) for `RegistryDashAiAction`.
+
+### Expected:
+- Each follow-up triggers its labelled indicator mid-stream and the indicator clears once Claude resumes text.
+- The DevTools EventStream tab shows at least one frame of each: `{"type":"text",...}`, `{"type":"tool_use","tool":"query_transfers","args":{...}}`, `{"type":"tool_result","tool":"query_transfers","ok":true}`, `{"type":"done"}`.
+- The four corresponding `AI analysis request:` server-log lines include `toolsUsed=[query_transfers]`, `toolsUsed=[get_pricing_rules]`, `toolsUsed=[query_registrar_activity]`, and `toolsUsed=[query_domain_details]` respectively.
+
+---
+
+## Test 31: Tier 3 Batch 2 — Guardrail validation
+
+**Goal:** Verify the validation gates documented in PR #124 produce user-visible tool errors rather than silently broken responses: `query_revenue_breakdown` rejects ranges > 2y and `group_by=registrar`; `query_expiration_curve` clamps `months_ahead` to [1, 60]; `get_tld_config` truncates `allowed_registrars` at 100.
+
+### Prerequisites:
+- Local-dev preferred (server log inspection is required). Alpha works for the date-range and clamp checks but not for the truncation case unless a TLD with > 100 allowed registrars exists.
+- For the truncation case, run `helpers/seed-test-data.sh` (or equivalent) to attach > 100 registrars to one TLD.
+
+### Steps:
+1. Open the analysis modal on **Financials → Registry Revenue**.
+2. Ask: `Break down revenue for tld example from 2022-01-01 through 2025-01-01 by operation.` (3-year span — exceeds the 2-year cap.)
+3. Watch the streamed response and tail the server log line for `toolsUsed=[query_revenue_breakdown]`.
+4. Close the modal. Reopen on Registry Revenue. Ask: `Break down revenue for tld example over the last 6 months by registrar.`
+5. Tail the server log again.
+6. Close. Open the modal on **Financials → Forecasting**. Ask: `How many domains in tld example expire in the next 240 months, broken out by month?` Tail the log for the descriptor line.
+7. Close. Open the modal on **Overview**. Ask: `How is the example TLD configured? List every registrar that can sell on it.` (Use the seeded TLD with > 100 allowed registrars.)
+
+### Expected:
+- Step 2: final assistant text includes a phrase like "date range exceeds the 2-year limit" (the tool returned an `is_error: true` result and Claude paraphrased it). Server log shows the `query_revenue_breakdown` invocation.
+- Step 4: final assistant text says `group_by=registrar` is not supported (or paraphrase). Server log shows the same tool name but a tool-error result.
+- Step 6: tool fires once, server log's per-tool descriptor (or the final assistant text) shows `months_ahead=60` — the value was silently clamped from 240 down to 60.
+- Step 7: assistant text mentions truncation ("showing 100 of N allowed registrars" or similar). Inspecting the SSE `tool_result` event (DevTools → EventStream) is fine; the result body itself is not on the wire (`tool_result` carries only `ok`), so confirmation comes from the assistant's paraphrase.
+
+---
+
+## Test 32: Tier 3 Batch 2 — Registrar-scoped permission denial
+
+**Goal:** Verify `get_registrar_details` enforces the new registrar-scoped permission gate (distinct from the TLD scope checked by Test 20).
+
+### Prerequisites:
+- A non-FTE user mapped to one specific registrar (e.g. `TheRegistrar`) and **not** mapped to another registrar that exists in the system (e.g. `NewRegistrar`). If the seeded fixture / `seed-test-data.sh` doesn't already provide one, mark this test partial and note the gap.
+
+### Steps:
+1. Log in as the scoped non-FTE user.
+2. Navigate to **Overview**, open the analysis modal.
+3. After the initial analysis, ask: `Tell me about registrar NewRegistrar.`
+4. Watch for the `🏢 Looking up registrar` indicator.
+5. Tail the server log for the `AI analysis request:` line.
+
+### Expected:
+- The indicator appears (the tool was called) and is replaced by a final assistant message of the form "I don't have access to that registrar" — never any details about NewRegistrar (no `iana_identifier`, no contacts, no allowed_tlds).
+- Server log shows `toolsUsed=[get_registrar_details]` with no stack trace.
+- Repeat the question with `TheRegistrar` (the user *is* mapped to it) — the assistant returns the registrar profile, confirming the denial in step 3 was scoped, not blanket.
+
+---
+
+## Test 33: Add to AI Chat — Conversation continues only via explicit "Add to current chat"
+
+**Goal:** Verify post-#127 behavior: the conversation owned by `AiAnalysisService` is preserved *only* when the user explicitly opts in via the Explore split-button "Add to current chat" item. Sparkle clicks on any page reset the conversation before opening (the singleton service is no longer treated as a per-page session resumer).
+
+### Prerequisites:
+- Same as Test 21. Test data sufficient for both the Domain Activity sparkle prompt and a non-empty Explore query result.
+
+### Steps:
+1. Navigate to **Domain Activity**, open the AI modal via the sparkle button → "Summarize trends". Wait for the initial analysis.
+2. Ask one follow-up: `Which TLD looks most active right now?` Wait for the response.
+3. Close the modal.
+4. Navigate to **Data Exploration**, configure any query (Source: Domain Activity, Metric: Count, Group By: TLD), click **Run Query**.
+5. Click **Add to AI Chat** → **Add to current chat**.
+6. Confirm the modal opens with the prior two turns still visible (the "Summarize trends" turn and the TLD follow-up), plus a new user turn carrying the descriptor and rows.
+7. Wait for Claude's response, then close the modal.
+8. Navigate to **Pricing**, click the **sparkle button**.
+9. Confirm the modal opens with a **fresh** conversation — only the new "Summarize trends — Pricing" seed turn. The prior Domain Activity / Explore turns must NOT be present (sparkle calls `resetConversation()` before `dialog.open()` per PR #127).
+10. From Explore again, click **Add to AI Chat** → **Start new chat**, then verify the chat opens with only the Explore-attached turn (no carry-over from the Pricing seed).
+
+### Expected:
+- Step 6: history is preserved across modal close + page navigation when re-entered through "Add to current chat".
+- Step 9: sparkle on a different page produces a clean conversation. Any bleed-through of prior turns is a regression of PR #127.
+- Step 10: "Start new chat" from Explore is also a clean reset.
+- No `Response interrupted. Try again?` ever appears, even if step 7's stream is closed mid-flight (PR #127 suppresses the user-visible interruption error on aborted fetches; cross-check via the SKILL.md note that no interceptor is calling `response.clone()` on `/ai/analyze`).
+
+---
+
+## Test 34: run_explore_query — promptVersion bump to v1.0.2
+
+**Goal:** Confirm the `ai.prompts.version` bump (v1.0.1 → v1.0.2) shipped in PR #126 reaches the orchestrator log line, since the bump is what carries the tools-header tie-breaker that drives Test 28's specific-vs-generic selection.
+
+### Prerequisites:
+- Local-dev or alpha with access to `RegistryDashAiAction` log lines.
+
+### Steps:
+1. Open the analysis modal on any page (Domain Activity is fine).
+2. Trigger any analysis (initial sparkle prompt is enough — no follow-up needed).
+3. Tail the server log for the `AI analysis request:` line.
+
+### Expected:
+- The log line includes `promptVersion=v1.0.2` (not `v1.0.1` or `v1`).
+- If `promptVersion=v1.0.1` is observed, `default-config.yaml`'s `ai.prompts.version` was not updated and Test 28's tie-breaker copy is also likely stale — file as a regression.
+
+---
+
+## Test 35: run_explore_query — Row-cap truncation (local-dev only)
+
+**Goal:** Verify the `ai.tools.maxRows` config knob caps the result payload and surfaces truncation either in the assistant's final text or in the audit log.
+
+### Prerequisites:
+- Local-dev only. Edit `default-config.yaml`'s `ai.tools.maxRows` to a small value (e.g. `5`). Restart the test server. Seed enough rows that an aggregation will exceed 5.
+
+### Steps:
+1. Open the analysis modal on **Domain Activity**.
+2. Ask a question that forces a wide-but-cheap aggregation, e.g. `For tld example, give me the count of activity per registrar per month for the last 12 months.` (Should produce > 5 rows.)
+3. Watch for the `🔬 Running data query` indicator.
+4. Wait for the final assistant text.
+5. Tail the server log for both the `RunExploreQueryTool` audit line and the `RegistryDashAiAction` `toolsUsed=` line.
+6. Revert `ai.tools.maxRows` and restart.
+
+### Expected:
+- The audit line from `RunExploreQueryTool` records the descriptor (`dataSource=DOMAIN_ACTIVITY`, `dimensions=[registrar, period]` or similar) and includes `truncated=true` (model-independent — this is the primary pass criterion).
+- The final assistant text either explicitly notes truncation ("showing 5 of N rows", or paraphrase) or is qualified ("partial results") — secondary criterion since it depends on Claude's paraphrasing.
+- No 502/504 or "Response interrupted" error reaches the browser.
+
+---
+
+## Test 36: Modal state reset on open — no stale "Response interrupted" or cross-chart prompt bleed
+
+**Goal:** Verify the PR #127 fixes for the AI chat modal: SSE fetches are wrapped in an `AbortController`, in-flight streams are cancelled on supersede / reset, the user-visible "Response interrupted. Try again?" is suppressed for aborted (non-network) fetches, and clicking the sparkle on a different chart does NOT fire chart-A's prompt while opening on chart B.
+
+### Prerequisites:
+- Local-dev or alpha. No special seed.
+
+### Steps:
+1. Navigate to **Portfolio**, open the AI modal via the sparkle button → wait for the initial analysis to **start streaming** (see chunks arriving in the modal).
+2. While the stream is still in flight, close the modal (X / Esc).
+3. Confirm the modal closes immediately and no `Response interrupted. Try again?` toast or modal-content message appears.
+4. Open DevTools → Network → confirm the in-flight `/console-api/registry-dash/ai/analyze` request shows status `(canceled)` (or equivalent client-side abort).
+5. Navigate to **Pricing**. Click the sparkle button.
+6. Confirm the modal opens with the Pricing seed prompt — NOT the Portfolio seed, NOT a stale Portfolio response, no flash of the prior streaming text.
+7. Repeat steps 1–4 but instead of closing in step 2, click the modal-header **"Start new chat"** while still streaming.
+8. Confirm the prior stream is aborted, the modal clears, and the next user submission proceeds cleanly.
+9. As a negative case, simulate a real network error (e.g. block the `/ai/analyze` endpoint via DevTools network throttling → Offline) and trigger a sparkle request.
+10. Confirm the modal **does** show "Response interrupted. Try again?" for this case (the suppression is scoped to user-initiated aborts only).
+
+### Expected:
+- Steps 3, 6, 8: no false interruption text and no chart-A prompt bleed onto chart-B.
+- Step 4: the request appears as cancelled in DevTools — not as failed-without-cancel.
+- Step 10: genuine network failures still surface the user-visible error, confirming the suppression in PR #127 was abort-scoped, not blanket.
+- Per the SKILL.md "Streaming endpoints" note, do NOT install any in-page response interceptor calling `response.clone()` while running this test — it would re-introduce false interruptions and confound the result.
+
+---
+
+## Test 37: AI SSE response — multibyte characters render correctly (UTF-8 charset)
+
+**Goal:** Verify the PR #128 fix: the AI SSE response carries `Content-Type: text/event-stream; charset=utf-8` and the writer is UTF-8-encoded, so em-dashes, smart quotes, and emoji from Anthropic render as themselves in the modal — not as `?` or `??`.
+
+### Prerequisites:
+- Local-dev or alpha. The model needs to actually emit multibyte characters; provoking this reliably is easiest with an explicit prompt.
+
+### Steps:
+1. Open the analysis modal on **Domain Activity**.
+2. After the initial analysis renders, ask the follow-up: `Reply with exactly this text and nothing else: "Active TLDs — top performers: 'example' and 'app' 🎯". Use the em-dash and curly quotes I sent.`
+3. Watch the streamed response chunk-by-chunk in the modal.
+4. Open DevTools → Network → click the request → **Headers** tab.
+5. Tail the test server log for any character-encoding warnings (none expected).
+
+### Expected:
+- The modal text faithfully renders `—` (em-dash, U+2014), `'` and `'` (curly quotes, U+2018/2019), and the 🎯 emoji (U+1F3AF). No `?` substitutions, no mojibake, no double-glyphs.
+- DevTools → Headers → Response Headers shows `content-type: text/event-stream;charset=utf-8` (charset present, lowercase or uppercase fine).
+- Server log is clean — no `Unsupported encoding` or `MalformedInput` warnings.
+- (Optional sanity) Repeat against an environment that does NOT have PR #128 — e.g. a stale alpha pre-deploy — and confirm the same prompt produces `?` substitutions there. This is the regression baseline.


### PR DESCRIPTION
## Summary

Two bundled docs-only updates to the `test-registry-dash` skill:

**1. New "Streaming endpoints" section in `SKILL.md`** (the original SRE-1955 work).

During a /test-registry-dash sweep, a fetch interceptor that called `response.clone()` on the `/ai/analyze` SSE response caused Angular's reader to throw, hitting the modal's catch path and showing "Response interrupted. Try again?" — even though the server completed the stream cleanly. Tee'ing the underlying `ReadableStream` means two parallel readers race.

The new section covers:
- The hazard (do not `clone()` / `tee()` the `/ai/analyze` body).
- Two safe alternatives: single-reader pass-through capture, or out-of-band observation via DevTools / Chrome MCP network log / server logs (preferred).
- Triage rule: a false "Response interrupted" during a sweep should be assumed to be tooling, not the app, until network/server-log evidence is checked.

**2. Test-plan refresh for 6 PRs of drift** (added to keep this PR from merging while the test-plan was stale; also a `chore(registry-dash):` style update but bundled here).

The drift detector flagged 6 merged PRs touching watched paths since the last reviewed commit (0e786ebf):

- #122 — AI Tier 3 v1 (agentic tool use)
- #124 — Tier 3 batch 2 (registrar / tld / revenue / renewal / expiration tools)
- #125 — "Add to AI Chat" from Data Exploration
- #126 — Tier 3 generic `run_explore_query` tool
- #127 — modal state reset + `AbortController` + suppress aborted-fetch error (SRE-1954)
- #128 — UTF-8 charset on AI SSE response (SRE-1952)

Adds 8 new tests (30-37):

| # | Coverage |
|---|---|
| 30 | All four PR #122 tools fire with correct indicator + SSE wire format |
| 31 | Batch-2 guardrail validation (date range, group_by, months_ahead clamp, allowed_registrars truncation) |
| 32 | Batch-2 registrar-scoped permission denial on `get_registrar_details` |
| 33 | Conversation continues only via explicit "Add to current chat"; sparkle resets per PR #127 |
| 34 | `promptVersion=v1.0.2` reaches `RegistryDashAiAction` log line |
| 35 | `ai.tools.maxRows` truncation surfaces in audit log (and ideally assistant text) |
| 36 | Modal abort/reset behavior — no stale "Response interrupted", no chart-A→chart-B prompt bleed, real network errors still surface |
| 37 | Multibyte characters (em-dash, smart quotes, emoji) render correctly through the SSE response |

`metadata.lastReviewedCommit` bumped to `e8626eb6` (current `origin/master`).

Docs-only — no app code change.

## Linear

[SRE-1955](https://linear.app/unstoppable-domains/issue/SRE-1955/test-registry-dash-skill-add-streaming-endpoints-caveat-sse-clone)

## Test plan

- [ ] Re-read `SKILL.md` rendered on GitHub and confirm the "Streaming endpoints" section reads cleanly.
- [ ] Re-read tests 30-37 in `test-plan.md` rendered on GitHub for tone/format consistency with the existing tests.
- [ ] Drift detector reports clean (`bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/check-drift.sh` produces no output) — verified locally.
- [ ] On the next /test-registry-dash sweep, exercise tests 30-37 against alpha post-deploy and confirm no fetch interceptor uses `response.clone()` on `/ai/analyze`.