### PR TITLE
chore(registry-dash): bump test-plan review to a48599093 (post PR #134)

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json
@@ -1,6 +1,6 @@
 {
-  "lastReviewedCommit": "5ae93c5a8e46cc18445239db443d45fc1a95e600",
-  "lastReviewedAt": "2026-05-04",
+  "lastReviewedCommit": "a48599093f87a473044394165d23935f9b6d7689",
+  "lastReviewedAt": "2026-05-05",
   "lastReviewer": "torrey@unstoppabledomains.com",
   "lastReviewerNote": "PR #134 SRE-1956 (modal interaction UX bundle: auto-scroll, queue, resize, input UX) merged on top of master after PR #132 SRE-1959 (dynamic Anthropic model catalog + complexity routing) and PR #133 SRE-1957 (Ask anything cold-start + universal sparkle on Financials sub-tabs). PR #132 owns tests 38-41. PR #134 + PR #130 own tests 42-62: 42-46 admin draft persistence + date awareness + dateRange, 47-53 queue chip lifecycle (type-during, FIFO, edit, remove, Stop/Resume, error/Retry, drainGeneration race), 54-56 auto-scroll + Jump-to-latest FAB, 57-61 resizable modal (drag, clamp, alt-tab abort, default fallback, theme), 62 combined input UX smoke (Shift+Enter, autogrow, wrap, send/stop swap, cancel preserves history). PR #133 owns tests 63-64 (renumbered from 42-43 in #133): cold-start Ask anything entry payload + universal sparkle drift guard on Financials sub-tabs. Test 1 + Test 2 updated for SRE-1957 universal coverage and 4-item menu with cold-start last."
 }


### PR DESCRIPTION
## Summary

- Reviewed master HEAD `a48599093` (PR #134 — SRE-1956 AI Chat modal interaction UX bundle) against the registry-dash test-plan skill watched paths.
- The existing `lastReviewerNote` already documents PR #134's content (tests 42-62: queue lifecycle, auto-scroll, resizable modal, input UX), and `test-plan.md` already contains tests 42-62 covering this surface area. **No `test-plan.md` changes were needed.**
- Only `metadata.json` is bumped: `lastReviewedCommit` → `a48599093…`, `lastReviewedAt` → `2026-05-05`.

## Test plan

- [x] Confirm `test-plan.md` already covers the diff in watched paths (`console-webapp/src/app/registry-dash/`, `core/src/main/java/google/registry/ai/`, `core/src/main/java/google/registry/ui/server/console/registrydash/`)
- [x] `metadata.json` bump is the only change