### PR TITLE
fix(registry-dash): relax drift gates and accept 4xx in port-open check

### DIFF
--- a/.claude/plugins/ud-registry-dash/commands/test-registry-dash.md
+++ b/.claude/plugins/ud-registry-dash/commands/test-registry-dash.md
@@ -6,9 +6,9 @@ Invoke the `test-registry-dash` skill to execute the Registry Dashboard UI test 
 
 The skill will:
 1. Compare HEAD against the last-reviewed commit recorded in `.claude/plugins/ud-registry-dash/skills/test-registry-dash/metadata.json` for files matching the watch list in `paths.txt`.
-2. If drift is detected, gate execution behind a forced test-plan update (worktree → PR), or require the user to type `proceed-without-test-updates` verbatim to bypass.
+2. If drift is detected, offer the user three paths: (a) update the test plan now — either bundled into the current branch or as a separate branch/worktree, or defer; (b) proceed anyway with a warning logged into the test report; (c) cancel.
 3. Prompt for the test environment: local-dev | alpha | sandbox. Production is rejected.
-4. Drive Chrome MCP to execute the 19-test plan in `test-plan.md`.
+4. Drive Chrome MCP to execute the test plan in `test-plan.md`.
 5. Report pass/fail per test.
 
 Args: `$ARGUMENTS` (optional — pass `--force-update` to skip straight to test-plan update flow).

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
@@ -41,22 +41,16 @@ If Docker isn't running, the script exits with a clear message — surface it to
 
 Show the user the drift summary, then offer three options:
 
-**a) Recommended: Update the test plan in a new worktree, PR to master.**
-- Ask the user: "What branch should the test-plan update branch off?"
-  - Default suggestion: `master` (clean baseline, use when not actively developing)
-  - Alternative: current branch (use when feature work is what's driving the test update)
-- Use the `superpowers:using-git-worktrees` skill to create the worktree.
-- Inside the worktree: read the diff for watched paths, propose updates to `test-plan.md`, propose updates to `metadata.json` (advance `lastReviewedCommit` to current HEAD, set `lastReviewer` to the git user).
-- Commit and open a PR against `master`. Title prefix `chore(registry-dash):`.
-- After PR is opened: stop. Tell the user "merge the PR, then re-run /test-registry-dash on a clean branch."
+**a) Update the test plan now.** Ask the user where to make the update:
+- **In the current branch** — bundle the test-plan update into the active feature branch. Use this when the drifting commits are part of the work the user is currently developing/reviewing; the test-plan changes ride along in the same PR.
+- **In a separate branch / worktree** — create a new branch (or use the `superpowers:using-git-worktrees` skill) off `master`, commit the test-plan update there, and open a standalone `chore(registry-dash):` PR against `master`. Use this when the drifting commits already merged and the user just needs to bump the metadata.
+- **Defer — handle separately later** — record the drift in the report and proceed to Phase 2 with a warning. Use this when the user wants to deal with the test-plan update on their own time.
 
-**b) Skip the update — proceed anyway.**
-- Require the user to type the **exact** phrase `proceed-without-test-updates` in their next message. Anything else (even close paraphrases) means abort.
-- If they type it correctly: log a warning into the test report ("⚠️ Tests run against drifted code; results may not reflect the current code state."), and continue to Phase 2.
-- This path exists for emergencies. Discourage it.
+In either of the first two paths, read the diff for watched paths, propose updates to `test-plan.md`, propose updates to `metadata.json` (advance `lastReviewedCommit` to current HEAD, set `lastReviewer` to the git user). Commit; if a standalone PR, open it against `master` with title prefix `chore(registry-dash):`. Then continue to Phase 2 (or stop, depending on how disruptive the test-plan changes were — ask the user).
 
-**c) Cancel.**
-- Stop and exit cleanly.
+**b) Skip the update — proceed anyway.** Confirm with the user (a normal yes/confirm is enough; no verbatim phrase). On confirmation: log a warning into the test report ("⚠️ Tests run against drifted code; results may not reflect the current code state."), and continue to Phase 2.
+
+**c) Cancel.** Stop and exit cleanly.
 
 ### Phase 2 — Environment selection
 
@@ -113,7 +107,6 @@ Only if all three confirm a real failure is this an app bug worth filing.
 
 - Do not modify `metadata.json` outside of an open PR. Local edits to it are not authoritative.
 - Do not run tests against production under any circumstance.
-- The override phrase `proceed-without-test-updates` must match **verbatim**. Do not accept paraphrases or partial matches.
 - Browser automation requires Chrome MCP tools (`mcp__claude-in-chrome__*`); load them via ToolSearch before driving the browser.
 
 ## When NOT to use

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh
@@ -45,8 +45,12 @@ for arg in "$@"; do
 done
 
 port_is_open() {
-  curl -sf --max-time 2 -o /dev/null "http://localhost:$1/" \
-    || curl -sf --max-time 2 -o /dev/null "http://[::1]:$1/"
+  # Treat any HTTP response (including 404) as "port open" — the test server
+  # has no root handler and returns 404 on /, but it's listening and serving.
+  # -f only succeeds on 2xx, so we'd miss a healthy server. Use plain --output
+  # /dev/null and check curl's exit status (0 = got a response).
+  curl -s --max-time 2 -o /dev/null "http://localhost:$1/" \
+    || curl -s --max-time 2 -o /dev/null "http://[::1]:$1/"
 }
 
 kill_stack() {


### PR DESCRIPTION
## Summary

Two small fixes to the `/test-registry-dash` plugin uncovered while running the skill against current master:

- **Phase 1b drift gates were over-restrictive.** Option (a) forced a fresh worktree off master + standalone PR even when the drift was caused by the user's active feature branch. Option (b) required typing the verbatim phrase `proceed-without-test-updates` to bypass. Both have been relaxed:
  - Option (a) now offers three paths: bundle the test-plan update into the current branch, do a separate branch/worktree, or defer (with a warning logged into the report).
  - Option (b) accepts a normal yes/confirm — no verbatim ceremony.
- **`port_is_open` in `start-local-stack.sh` used `curl -sf`,** which fails on 4xx. The test server has no root handler and returns 404 on `/`, so the script reported the port as down even though Jetty was bound and serving — bailing out before starting `ng`. Switched to plain `curl -s` so any HTTP response counts as "port open."

## Test plan

- [ ] Re-run `/test-registry-dash`. With current drift, verify the new three-option Phase 1b prompt is shown and that picking (b) accepts a plain "yes."
- [ ] On a fresh local stack: `bash .claude/plugins/ud-registry-dash/skills/test-registry-dash/helpers/start-local-stack.sh` should reach the `ng :4200` startup phase without bailing on the test-server check.