### PR TITLE
chore(registry-dash): tag admin-gated tests with Requires + capability probe

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/SKILL.md
@@ -77,10 +77,33 @@ Smoke tier targets ~15–25 min on alpha and covers DOM-only checks (sparkle vis
 
 When the skill is invoked, parse any `--tier=<value>` argument from the user's message before Phase 3. Carry the resolved tier filter into Phase 3 and apply it when reading `test-plan.md`.
 
+### Phase 2d — Capability detection
+
+Before kicking off Phase 3, probe the chosen environment for capabilities that gate certain tests. Currently:
+
+- **admin-page**: navigate to `/#/registry-dash/admin` and check whether the URL stays on `admin` or redirects to `/overview` (the route guard rejects non-admin users by silently redirecting). Equivalent JS check from any registry-dash page:
+
+  ```js
+  (async () => {
+    const before = location.hash;
+    location.hash = '#/registry-dash/admin';
+    await new Promise(r => setTimeout(r, 1500));
+    const ok = location.hash.includes('/admin');
+    if (!ok) location.hash = before;
+    return ok;
+  })()
+  ```
+
+  Returns `true` if the admin page is visible to this user, `false` otherwise.
+
+When a capability check fails, mark every test tagged `**Requires:** <capability>` in the test plan as `🚫 Skipped — <capability> unavailable in this environment`. This is distinct from `⏭️ Skipped` (out-of-tier) and from `❌ Failed`.
+
+Add new capabilities by repeating the same pattern: tag tests with `**Requires:** <name>`, and add a probe + skip rule here.
+
 ### Phase 3 — Test execution
 
 1. Read `test-plan.md`.
-2. Use `TaskCreate` to create one task per numbered test in the plan **whose `**Tier:**` line matches the active tier filter** (smoke / full / all). Tests outside the active tier are skipped silently — do not create tasks for them and do not list them as `⏭️ Skipped` in the report; the tier filter is the explicit user choice.
+2. Use `TaskCreate` to create one task per numbered test in the plan **whose `**Tier:**` line matches the active tier filter AND whose `**Requires:**` capabilities are all available** (per Phase 2d). Tests outside the active tier are skipped silently — do not create tasks for them and do not list them as `⏭️ Skipped` in the report; the tier filter is the explicit user choice. Tests skipped by capability are not surfaced as TaskCreate items either, but they DO appear in the Phase 4 report under a `🚫 Skipped (env)` row so the user knows what was deferred.
 3. Open Chrome MCP, navigate to the chosen environment, log in if needed (the user's session should already be valid).
 4. Execute each test in sequence. For each:
    - Mark `in_progress` via `TaskUpdate`.
@@ -90,7 +113,7 @@ When the skill is invoked, parse any `--tier=<value>` argument from the user's m
 
 ### Phase 4 — Reporting
 
-Print a summary table with one row per test: ✅ Passed / ⚠️ Partial / ❌ Failed / ⏭️ Skipped. For any non-pass, include a one-line root cause and a file path or URL pointer.
+Print a summary table with one row per test using one of these states: ✅ Passed / ⚠️ Partial / ❌ Failed / ⏭️ Skipped (out-of-tier) / 🚫 Skipped (env-gated). For any non-pass, include a one-line root cause and a file path or URL pointer.
 
 If any new bugs are discovered, offer to log them as Linear tickets in the RSP project, Registry Dashboard milestone, with `bug` label.
 

--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -820,6 +820,7 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 
 **Goal:** Verify the admin page renders the live model catalog and the fetched-at timestamp.
 **Tier:** smoke
+**Requires:** admin-page
 
 ### Prerequisites:
 - Logged in as an FTE/admin user (admin GET requires `MANAGE_COST_BASIS`).
@@ -841,6 +842,7 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 
 **Goal:** Verify the **Refresh now** button re-fetches `/v1/models` from Anthropic and updates `fetchedAt`.
 **Tier:** full
+**Requires:** admin-page
 **Tier rationale:** Triggers a server-side POST to refresh the catalog (admin-required state change, not pure UI render).
 
 ### Steps:
@@ -898,6 +900,7 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 
 **Goal:** Verify the Advanced (system prompt editor) panel is admin-only and resolves admin status from `UserDataService.userData()?.isAdmin` when the host doesn't pass `[isAdmin]` explicitly (PR #130).
 **Tier:** smoke
+**Requires:** admin-page
 
 ### Prerequisites:
 - Two test users: one FTE/admin (`userData.isAdmin === true`) and one non-admin.
@@ -923,6 +926,7 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 
 **Goal:** Verify the Advanced textarea autosaves to localStorage under `ai-system-prompt-draft:<page>` per-keystroke, restores on reopen, and is scoped per-page so a draft on one page does not bleed into another (PR #130 review fix).
 **Tier:** smoke
+**Requires:** admin-page
 **Tier rationale:** Pure localStorage + DOM state — opens modal, types, inspects keys, no streaming required.
 
 ### Prerequisites:
@@ -951,6 +955,7 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 
 **Goal:** Verify a saved draft only takes effect on the next request when the admin has explicitly expanded Advanced (per `systemPrompt: this.showAdvanced() ? this.editableSystemPrompt : undefined` in both `sendInitialRequest` and `runQueuedPrompt`).
 **Tier:** full
+**Requires:** admin-page
 
 ### Prerequisites:
 - Admin user. Local-dev preferred (server log inspection).


### PR DESCRIPTION
- Adds **Requires:** admin-page line to admin-gated tests in test-plan.md
- Adds Phase 2d capability detection to SKILL.md so the skill skips admin
  tests with 🚫 (env-gated) instead of failing them when run by a
  non-admin user

Documentation/skill-config only — no production code changes.