### PR TITLE
fix(registry-dash): serialize AI model catalog entry fields

### DIFF
--- a/core/src/main/java/google/registry/ai/AnthropicModelCatalog.java
+++ b/core/src/main/java/google/registry/ai/AnthropicModelCatalog.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.annotations.Expose;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -254,7 +255,8 @@ public class AnthropicModelCatalog {
   }
 
   /** Public model record exposed via API to the UI. */
-  public record ModelInfo(String id, String displayName, String createdAt) {}
+  public record ModelInfo(
+      @Expose String id, @Expose String displayName, @Expose String createdAt) {}
 
   private record CatalogSnapshot(
       ImmutableMap<String, ImmutableList<ModelInfo>> catalog, Instant fetchedAt) {}

--- a/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/registrydash/RegistryDashAiActionTest.java
@@ -24,9 +24,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.TestLogHandler;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonObject;
 import google.registry.ai.AiOrchestrator;
 import google.registry.ai.AiRateLimiter;
 import google.registry.ai.AnthropicModelCatalog;
+import google.registry.ai.AnthropicModelCatalog.ModelInfo;
 import google.registry.config.RegistryConfigSettings;
 import google.registry.model.console.User;
 import google.registry.persistence.transaction.JpaTestExtensions;
@@ -36,6 +38,7 @@ import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
 import google.registry.ui.server.console.ConsoleApiParams;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
@@ -502,6 +505,38 @@ class RegistryDashAiActionTest {
     action.run();
 
     assertThat(response.getStatus()).isEqualTo(429);
+  }
+
+  @Test
+  void testGet_serializesCatalogEntryFields() throws Exception {
+    when(params.request().getMethod()).thenReturn("GET");
+    when(modelCatalog.currentCatalog())
+        .thenReturn(
+            ImmutableMap.of(
+                "opus",
+                ImmutableList.of(
+                    new ModelInfo("claude-opus-4-7-20260101", "Opus 4.7", "2026-01-01"))));
+    when(modelCatalog.lastFetchedAt()).thenReturn(Instant.parse("2026-05-05T00:00:00Z"));
+
+    RegistryDashAiAction action =
+        new RegistryDashAiAction(
+            params,
+            Optional.empty(),
+            orchestrator,
+            rateLimiter,
+            defaultPromptConfig(),
+            modelCatalog,
+            clock);
+    action.run();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    JsonObject body = JsonParser.parseString(response.getPayload()).getAsJsonObject();
+    JsonObject entry =
+        body.getAsJsonObject("catalog").getAsJsonArray("opus").get(0).getAsJsonObject();
+    assertThat(entry.get("id").getAsString()).isEqualTo("claude-opus-4-7-20260101");
+    assertThat(entry.get("displayName").getAsString()).isEqualTo("Opus 4.7");
+    assertThat(entry.get("createdAt").getAsString()).isEqualTo("2026-01-01");
+    assertThat(body.get("fetchedAt").getAsString()).isNotEmpty();
   }
 
   private RegistryConfigSettings.Prompts defaultPromptConfig() {


### PR DESCRIPTION
## Summary

`GET /console-api/registry-dash/ai/analyze` was returning catalog entries as empty objects:

```json
{"catalog":{"opus":[{},{},{}],"sonnet":[{},{},{}],"haiku":[{}]},"fetchedAt":"…"}
```

Each entry should carry `id`, `displayName`, and `createdAt`.

## Root cause

`ModelInfo` is a Java `record` whose components had no `@Expose` annotation. The action serializes through the project-wide `Gson` from `GsonUtils.provideGson()`, which is built with `.excludeFieldsWithoutExposeAnnotation()` — so every field of every entry was excluded.

Introduced in 164a1121c (#132, "feat(registry-dash): dynamic Anthropic model catalog + complexity routing").

## Fix

- Annotate the three `ModelInfo` record components with `@Expose` (`AnthropicModelCatalog.java`). This matches the existing record-DTO convention in `mosapi/MosApiModels.java`.
- Add a regression test in `RegistryDashAiActionTest` that hits the `GET` path with a stubbed catalog and asserts the JSON entry shape (`id`, `displayName`, `createdAt`, `fetchedAt`). This test fails on `master` and passes after the annotation change.

## Test plan

- [x] `./nom_build :core:standardTest --testFilter='*RegistryDashAiActionTest*'` — passes
- [ ] After deploy to alpha, re-run Test 38 step 3 from `test-registry-dash/test-plan.md`: `GET https://console.dnex-alpha.com/console-api/registry-dash/ai/analyze` should return entries with populated fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)