### PR TITLE
feat(registry-dash): per-source date awareness + query_domain_footprint tool [SRE-1962]

### DIFF
--- a/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
+++ b/.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md
@@ -1487,3 +1487,107 @@ Steps: open modal on Financials > Forecasting, ask "How many domains in tld exam
 - Modal renders a yellow "Out of range" chip with the diagnostic in tooltip.
 - Final assistant text tells the user the range is in the future and suggests a different range - does NOT silently say "no transfers in March 2027" without context.
 - Server log shows `toolsUsed=[query_transfers]` with no second invocation of the same tool with the same args.
+
+---
+
+## Test 68: Tier 3 — query_domain_footprint "largest registrar" (SRE-1962 acceptance)
+
+**Goal:** Confirm the SRE-1962 acceptance criterion: "who is the largest registrar by registered domain footprint?" returns a real answer in one tool call via the new `query_domain_footprint` tool, not the old generic-blocked path.
+**Tier:** full
+
+### Prerequisites:
+- Local-dev or alpha. At least two TLDs and two registrars with seeded `Domain` rows (current sponsorship), so the count breakdown is non-trivial.
+
+### Steps:
+1. Open the analysis modal on **Overview** (or any page).
+2. Ask: `Who is the largest registrar across all of our TLDs?`
+3. Watch for the inline indicator `🌐 Counting registered domains`.
+4. Read the final assistant text.
+5. Tail the server log for `RegistryDashAiAction` and the `query_domain_footprint:` descriptor line.
+
+### Expected:
+- Indicator `🌐 Counting registered domains` (NOT `🔬 Running data query`) appears mid-stream.
+- Single tool call: `toolsUsed=[query_domain_footprint]`. No `run_explore_query` retry.
+- Final assistant text names a single registrar and a count (e.g. "registrar X with N domains").
+- Server log line includes `tlds=[]`, `registrarIds=[]`, `groupBy=registrar` (or `both` if the LLM picked the default), and `limit=100` (or whatever default is applied).
+- Tool payload includes a `totalDomains` rollup field.
+
+---
+
+## Test 69: Tier 3 — query_domain_footprint by TLD and registrar
+
+**Goal:** Confirm the breakdown variant works and that filtering + grouping return the expected shape.
+**Tier:** full
+
+### Steps:
+1. Open the modal on Overview.
+2. Ask: `Show me a breakdown of registered domains by registrar and TLD.`
+3. Watch indicator and DevTools → Network → most recent `analyze` request → EventStream tab.
+4. Confirm the `tool_result` frame for `query_domain_footprint`.
+
+### Expected:
+- Indicator `🌐 Counting registered domains`.
+- `tool_result` data has `rows` array with `tld`, `registrar`, and `count` fields per row, sorted descending by `count`.
+- `rowCount`, `totalDomains`, and `truncated` fields are present on the payload.
+- Final assistant text presents a table-like or itemized breakdown.
+
+---
+
+## Test 70: Tier 3 — run_explore_query with DOMAIN_COUNTS without dates (SRE-1962 regression)
+
+**Goal:** Confirm the SRE-1962 fix: `run_explore_query` with `DOMAIN_COUNTS` and no date params succeeds, instead of failing with `INVALID_ARGS` for missing dates (the original symptom).
+**Tier:** full
+
+### Prerequisites:
+- Local-dev preferred (server log inspection required to confirm the descriptor line).
+
+### Steps:
+1. Open the modal. Ask a question subtle enough that Claude reaches for the generic tool against DOMAIN_COUNTS rather than `query_domain_footprint` (e.g. ask for an unusual dimension combo only the generic supports). If the LLM keeps picking `query_domain_footprint`, force the path by injecting via DevTools or direct API call:
+   ```
+   curl -s -X POST .../console-api/registry-dash/ai/analyze \
+     -H 'Content-Type: application/json' \
+     --data '{"data_source":"DOMAIN_COUNTS","tld":"example","metrics":["count"],"dimensions":["registrar"]}'
+   ```
+   (Adapt to whatever the actual tool-call path is.)
+2. Tail the server log for `AI tool run_explore_query:` and the corresponding `tool_result` `status`.
+
+### Expected:
+- Tool returns `status: "OK"` (or `"EMPTY_FOR_RANGE"` if no data for the TLD), NOT `INVALID_ARGS`.
+- Server log line shows `startDate=null endDate=null`.
+- The descriptor line does not include the "Filter 'dateRange' not supported" message.
+
+---
+
+## Test 71: Tier 3 — run_explore_query DOMAIN_COUNTS with dates is silently stripped + noted
+
+**Goal:** Confirm that when the LLM (or a manual caller) passes start_date/end_date with DOMAIN_COUNTS, the tool silently strips the dates, runs the query anyway, and surfaces a `notes[]` advisory in the OK payload — instead of returning INVALID_ARGS and blocking.
+**Tier:** full
+
+### Prerequisites:
+- Local-dev preferred.
+
+### Steps:
+1. Force a `run_explore_query` call with `data_source=DOMAIN_COUNTS`, dimensions `[tld, registrar]`, metrics `[count]`, AND `start_date`/`end_date` populated. The simplest path: temporarily prompt-inject in the chat ("Run explore query against DOMAIN_COUNTS for tld example with start_date 2026-01-01, end_date 2026-04-30, dimensions [tld, registrar], metric count") or call the API directly.
+2. Tail the server log for the descriptor line.
+3. Inspect the `tool_result` frame in DevTools EventStream.
+
+### Expected:
+- Tool returns `status: "OK"` (or `"EMPTY_FOR_RANGE"`), NOT `INVALID_ARGS`.
+- Server log shows `startDate=null endDate=null` (the dates were stripped before the descriptor was built).
+- Tool payload includes a top-level `notes` array containing a string like: *"start_date/end_date were ignored: DOMAIN_COUNTS is a current-state snapshot and does not support date filtering."*
+- Assistant final text either echoes the advisory ("note: dates aren't applicable here…") or just answers the question; it does NOT report a tool failure.
+
+---
+
+## Test 72: Tier 3 — Tool descriptions document per-source date requirement
+
+**Goal:** Lightweight smoke that the AI tool registry surfaces the new per-source `dates=required|n/a` documentation. Protects against accidental regressions of the SRE-1962 description string.
+**Tier:** smoke
+
+### Steps:
+1. Hit the local AI tool catalog endpoint (or the orchestrator log line that emits the Anthropic tool definitions).
+2. Find the `run_explore_query` definition.
+
+### Expected:
+- The `description` text contains both `dates=required` (for sources like REVENUE, DOMAIN_ACTIVITY, RENEWAL_RATES, EXPIRATION_CURVE, TRANSACTIONS) and `dates=n/a` (for DOMAIN_COUNTS and PRICING_RULES).
+- The `input_schema.required` array does NOT contain `start_date` or `end_date`.

--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.models.ts
@@ -148,6 +148,7 @@ export const TOOL_LABELS: Record<string, string> = {
   query_revenue_breakdown: '💵 Breaking down revenue',
   query_renewal_rates: '🔄 Checking renewal rates',
   query_expiration_curve: '📉 Mapping expirations',
+  query_domain_footprint: '🌐 Counting registered domains',
   run_explore_query: '🔬 Running data query',
 };
 

--- a/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
+++ b/core/src/main/java/google/registry/ai/tools/AiToolRegistry.java
@@ -39,6 +39,7 @@ public class AiToolRegistry {
       QueryRevenueBreakdownTool queryRevenueBreakdown,
       QueryRenewalRatesTool queryRenewalRates,
       QueryExpirationCurveTool queryExpirationCurve,
+      QueryDomainFootprintTool queryDomainFootprint,
       RunExploreQueryTool runExploreQuery) {
     this(
         ImmutableList.of(
@@ -51,6 +52,7 @@ public class AiToolRegistry {
             queryRevenueBreakdown,
             queryRenewalRates,
             queryExpirationCurve,
+            queryDomainFootprint,
             runExploreQuery));
   }
 

--- a/core/src/main/java/google/registry/ai/tools/QueryDomainFootprintTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryDomainFootprintTool.java
@@ -1,0 +1,247 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.FluentLogger;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.ui.server.console.registrydash.ExploreDataSource;
+import google.registry.ui.server.console.registrydash.ExploreQueryDescriptor;
+import google.registry.ui.server.console.registrydash.RegistryDashAccessUtil;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * AI tool: snapshot of currently-registered domains under management, optionally grouped by
+ * registrar and/or TLD. Backed by {@link ExploreDataSource#DOMAIN_COUNTS} but with an obvious
+ * shape so the LLM doesn't have to learn the dateless-source quirk of {@code run_explore_query}.
+ *
+ * <p>Answers questions like "who is the largest registrar across all TLDs?" or "how many domains
+ * under .foo by registrar?". No date params — DOMAIN_COUNTS is a current-state aggregator.
+ */
+@Singleton
+public class QueryDomainFootprintTool implements AiTool {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+  private static final int DEFAULT_LIMIT = 100;
+  private static final int MAX_LIMIT = 1000;
+  private static final ImmutableSet<String> ALLOWED_GROUP_BY =
+      ImmutableSet.of("registrar", "tld", "both");
+
+  @Inject
+  public QueryDomainFootprintTool() {}
+
+  @Override
+  public String name() {
+    return "query_domain_footprint";
+  }
+
+  @Override
+  public Complexity complexity() {
+    return Complexity.MEDIUM;
+  }
+
+  @Override
+  public String description() {
+    return "Snapshot of currently-registered domains under management. Returns a count of active"
+        + " domains, optionally grouped by registrar, by tld, or by both. Use to answer questions"
+        + " like 'who is the largest registrar?' or 'how many domains under .example?'. No date"
+        + " params — this is a current-state snapshot, not a time series. Results are sorted by"
+        + " count descending.";
+  }
+
+  @Override
+  public JsonObject inputSchema() {
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    JsonObject props = new JsonObject();
+
+    JsonObject tlds = new JsonObject();
+    tlds.addProperty("type", "array");
+    JsonObject tldsItems = new JsonObject();
+    tldsItems.addProperty("type", "string");
+    tlds.add("items", tldsItems);
+    tlds.addProperty(
+        "description",
+        "Optional. Filter to these TLDs. If omitted, all TLDs the caller has access to are"
+            + " included.");
+    props.add("tlds", tlds);
+
+    JsonObject registrarIds = new JsonObject();
+    registrarIds.addProperty("type", "array");
+    JsonObject registrarIdsItems = new JsonObject();
+    registrarIdsItems.addProperty("type", "string");
+    registrarIds.add("items", registrarIdsItems);
+    registrarIds.addProperty("description", "Optional. Filter to these registrar IDs.");
+    props.add("registrar_ids", registrarIds);
+
+    JsonObject groupBy = new JsonObject();
+    groupBy.addProperty("type", "string");
+    groupBy.addProperty(
+        "description",
+        "How to group the count. 'registrar' = one row per registrar (across all in-scope TLDs),"
+            + " 'tld' = one row per TLD, 'both' = one row per (tld, registrar). Default: 'both'.");
+    JsonArray groupByEnum = new JsonArray();
+    ALLOWED_GROUP_BY.forEach(groupByEnum::add);
+    groupBy.add("enum", groupByEnum);
+    props.add("group_by", groupBy);
+
+    JsonObject limit = new JsonObject();
+    limit.addProperty("type", "integer");
+    limit.addProperty(
+        "description",
+        "Optional. Maximum rows to return. Default 100, capped at " + MAX_LIMIT + ".");
+    props.add("limit", limit);
+
+    schema.add("properties", props);
+    schema.add("required", new JsonArray());
+    return schema;
+  }
+
+  @Override
+  public ToolResult executeWithStatus(JsonObject args, User user) {
+    String groupBy = "both";
+    if (args.has("group_by") && !args.get("group_by").isJsonNull()) {
+      groupBy = args.get("group_by").getAsString();
+      if (!ALLOWED_GROUP_BY.contains(groupBy)) {
+        return ToolResult.invalidArgs(
+            "Invalid group_by '" + groupBy + "'. Allowed: " + ALLOWED_GROUP_BY);
+      }
+    }
+    int limit = DEFAULT_LIMIT;
+    if (args.has("limit") && !args.get("limit").isJsonNull()) {
+      limit = args.get("limit").getAsInt();
+      if (limit <= 0) {
+        return ToolResult.invalidArgs("limit must be positive");
+      }
+      limit = Math.min(limit, MAX_LIMIT);
+    }
+    List<String> requestedTlds = optionalStringArrayArg(args, "tlds");
+    List<String> registrarIds = optionalStringArrayArg(args, "registrar_ids");
+
+    boolean isAdmin = user.getUserRoles().getGlobalRole() == GlobalRole.FTE;
+    ImmutableSet<String> accessTlds =
+        isAdmin
+            ? ImmutableSet.of()
+            : RegistryDashAccessUtil.getMappedTlds(user.getEmailAddress());
+    if (!isAdmin) {
+      for (String t : requestedTlds) {
+        if (!accessTlds.contains(t)) {
+          return ToolResult.permissionDenied("Permission denied for tld: " + t);
+        }
+      }
+    }
+    ImmutableSet<String> effectiveTlds =
+        RegistryDashAccessUtil.applyFilter(accessTlds, ImmutableSet.copyOf(requestedTlds), isAdmin);
+
+    List<String> dimensions =
+        switch (groupBy) {
+          case "registrar" -> List.of("registrar");
+          case "tld" -> List.of("tld");
+          default -> List.of("tld", "registrar");
+        };
+
+    ExploreQueryDescriptor desc =
+        ToolJpaHelper.descriptor(
+            ExploreDataSource.DOMAIN_COUNTS.name(),
+            dimensions,
+            List.of("count"),
+            requestedTlds,
+            registrarIds,
+            List.of(),
+            List.of(),
+            null,
+            null);
+
+    logger.atInfo().log(
+        "AI tool query_domain_footprint: user=%s tlds=%s registrarIds=%s groupBy=%s limit=%d",
+        user.getEmailAddress(), requestedTlds, registrarIds, groupBy, limit);
+
+    List<String> columns = new ArrayList<>(dimensions);
+    columns.add("count");
+
+    JsonObject payload;
+    try {
+      payload =
+          ToolJpaHelper.runExplore(
+              ExploreDataSource.DOMAIN_COUNTS, desc, effectiveTlds, columns, MAX_LIMIT);
+    } catch (AiToolException e) {
+      return ToolResult.invalidArgs(e.getMessage());
+    }
+
+    JsonArray rows = payload.getAsJsonArray("rows");
+    JsonArray sorted = sortAndLimitByCount(rows, limit);
+    long total = sumCounts(rows);
+    payload.add("rows", sorted);
+    payload.addProperty("rowCount", sorted.size());
+    payload.addProperty("totalDomains", total);
+    payload.addProperty("truncated", rows.size() > sorted.size());
+
+    if (sorted.size() == 0) {
+      return ToolResult.emptyForRange(
+          payload, "no domains under management for the requested filters");
+    }
+    return ToolResult.ok(payload);
+  }
+
+  private static JsonArray sortAndLimitByCount(JsonArray rows, int limit) {
+    List<JsonElement> list = new ArrayList<>(rows.size());
+    rows.forEach(list::add);
+    list.sort(
+        Comparator.comparingLong(
+                (JsonElement el) -> {
+                  JsonObject obj = el.getAsJsonObject();
+                  return obj.has("count") && !obj.get("count").isJsonNull()
+                      ? obj.get("count").getAsLong()
+                      : 0L;
+                })
+            .reversed());
+    JsonArray out = new JsonArray();
+    for (int i = 0; i < Math.min(limit, list.size()); i++) {
+      out.add(list.get(i));
+    }
+    return out;
+  }
+
+  private static long sumCounts(JsonArray rows) {
+    long total = 0;
+    for (JsonElement el : rows) {
+      JsonObject obj = el.getAsJsonObject();
+      if (obj.has("count") && !obj.get("count").isJsonNull()) {
+        total += obj.get("count").getAsLong();
+      }
+    }
+    return total;
+  }
+
+  private static List<String> optionalStringArrayArg(JsonObject args, String key) {
+    if (!args.has(key) || args.get(key).isJsonNull()) {
+      return List.of();
+    }
+    JsonArray arr = args.getAsJsonArray(key);
+    List<String> out = new ArrayList<>(arr.size());
+    for (JsonElement el : arr) {
+      out.add(el.getAsString());
+    }
+    return out;
+  }
+}

--- a/core/src/main/java/google/registry/ai/tools/QueryDomainFootprintTool.java
+++ b/core/src/main/java/google/registry/ai/tools/QueryDomainFootprintTool.java
@@ -27,7 +27,6 @@ import google.registry.ui.server.console.registrydash.RegistryDashAccessUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -179,58 +178,32 @@ public class QueryDomainFootprintTool implements AiTool {
     List<String> columns = new ArrayList<>(dimensions);
     columns.add("count");
 
+    // The DOMAIN_COUNTS SQL is `ORDER BY count_value DESC LIMIT :maxRows`, so the rows we get
+    // back are already the top-N groups even when the true cardinality exceeds the limit. We pass
+    // `limit` directly so the SQL returns at most that many groups.
     JsonObject payload;
     try {
       payload =
           ToolJpaHelper.runExplore(
-              ExploreDataSource.DOMAIN_COUNTS, desc, effectiveTlds, columns, MAX_LIMIT);
+              ExploreDataSource.DOMAIN_COUNTS, desc, effectiveTlds, columns, limit);
     } catch (AiToolException e) {
       return ToolResult.invalidArgs(e.getMessage());
     }
 
-    JsonArray rows = payload.getAsJsonArray("rows");
-    JsonArray sorted = sortAndLimitByCount(rows, limit);
-    long total = sumCounts(rows);
-    payload.add("rows", sorted);
-    payload.addProperty("rowCount", sorted.size());
+    // Authoritative total — independent of row truncation. Computed via a separate ungrouped
+    // COUNT(*) so we don't under-report when there are more groups than `limit`.
+    long total =
+        ToolJpaHelper.countActiveDomains(effectiveTlds, ImmutableSet.copyOf(registrarIds));
     payload.addProperty("totalDomains", total);
-    payload.addProperty("truncated", rows.size() > sorted.size());
+    // `truncated` is true when the SQL hit the limit (more groups exist than were returned).
+    int rowCount = payload.has("rowCount") ? payload.get("rowCount").getAsInt() : 0;
+    payload.addProperty("truncated", rowCount >= limit);
 
-    if (sorted.size() == 0) {
+    if (rowCount == 0) {
       return ToolResult.emptyForRange(
           payload, "no domains under management for the requested filters");
     }
     return ToolResult.ok(payload);
-  }
-
-  private static JsonArray sortAndLimitByCount(JsonArray rows, int limit) {
-    List<JsonElement> list = new ArrayList<>(rows.size());
-    rows.forEach(list::add);
-    list.sort(
-        Comparator.comparingLong(
-                (JsonElement el) -> {
-                  JsonObject obj = el.getAsJsonObject();
-                  return obj.has("count") && !obj.get("count").isJsonNull()
-                      ? obj.get("count").getAsLong()
-                      : 0L;
-                })
-            .reversed());
-    JsonArray out = new JsonArray();
-    for (int i = 0; i < Math.min(limit, list.size()); i++) {
-      out.add(list.get(i));
-    }
-    return out;
-  }
-
-  private static long sumCounts(JsonArray rows) {
-    long total = 0;
-    for (JsonElement el : rows) {
-      JsonObject obj = el.getAsJsonObject();
-      if (obj.has("count") && !obj.get("count").isJsonNull()) {
-        total += obj.get("count").getAsLong();
-      }
-    }
-    return total;
   }
 
   private static List<String> optionalStringArrayArg(JsonObject args, String key) {

--- a/core/src/main/java/google/registry/ai/tools/RunExploreQueryTool.java
+++ b/core/src/main/java/google/registry/ai/tools/RunExploreQueryTool.java
@@ -81,11 +81,14 @@ public class RunExploreQueryTool implements AiTool {
           .append(": metrics=")
           .append(source.getAllowedMetrics())
           .append(", dimensions=")
-          .append(source.getAllowedDimensions());
+          .append(source.getAllowedDimensions())
+          .append(", dates=")
+          .append(source.supportsDateRange() ? "required" : "n/a (current-state snapshot)");
     }
     sb.append(
-        "\n\nAlways pass start_date and end_date (ISO YYYY-MM-DD). Filters registrar_ids, "
-            + "operations, activity_types are optional.");
+        "\n\nstart_date and end_date (ISO YYYY-MM-DD) are required for sources marked"
+            + " dates=required and ignored for sources marked dates=n/a. Filters registrar_ids,"
+            + " operations, activity_types are optional.");
     return sb.toString();
   }
 
@@ -115,13 +118,19 @@ public class RunExploreQueryTool implements AiTool {
     JsonObject startDate = new JsonObject();
     startDate.addProperty("type", "string");
     startDate.addProperty(
-        "description", "ISO date or datetime, inclusive (e.g. '2026-04-01').");
+        "description",
+        "ISO date or datetime, inclusive (e.g. '2026-04-01'). Required for sources that support"
+            + " dateRange (see tool description). Ignored for current-state sources like"
+            + " DOMAIN_COUNTS and PRICING_RULES.");
     props.add("start_date", startDate);
 
     JsonObject endDate = new JsonObject();
     endDate.addProperty("type", "string");
     endDate.addProperty(
-        "description", "ISO date or datetime, inclusive (e.g. '2026-04-30').");
+        "description",
+        "ISO date or datetime, inclusive (e.g. '2026-04-30'). Required for sources that support"
+            + " dateRange (see tool description). Ignored for current-state sources like"
+            + " DOMAIN_COUNTS and PRICING_RULES.");
     props.add("end_date", endDate);
 
     JsonObject metrics = new JsonObject();
@@ -174,8 +183,6 @@ public class RunExploreQueryTool implements AiTool {
     JsonArray required = new JsonArray();
     required.add("data_source");
     required.add("tld");
-    required.add("start_date");
-    required.add("end_date");
     required.add("metrics");
     schema.add("required", required);
 
@@ -193,13 +200,7 @@ public class RunExploreQueryTool implements AiTool {
       return ToolResult.invalidArgs("Missing required arg: tld");
     }
     Optional<String> startDate = stringArg(args, "start_date");
-    if (startDate.isEmpty()) {
-      return ToolResult.invalidArgs("Missing required arg: start_date");
-    }
     Optional<String> endDate = stringArg(args, "end_date");
-    if (endDate.isEmpty()) {
-      return ToolResult.invalidArgs("Missing required arg: end_date");
-    }
     if (!args.has("metrics") || args.get("metrics").isJsonNull()) {
       return ToolResult.invalidArgs("Missing required arg: metrics");
     }
@@ -220,6 +221,24 @@ public class RunExploreQueryTool implements AiTool {
           "Unknown data_source: " + dataSourceName.get() + ". Valid: " + validDataSourceNames());
     }
 
+    // Per-source date handling. Sources that support dateRange require both dates; sources that
+    // don't (DOMAIN_COUNTS, PRICING_RULES) silently strip any dates the LLM passes and surface a
+    // note in the OK payload so the LLM can echo the constraint back to the user.
+    String dateNote = null;
+    if (source.supportsDateRange()) {
+      if (startDate.isEmpty() || endDate.isEmpty()) {
+        return ToolResult.invalidArgs(
+            "start_date and end_date are required for data_source=" + source.name());
+      }
+    } else if (startDate.isPresent() || endDate.isPresent()) {
+      dateNote =
+          "start_date/end_date were ignored: "
+              + source.name()
+              + " is a current-state snapshot and does not support date filtering.";
+      startDate = Optional.empty();
+      endDate = Optional.empty();
+    }
+
     try {
       ToolJpaHelper.assertTldAccess(user, tld.get());
     } catch (AiToolException e) {
@@ -236,8 +255,8 @@ public class RunExploreQueryTool implements AiTool {
             registrarIds,
             operations,
             activityTypes,
-            startDate.get(),
-            endDate.get());
+            startDate.orElse(null),
+            endDate.orElse(null));
 
     // Tool-local audit log: descriptor-level detail not captured by the orchestrator's toolsUsed
     // list. Consolidation into the orchestrator's log line is a follow-up.
@@ -252,8 +271,8 @@ public class RunExploreQueryTool implements AiTool {
         registrarIds,
         operations,
         activityTypes,
-        startDate.get(),
-        endDate.get());
+        startDate.orElse(null),
+        endDate.orElse(null));
 
     JsonObject payload;
     try {
@@ -268,20 +287,27 @@ public class RunExploreQueryTool implements AiTool {
     } catch (AiToolException e) {
       return ToolResult.invalidArgs(e.getMessage());
     }
+    if (dateNote != null) {
+      JsonArray notes = new JsonArray();
+      notes.add(dateNote);
+      payload.add("notes", notes);
+    }
     int rowCount = payload.has("rowCount") ? payload.get("rowCount").getAsInt() : 0;
     if (rowCount > 0) {
       return ToolResult.ok(payload);
     }
-    return ToolResult.emptyForRange(
-        payload,
-        "no rows for data_source="
-            + source.name()
-            + ", tld="
-            + tld.get()
-            + " between "
-            + startDate.get()
-            + " and "
-            + endDate.get());
+    String emptyDiag =
+        startDate.isPresent() && endDate.isPresent()
+            ? "no rows for data_source="
+                + source.name()
+                + ", tld="
+                + tld.get()
+                + " between "
+                + startDate.get()
+                + " and "
+                + endDate.get()
+            : "no rows for data_source=" + source.name() + ", tld=" + tld.get();
+    return ToolResult.emptyForRange(payload, emptyDiag);
   }
 
   /**

--- a/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
+++ b/core/src/main/java/google/registry/ai/tools/ToolJpaHelper.java
@@ -309,6 +309,39 @@ final class ToolJpaHelper {
   record DataExtent(Instant min, Instant max) {}
 
   /**
+   * Returns the total count of currently-registered (non-deleted) domains under management,
+   * scoped to the given TLDs and registrar IDs. Mirrors the WHERE clauses of
+   * {@link google.registry.ui.server.console.registrydash.ExploreQueryBuilder#buildDomainCounts}
+   * but without grouping, so the result is unaffected by row-limit truncation.
+   */
+  static long countActiveDomains(
+      ImmutableSet<String> tlds, ImmutableSet<String> registrarIds) {
+    StringBuilder sql = new StringBuilder("SELECT COUNT(*) FROM \"Domain\" d WHERE ");
+    sql.append("d.deletion_time > CURRENT_TIMESTAMP");
+    if (!tlds.isEmpty()) {
+      sql.append(" AND d.tld IN (:tlds)");
+    }
+    if (!registrarIds.isEmpty()) {
+      sql.append(" AND d.current_sponsor_registrar_id IN (:registrarIds)");
+    }
+    return tm().transact(
+        () -> {
+          Query q = tm().getEntityManager().createNativeQuery(sql.toString());
+          if (!tlds.isEmpty()) {
+            q.setParameter("tlds", tlds);
+          }
+          if (!registrarIds.isEmpty()) {
+            q.setParameter("registrarIds", registrarIds);
+          }
+          Object raw = q.getSingleResult();
+          if (raw instanceof Number n) {
+            return n.longValue();
+          }
+          return 0L;
+        });
+  }
+
+  /**
    * Builds an {@link ExploreQueryDescriptor} programmatically by serializing args to JSON and
    * deserializing into the descriptor (whose fields are otherwise private with no setters).
    */

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreDataSource.java
@@ -79,6 +79,11 @@ public enum ExploreDataSource {
     return allowedDimensions;
   }
 
+  /** Whether this source accepts a {@code dateRange} filter. */
+  public boolean supportsDateRange() {
+    return allowedFilters.contains("dateRange");
+  }
+
   /**
    * Validates the descriptor against this source's allowlist. Throws IllegalArgumentException on
    * unknown fields.

--- a/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
+++ b/core/src/main/java/google/registry/ui/server/console/registrydash/ExploreQueryBuilder.java
@@ -203,7 +203,11 @@ public final class ExploreQueryBuilder {
     if (!f.getRegistrarIds().isEmpty()) {
       whereClauses.add("d.current_sponsor_registrar_id IN (:registrarIds)");
     }
-    return assembleQuery(selectCols, "\"Domain\" d", whereClauses, groupByCols, null);
+    // Order by count_value desc so a LIMIT applied at the SQL layer returns the largest groups,
+    // not arbitrary ones. Required for correctness of `query_domain_footprint`'s "top N" usage
+    // when the true (tld, registrar) cardinality exceeds the limit.
+    return assembleQuery(
+        selectCols, "\"Domain\" d", whereClauses, groupByCols, "count_value DESC");
   }
 
   private static String buildRenewalRates(

--- a/core/src/test/java/google/registry/ai/tools/QueryDomainFootprintToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/QueryDomainFootprintToolTest.java
@@ -1,0 +1,166 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ai.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import google.registry.model.console.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link QueryDomainFootprintTool}. */
+class QueryDomainFootprintToolTest extends AiToolTestBase {
+
+  private final QueryDomainFootprintTool tool = new QueryDomainFootprintTool();
+
+  @BeforeEach
+  void setUp() {
+    createTld("tld");
+    createTld("other-tld");
+  }
+
+  @Test
+  void name_isStable() {
+    assertThat(tool.name()).isEqualTo("query_domain_footprint");
+  }
+
+  @Test
+  void description_mentionsCurrentStateAndNoDates() {
+    String desc = tool.description();
+    assertThat(desc).ignoringCase().contains("current-state");
+    assertThat(desc).ignoringCase().contains("no date");
+  }
+
+  @Test
+  void inputSchema_hasNoRequiredFields() {
+    JsonObject schema = tool.inputSchema();
+    assertThat(schema.getAsJsonArray("required")).hasSize(0);
+    JsonObject props = schema.getAsJsonObject("properties");
+    assertThat(props.has("tlds")).isTrue();
+    assertThat(props.has("registrar_ids")).isTrue();
+    assertThat(props.has("group_by")).isTrue();
+    assertThat(props.has("limit")).isTrue();
+    JsonArray groupByEnum = props.getAsJsonObject("group_by").getAsJsonArray("enum");
+    assertThat(groupByEnum.toString()).contains("registrar");
+    assertThat(groupByEnum.toString()).contains("tld");
+    assertThat(groupByEnum.toString()).contains("both");
+  }
+
+  @Test
+  void execute_admin_defaultGroupByBoth_emptyForRange() {
+    // No domains in test DB → empty result, but the tool must succeed (not INVALID_ARGS).
+    User user = createFteUser("admin@example.com");
+
+    ToolResult result = tool.executeWithStatus(new JsonObject(), user);
+
+    assertToolResultStatus(result, ToolResult.Status.EMPTY_FOR_RANGE);
+    JsonObject payload = result.data().getAsJsonObject();
+    assertThat(payload.has("rows")).isTrue();
+    assertThat(payload.get("totalDomains").getAsLong()).isEqualTo(0L);
+  }
+
+  @Test
+  void execute_admin_groupByRegistrar_emptyForRange() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("group_by", "registrar");
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.EMPTY_FOR_RANGE);
+  }
+
+  @Test
+  void execute_admin_groupByTld_emptyForRange() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("group_by", "tld");
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.EMPTY_FOR_RANGE);
+  }
+
+  @Test
+  void execute_invalidGroupBy_returnsInvalidArgs() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("group_by", "registrar_id");
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.INVALID_ARGS);
+    assertThat(result.diagnostic()).ignoringCase().contains("invalid group_by");
+  }
+
+  @Test
+  void execute_negativeLimit_returnsInvalidArgs() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("limit", -5);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.INVALID_ARGS);
+    assertThat(result.diagnostic()).contains("limit");
+  }
+
+  @Test
+  void execute_unauthorizedTld_returnsPermissionDenied() {
+    // Non-admin mapped only to "other-tld" — requesting "tld" must fail.
+    User user = createRoUser("ro@example.com");
+    mapUserToTld("ro@example.com", "other-tld");
+    JsonObject argsJson = new JsonObject();
+    JsonArray tlds = new JsonArray();
+    tlds.add("tld");
+    argsJson.add("tlds", tlds);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.PERMISSION_DENIED);
+    assertThat(result.diagnostic()).ignoringCase().contains("permission denied");
+  }
+
+  @Test
+  void execute_admin_tldsFilterSubset_runsScopedQuery() {
+    // Admin filtering to one TLD; still empty (no domains) but tool must succeed.
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    JsonArray tlds = new JsonArray();
+    tlds.add("tld");
+    argsJson.add("tlds", tlds);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.EMPTY_FOR_RANGE);
+  }
+
+  @Test
+  void execute_explicitLimit_returnsPayloadWithRowCount() {
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("limit", 5);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.EMPTY_FOR_RANGE);
+    JsonObject payload = result.data().getAsJsonObject();
+    assertThat(payload.get("rowCount").getAsInt()).isEqualTo(0);
+    assertThat(payload.has("totalDomains")).isTrue();
+  }
+}

--- a/core/src/test/java/google/registry/ai/tools/RunExploreQueryToolTest.java
+++ b/core/src/test/java/google/registry/ai/tools/RunExploreQueryToolTest.java
@@ -58,14 +58,25 @@ class RunExploreQueryToolTest extends AiToolTestBase {
   @Test
   void inputSchema_hasRequiredFields() {
     JsonObject schema = tool.inputSchema();
-    assertThat(schema.getAsJsonArray("required").toString())
-        .contains("data_source");
-    assertThat(schema.getAsJsonArray("required").toString()).contains("tld");
-    assertThat(schema.getAsJsonArray("required").toString()).contains("start_date");
-    assertThat(schema.getAsJsonArray("required").toString()).contains("end_date");
-    assertThat(schema.getAsJsonArray("required").toString()).contains("metrics");
+    String required = schema.getAsJsonArray("required").toString();
+    assertThat(required).contains("data_source");
+    assertThat(required).contains("tld");
+    assertThat(required).contains("metrics");
+    // Dates are per-source optional (SRE-1962): required for sources that support dateRange,
+    // ignored for current-state sources like DOMAIN_COUNTS.
+    assertThat(required).doesNotContain("start_date");
+    assertThat(required).doesNotContain("end_date");
     assertThat(schema.getAsJsonObject("properties").getAsJsonObject("data_source").has("enum"))
         .isTrue();
+  }
+
+  @Test
+  void description_documentsPerSourceDateRequirement() {
+    String desc = tool.description();
+    // DOMAIN_COUNTS is a current-state snapshot; REVENUE accepts a date range.
+    assertThat(desc).contains("DOMAIN_COUNTS");
+    assertThat(desc).contains("dates=n/a");
+    assertThat(desc).contains("dates=required");
   }
 
   @Test
@@ -160,6 +171,78 @@ class RunExploreQueryToolTest extends AiToolTestBase {
     ToolResult result = tool.executeWithStatus(argsJson, user);
     assertToolResultStatus(result, ToolResult.Status.PERMISSION_DENIED);
     assertThat(result.diagnostic()).ignoringCase().contains("permission denied");
+  }
+
+  @Test
+  void execute_domainCountsWithoutDates_succeeds() {
+    // DOMAIN_COUNTS is a current-state snapshot — dates are not required and should not block.
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("data_source", "DOMAIN_COUNTS");
+    argsJson.addProperty("tld", "tld");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("count");
+    argsJson.add("metrics", metrics);
+    com.google.gson.JsonArray dims = new com.google.gson.JsonArray();
+    dims.add("registrar");
+    argsJson.add("dimensions", dims);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    // No domains in the test DB → EMPTY_FOR_RANGE, but crucially NOT INVALID_ARGS for missing
+    // dates (the SRE-1962 regression case).
+    assertThat(result.status())
+        .isAnyOf(ToolResult.Status.OK, ToolResult.Status.EMPTY_FOR_RANGE);
+    assertThat(result.data().getAsJsonObject().has("rows")).isTrue();
+    // emptyForRange diagnostic should not mention a date range when none was supplied.
+    if (result.status() == ToolResult.Status.EMPTY_FOR_RANGE) {
+      assertThat(result.diagnostic()).doesNotContain("between");
+    }
+  }
+
+  @Test
+  void execute_domainCountsWithDates_stripsDatesAndAttachesNote() {
+    // SRE-1962: when dates are supplied to a source that doesn't accept them, the tool must
+    // silently strip the dates and surface a note instead of returning INVALID_ARGS.
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("data_source", "DOMAIN_COUNTS");
+    argsJson.addProperty("tld", "tld");
+    argsJson.addProperty("start_date", "2026-01-01");
+    argsJson.addProperty("end_date", "2026-04-29");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("count");
+    argsJson.add("metrics", metrics);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertThat(result.status())
+        .isAnyOf(ToolResult.Status.OK, ToolResult.Status.EMPTY_FOR_RANGE);
+    JsonObject payload = result.data().getAsJsonObject();
+    assertThat(payload.has("notes")).isTrue();
+    assertThat(payload.getAsJsonArray("notes").get(0).getAsString())
+        .ignoringCase()
+        .contains("ignored");
+    assertThat(payload.getAsJsonArray("notes").get(0).getAsString())
+        .contains("DOMAIN_COUNTS");
+  }
+
+  @Test
+  void execute_revenueWithoutDates_returnsInvalidArgs() {
+    // REVENUE supports dateRange; dates remain required for it.
+    User user = createFteUser("admin@example.com");
+    JsonObject argsJson = new JsonObject();
+    argsJson.addProperty("data_source", "REVENUE");
+    argsJson.addProperty("tld", "tld");
+    com.google.gson.JsonArray metrics = new com.google.gson.JsonArray();
+    metrics.add("amount");
+    argsJson.add("metrics", metrics);
+
+    ToolResult result = tool.executeWithStatus(argsJson, user);
+
+    assertToolResultStatus(result, ToolResult.Status.INVALID_ARGS);
+    assertThat(result.diagnostic()).contains("REVENUE");
+    assertThat(result.diagnostic()).ignoringCase().contains("required");
   }
 
   /** Minimal valid args for DOMAIN_ACTIVITY. */


### PR DESCRIPTION
## Summary

Fixes the AI chat input-schema mismatch that blocked basic registrar/TLD aggregation questions. On alpha 2026-05-05, "who is the largest registrar across all TLDs?" → \"i want registered domain footprint\" produced an unrecoverable INVALID_ARGS because \`run_explore_query\` declared dates as required while \`DOMAIN_COUNTS\` rejects \`dateRange\` filters. The LLM gave up.

Two changes:

1. **Per-source date schema in \`run_explore_query\`** — \`start_date\`/\`end_date\` removed from the required schema. For sources that support \`dateRange\` (REVENUE, DOMAIN_ACTIVITY, RENEWAL_RATES, EXPIRATION_CURVE, TRANSACTIONS) dates remain required and validated. For sources that don't (DOMAIN_COUNTS, PRICING_RULES) any caller-supplied dates are silently stripped and a \`notes[]\` advisory is attached to the OK payload so the LLM can echo the constraint to the user. The tool description documents \`dates=required|n/a\` per source so Claude sees the constraint inline.

2. **New \`query_domain_footprint\` tool** — a current-state snapshot of registered domains. Args: optional \`tlds[]\`, \`registrar_ids[]\`, \`group_by\` (\`registrar\` | \`tld\` | \`both\`, default \`both\`), \`limit\` (default 100, capped at 1000). Backed by DOMAIN_COUNTS with in-tool sort by count desc + \`totalDomains\` rollup. Frontend \`TOOL_LABELS\` entry (\`🌐 Counting registered domains\`) added.

Acceptance criteria from SRE-1962:
- "Who is the largest registrar by registered domain footprint?" returns a real answer in one tool call → covered by new tool + Test 68 in test-plan.md.
- \`run_explore_query\` with \`DOMAIN_COUNTS\` and no date params succeeds → covered by Test 70 + unit test \`execute_domainCountsWithoutDates_succeeds\`.
- \`query_domain_footprint\` is exposed in the AI tool registry, has a frontend \`TOOL_LABELS\` entry, has unit tests → all covered.
- Tool descriptions explicitly state which params each source/tool needs → covered by description rewrite + Test 72.

Linear: https://linear.app/unstoppable-domains/issue/SRE-1962

## Test plan

- [x] Unit tests pass: \`./gradlew :core:standardTest --tests 'google.registry.ai.tools.*'\` (24 tests, BUILD SUCCESSFUL)
- [x] New \`RunExploreQueryToolTest\` cases: \`execute_domainCountsWithoutDates_succeeds\`, \`execute_domainCountsWithDates_stripsDatesAndAttachesNote\`, \`execute_revenueWithoutDates_returnsInvalidArgs\`, \`description_documentsPerSourceDateRequirement\`
- [x] New \`QueryDomainFootprintToolTest\` (11 cases): default-group-by, group-by-registrar, group-by-tld, invalid-group-by, negative-limit, unauthorized-tld permission, admin-tlds-filter, schema-shape, name/description smoke
- [x] Test plan: Tests 68–72 added (\`query_domain_footprint\` largest-registrar acceptance, breakdown, dateless DOMAIN_COUNTS regression, date-stripping advisory, tool-description smoke)
- [ ] Manual chrome verify on alpha-gke post-deploy (Tests 68–72) — see \`.claude/plugins/ud-registry-dash/skills/test-registry-dash/test-plan.md\`

## Out of scope

- Other aggregate tools (revenue snapshot, etc.)
- LLM-side retry logic
- Reworking other data sources beyond DOMAIN_COUNTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)