### PR TITLE
chore(registry-dash): SSE frame logging to diagnose AI tool-pill loss (SRE-1963)

### DIFF
--- a/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
+++ b/console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts
@@ -201,6 +201,15 @@ export class AiAnalysisService {
             }
 
             const typed = frame as AiStreamFrame;
+            console.debug(
+              '[ai-chat] frame',
+              typed.type,
+              typed.type === 'tool_use'
+                ? typed.tool
+                : typed.type === 'tool_result'
+                ? `${typed.tool}/${typed.status ?? typed.ok}`
+                : '',
+            );
             if (typed.type === 'text') {
               accumulated += typed.text;
               this.streamedText.set(accumulated);
@@ -240,8 +249,8 @@ export class AiAnalysisService {
               );
             }
             // 'done' is informational; the [DONE] sentinel still terminates the loop.
-          } catch {
-            // skip malformed chunks
+          } catch (e) {
+            console.warn('[ai-chat] dropped malformed SSE frame', { data, error: e });
           }
         }
       }


### PR DESCRIPTION
## Summary

PR #141 was supposed to make tool pills persist in the chat scrollback, but on alpha they still vanish: pills appear IN_FLIGHT during execution, then by the end of the response no pills remain (and turn-0 / turn-1 assistant text gets concatenated with no per-turn split).

Backend GCP logs (`ud-registry-alpha-gke`, `k8s_container`) confirm the orchestrator emitted `ToolUseEvent` + `ToolResultEvent` for every tool call across every turn — so the SSE wire definitely carries the frames; the frontend is losing them somewhere.

Static analysis of `ai-analysis.service.ts` couldn't pinpoint the failure path. The frontend has no logging, and the SSE handler's `catch` block silently swallows every parse error, so any code change right now is a guess.

## What changed

Two diagnostic lines in `console-webapp/src/app/registry-dash/ai/ai-analysis.service.ts`. **No behavior change.**

1. **Un-silence the parse-error catch** — `console.warn` the dropped frame and the parse error so chunk-boundary truncation or unexpected bytes in `args` surface instead of disappearing.
2. **Trace every frame at the dispatch** — `console.debug` the type + tool/status of every frame the frontend actually sees, in order.

Cross-referenced against the GCP turn-by-turn tool log we already have, this will tell us instantly whether:
- frames are silently failing `JSON.parse` (the `console.warn` will fire);
- frames never reach the dispatch (frame log shows a count below the GCP backend log);
- frames arrive correctly but pills still vanish (state mutation or CSS issue, easy to confirm with `ng.getComponent(...).aiService.conversationHistory()` in the console).

In every case the next change is one specific, targeted fix to the actual failure mode rather than a defensive sweep.

Linear: https://linear.app/unstoppable-domains/issue/SRE-1963

## Test plan

- [x] `tsc` clean (no behavior change; logging only)
- [ ] Deploy to alpha
- [ ] Repro the original prompt ("further drill in to renewal explosion" or any multi-tool prompt) with DevTools console open
- [ ] Capture the `[ai-chat] frame …` and `[ai-chat] dropped malformed SSE frame …` output and compare to the matching GCP backend turn log for the session
- [ ] Open a follow-up PR with the targeted fix, removing the `console.debug` and ideally keeping the `console.warn` as a permanent guardrail

🤖 Generated with [Claude Code](https://claude.com/claude-code)